### PR TITLE
[auto] Translate JAVA API Reference to Japanese

### DIFF
--- a/japanese/java/_index.md
+++ b/japanese/java/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Aspose.Page for Java"
+type: docs
+weight: 11
+url: /ja/java/
+description: "Aspose.Page for Java API リファレンスには、サンプル、コードスニペット、API ドキュメントが含まれています。パッケージ、クラス、インターフェイス、その他の API 詳細を提供します。"
+is_root: true
+---
+## Packages
+| パッケージ | 説明 |
+| --- | --- |
+| [com.aspose.eps](./com.aspose.eps) | **com.aspose.eps** は、PS/EPS ファイルを扱うすべてのクラスのルートパッケージです。 |
+| [com.aspose.eps.cpp](./com.aspose.eps.cpp) |  |
+| [com.aspose.eps.device](./com.aspose.eps.device) | **com.aspose.eps.device** パッケージは、PS/EPS を他の形式に変換する際に使用できる可能なデバイスと保存オプションのクラスを提供します。 |
+| [com.aspose.eps.plugins](./com.aspose.eps.plugins) | ``` **com.aspose.eps.plugins** ``` には EPS プラグイン クラスが含まれています。 |
+| [com.aspose.page](./com.aspose.page) | **Aspose.Page** は、Aspose.Page ライブラリのすべてのクラスのルートパッケージであり、**Device** のように直接含まれるものや、いくつかのサブパッケージを介して間接的に含まれるものがあります。 |
+| [com.aspose.page.plugins](./com.aspose.page.plugins) | ``` **com.aspose.page.plugins** ``` には、すべての Aspose.Page プラグインに共通するインターフェイスとクラスが含まれています。 |
+| [com.aspose.xps](./com.aspose.xps) | **com.aspose.xps** は、XPS ドキュメントを扱うすべてのクラスのルートパッケージです。 |
+| [com.aspose.xps.features.EventBasedModifications](./com.aspose.xps.features.eventbasedmodifications) | **com.aspose.xps.features.EventBasedModifications** パッケージは、XPS ドキュメントのイベントベースの変更に関連するクラスを提供します。 |
+| [com.aspose.xps.features.HyperlinkCollector](./com.aspose.xps.features.hyperlinkcollector) | **com.aspose.xps.features.HyperlinkCollector** パッケージは、ハイパーリンクを含む XPS 要素を収集するクラスを提供します。 |
+| [com.aspose.xps.metadata](./com.aspose.xps.metadata) | **com.aspose.xps.metadata** パッケージは、XPS ドキュメントのメタデータを記述するクラスを提供します。 |
+| [com.aspose.xps.plugins](./com.aspose.xps.plugins) | ``` **com.aspose.xps.plugins** ``` には XPS プラグインのクラスが含まれています。 |
+| [com.aspose.xps.rendering](./com.aspose.xps.rendering) | **com.aspose.xps.rendering** パッケージは、XPS ドキュメントを他の形式にレンダリングするための基本クラスを提供します。 |

--- a/japanese/java/com.aspose.eps.cpp/_index.md
+++ b/japanese/java/com.aspose.eps.cpp/_index.md
@@ -1,0 +1,14 @@
+---
+title: "com.aspose.eps.cpp"
+second_title: "Aspose.Page for Java API リファレンス"
+description: 
+type: docs
+weight: 11
+url: /ja/java/com.aspose.eps.cpp/
+---
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [PSObjectEqComparer<T>](../com.aspose.eps.cpp/psobjecteqcomparer) |  |

--- a/japanese/java/com.aspose.eps.cpp/psobjecteqcomparer/_index.md
+++ b/japanese/java/com.aspose.eps.cpp/psobjecteqcomparer/_index.md
@@ -1,0 +1,186 @@
+---
+title: "PSObjectEqComparer"
+second_title: "Aspose.Page for Java API リファレンス"
+description: 
+type: docs
+weight: 10
+url: /ja/java/com.aspose.eps.cpp/psobjecteqcomparer/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.util.Comparator
+```
+public class PSObjectEqComparer<T> implements Comparator<T>
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PSObjectEqComparer()](#PSObjectEqComparer--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [compare(T x, T y)](#compare-T-T-) |  |
+| [equals(T x, T y)](#equals-T-T-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHashCode(T obj)](#getHashCode-T-) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PSObjectEqComparer() {#PSObjectEqComparer--}
+```
+public PSObjectEqComparer()
+```
+
+
+### compare(T x, T y) {#compare-T-T-}
+```
+public int compare(T x, T y)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | T |  |
+| y | T |  |
+
+**Returns:**
+int
+### equals(T x, T y) {#equals-T-T-}
+```
+public boolean equals(T x, T y)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | T |  |
+| y | T |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHashCode(T obj) {#getHashCode-T-}
+```
+public int getHashCode(T obj)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T |  |
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.device/_index.md
+++ b/japanese/java/com.aspose.eps.device/_index.md
@@ -1,0 +1,27 @@
+---
+title: "com.aspose.eps.device"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.eps.device パッケージは、PS/EPS を他の形式に変換する際に使用できる可能なデバイスと保存オプションのクラスを提供します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.eps.device/
+---
+
+**com.aspose.eps.device** パッケージは、PS/EPS を他の形式に変換する際に使用できる可能なデバイスと保存オプションのクラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [ImageSaveOptions](../com.aspose.eps.device/imagesaveoptions) | このクラスは、変換プロセスの管理に必要なオプションを含んでいます。 |
+| [PdfSaveOptions](../com.aspose.eps.device/pdfsaveoptions) | このクラスは、変換プロセスの管理に必要なオプションを含んでいます。 |
+| [PsSaveOptions](../com.aspose.eps.device/pssaveoptions) | このクラスは、変換プロセスの管理に必要なオプションを含んでいます。 |
+| [TextDevice](../com.aspose.eps.device/textdevice) |  |
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| --- | --- |
+| [PsSaveFormat](../com.aspose.eps.device/pssaveformat) | この列挙体には、利用可能な保存形式のオプションが含まれています。 |
+| [SmoothingMode](../com.aspose.eps.device/smoothingmode) | スムージングモード列挙体。 |

--- a/japanese/java/com.aspose.eps.device/imagesaveoptions/_index.md
+++ b/japanese/java/com.aspose.eps.device/imagesaveoptions/_index.md
@@ -1,0 +1,501 @@
+---
+title: "ImageSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、変換プロセスの管理に必要なオプションを含んでいます。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.eps.device/imagesaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+```
+public class ImageSaveOptions extends SaveOptions
+```
+
+このクラスは、変換プロセスの管理に必要なオプションを含んでいます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageSaveOptions()](#ImageSaveOptions--) | ImageSaveOptions クラスの新しいインスタンスを初期化し、フラグ suppressErrors (true) と debug (false) のデフォルト値を設定します。 |
+| [ImageSaveOptions(ImageFormat imageFormat)](#ImageSaveOptions-com.aspose.page.ImageFormat-) | 指定された画像形式で ImageSaveOptions の新しいインスタンスを初期化します。 |
+| [ImageSaveOptions(Dimension size)](#ImageSaveOptions-java.awt.Dimension-) | 指定された画像サイズで ImageSaveOptions の新しいインスタンスを初期化します。 |
+| [ImageSaveOptions(Dimension size, ImageFormat imageFormat)](#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-) | 指定された画像サイズと画像形式で ImageSaveOptions の新しいインスタンスを初期化します。 |
+| [ImageSaveOptions(ImageFormat imageFormat, boolean supressErrors)](#ImageSaveOptions-com.aspose.page.ImageFormat-boolean-) | 指定された画像形式と suppressErrors フラグで ImageSaveOptions の新しいインスタンスを初期化します。 |
+| [ImageSaveOptions(Dimension size, boolean supressErrors)](#ImageSaveOptions-java.awt.Dimension-boolean-) | 指定された画像サイズと suppressErrors フラグで ImageSaveOptions の新しいインスタンスを初期化します。 |
+| [ImageSaveOptions(Dimension size, ImageFormat imageFormat, boolean supressErrors)](#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-boolean-) | 指定された画像サイズ、画像形式、そして suppressErrors フラグで ImageSaveOptions の新しいインスタンスを初期化します。 |
+| [ImageSaveOptions(boolean supressErrors)](#ImageSaveOptions-boolean-) | ImageSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値を設定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageFormat()](#getImageFormat--) | 結果画像の画像形式を取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getResolution()](#getResolution--) | 結果画像の解像度を返します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | スムージングモードを取得します。 |
+| [getTryJoinImageFragments()](#getTryJoinImageFragments--) | ライブラリが画像フラグメントを結合しようとするかどうかを示します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageFormat(ImageFormat imageFormat)](#setImageFormat-com.aspose.page.ImageFormat-) | 結果画像の画像形式を指定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setResolution(float resolution)](#setResolution-float-) | 結果画像の解像度を指定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSmoothingMode(SmoothingMode smoothingMode)](#setSmoothingMode-com.aspose.eps.device.SmoothingMode-) | スムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTryJoinImageFragments(boolean tryJoinImageFragments)](#setTryJoinImageFragments-boolean-) | ライブラリが画像フラグメントの結合を試みるかどうかを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions() {#ImageSaveOptions--}
+```
+public ImageSaveOptions()
+```
+
+
+ImageSaveOptions クラスの新しいインスタンスを初期化し、フラグ suppressErrors (true) と debug (false) のデフォルト値を設定します。
+
+### ImageSaveOptions(ImageFormat imageFormat) {#ImageSaveOptions-com.aspose.page.ImageFormat-}
+```
+public ImageSaveOptions(ImageFormat imageFormat)
+```
+
+
+指定された画像形式で ImageSaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 画像の形式です。 |
+
+### ImageSaveOptions(Dimension size) {#ImageSaveOptions-java.awt.Dimension-}
+```
+public ImageSaveOptions(Dimension size)
+```
+
+
+指定された画像サイズで ImageSaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 画像サイズ。 |
+
+### ImageSaveOptions(Dimension size, ImageFormat imageFormat) {#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-}
+```
+public ImageSaveOptions(Dimension size, ImageFormat imageFormat)
+```
+
+
+指定された画像サイズと画像形式で ImageSaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 画像サイズ。 |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 画像の形式。 |
+
+### ImageSaveOptions(ImageFormat imageFormat, boolean supressErrors) {#ImageSaveOptions-com.aspose.page.ImageFormat-boolean-}
+```
+public ImageSaveOptions(ImageFormat imageFormat, boolean supressErrors)
+```
+
+
+指定された画像形式と suppressErrors フラグで ImageSaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 画像の形式。 |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### ImageSaveOptions(Dimension size, boolean supressErrors) {#ImageSaveOptions-java.awt.Dimension-boolean-}
+```
+public ImageSaveOptions(Dimension size, boolean supressErrors)
+```
+
+
+指定された画像サイズと suppressErrors フラグで ImageSaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 画像サイズ。 |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### ImageSaveOptions(Dimension size, ImageFormat imageFormat, boolean supressErrors) {#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-boolean-}
+```
+public ImageSaveOptions(Dimension size, ImageFormat imageFormat, boolean supressErrors)
+```
+
+
+指定された画像サイズ、画像形式、そして suppressErrors フラグで ImageSaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 画像サイズ。 |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 画像の形式。 |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### ImageSaveOptions(boolean supressErrors) {#ImageSaveOptions-boolean-}
+```
+public ImageSaveOptions(boolean supressErrors)
+```
+
+
+ImageSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageFormat() {#getImageFormat--}
+```
+public ImageFormat getImageFormat()
+```
+
+
+結果画像の画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat) - An output image format.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+結果画像の解像度を返します。
+
+**Returns:**
+float - 画像の解像度。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+スムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.eps.device/smoothingmode) - the smoothingMode.
+### getTryJoinImageFragments() {#getTryJoinImageFragments--}
+```
+public boolean getTryJoinImageFragments()
+```
+
+
+ライブラリが画像フラグメントの結合を試みるかどうかを示します。これは、ソースの PS/EPS ファイル内の画像がフラグメントに分割されている場合に使用されます。このフラグがない場合、フラグメント間に細い隙間が残ります。
+
+**Returns:**
+boolean - フラグの値。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageFormat(ImageFormat imageFormat) {#setImageFormat-com.aspose.page.ImageFormat-}
+```
+public void setImageFormat(ImageFormat imageFormat)
+```
+
+
+結果画像の画像形式を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 出力画像形式です。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setResolution(float resolution) {#setResolution-float-}
+```
+public void setResolution(float resolution)
+```
+
+
+結果画像の解像度を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 解像度 | float | 画像の解像度です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSmoothingMode(SmoothingMode smoothingMode) {#setSmoothingMode-com.aspose.eps.device.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode smoothingMode)
+```
+
+
+スムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| smoothingMode | [SmoothingMode](../../com.aspose.eps.device/smoothingmode) | 設定する smoothingMode |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTryJoinImageFragments(boolean tryJoinImageFragments) {#setTryJoinImageFragments-boolean-}
+```
+public void setTryJoinImageFragments(boolean tryJoinImageFragments)
+```
+
+
+ライブラリが画像フラグメントの結合を試みるかどうかを指定します。これは、ソースの PS/EPS ファイル内の画像がフラグメントに分割されている場合に使用されます。このフラグがない場合、フラグメント間に細い隙間が残ります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| tryJoinImageFragments | boolean | フラグの値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.device/pdfsaveoptions/_index.md
+++ b/japanese/java/com.aspose.eps.device/pdfsaveoptions/_index.md
@@ -1,0 +1,341 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、変換プロセスの管理に必要なオプションを含んでいます。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.eps.device/pdfsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+```
+public class PdfSaveOptions extends SaveOptions
+```
+
+このクラスは、変換プロセスの管理に必要なオプションを含んでいます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ suppressErrors (true) と debug (false) のデフォルト値を設定します。 |
+| [PdfSaveOptions(boolean supressErrors)](#PdfSaveOptions-boolean-) | PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値を設定します。 |
+| [PdfSaveOptions(Dimension size)](#PdfSaveOptions-java.awt.Dimension-) | PdfSaveOptions クラスの新しいインスタンスを初期化し、ページサイズを設定します。 |
+| [PdfSaveOptions(boolean supressErrors, Dimension size)](#PdfSaveOptions-boolean-java.awt.Dimension-) | PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値とページサイズを設定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ suppressErrors (true) と debug (false) のデフォルト値を設定します。
+
+### PdfSaveOptions(boolean supressErrors) {#PdfSaveOptions-boolean-}
+```
+public PdfSaveOptions(boolean supressErrors)
+```
+
+
+PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### PdfSaveOptions(Dimension size) {#PdfSaveOptions-java.awt.Dimension-}
+```
+public PdfSaveOptions(Dimension size)
+```
+
+
+PdfSaveOptions クラスの新しいインスタンスを初期化し、ページサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページのサイズです。 |
+
+### PdfSaveOptions(boolean supressErrors, Dimension size) {#PdfSaveOptions-boolean-java.awt.Dimension-}
+```
+public PdfSaveOptions(boolean supressErrors, Dimension size)
+```
+
+
+PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値とページサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+| size | java.awt.Dimension | ページのサイズです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.device/pssaveformat/_index.md
+++ b/japanese/java/com.aspose.eps.device/pssaveformat/_index.md
@@ -1,0 +1,250 @@
+---
+title: "PsSaveFormat"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "この列挙体には、利用可能な保存形式のオプションが含まれています。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.eps.device/pssaveformat/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PsSaveFormat extends Enum<PsSaveFormat>
+```
+
+この列挙は保存形式の利用可能なオプションを含みます。PS または EPS が使用できます。EPS は 1 ページのドキュメントのみで使用され、PS ファイルは任意のページ数を含むことができます。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [EPS](#EPS) | このオプションは、結果のドキュメントが Encapsulated PostScript (EPS) ファイルである必要があることを示します。 |
+| [PS](#PS) | このオプションは、結果のドキュメントが PostScript (PS) または Encapsulated PostScript (EPS) ファイルである必要があることを示します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EPS {#EPS}
+```
+public static final PsSaveFormat EPS
+```
+
+
+このオプションは、結果のドキュメントが Encapsulated PostScript (EPS) ファイルである必要があることを示します。1 ページのドキュメントにのみ使用されます;
+
+### PS {#PS}
+```
+public static final PsSaveFormat PS
+```
+
+
+このオプションは、結果のドキュメントが PostScript (PS) または Encapsulated PostScript (EPS) ファイルである必要があることを示します。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PsSaveFormat valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[PsSaveFormat](../../com.aspose.eps.device/pssaveformat)
+### values() {#values--}
+```
+public static PsSaveFormat[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.eps.device.PsSaveFormat[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.device/pssaveoptions/_index.md
+++ b/japanese/java/com.aspose.eps.device/pssaveoptions/_index.md
@@ -1,0 +1,487 @@
+---
+title: "PsSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、変換プロセスの管理に必要なオプションを含んでいます。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.eps.device/pssaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+```
+public class PsSaveOptions extends SaveOptions
+```
+
+このクラスは、変換プロセスの管理に必要なオプションを含んでいます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsSaveOptions()](#PsSaveOptions--) | PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ suppressErrors (true) と debug (false) のデフォルト値を設定します。 |
+| [PsSaveOptions(boolean supressErrors)](#PsSaveOptions-boolean-) | PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値を設定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBackgroundColor()](#getBackgroundColor--) |  |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getEmbedFontsAs()](#getEmbedFontsAs--) |  |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getMargins()](#getMargins--) |  |
+| [getPageSize()](#getPageSize--) |  |
+| [getSaveFormat()](#getSaveFormat--) |  |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isEmbedFonts()](#isEmbedFonts--) | PS ドキュメントに使用されたフォントを埋め込むかどうかを示します |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [isTransparent()](#isTransparent--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBackgroundColor(Color backgroundColor)](#setBackgroundColor-java.awt.Color-) |  |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setEmbedFonts(boolean embedFonts)](#setEmbedFonts-boolean-) | PS ドキュメントに使用されたフォントを埋め込むかどうかを指定します |
+| [setEmbedFontsAs(String embedFontsAs)](#setEmbedFontsAs-java.lang.String-) | PS ドキュメントにフォントを埋め込むフォントタイプを指定します |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setMargins(Insets margins)](#setMargins-java.awt.Insets-) |  |
+| [setPageSize(Dimension pageSize)](#setPageSize-java.awt.Dimension-) |  |
+| [setSaveFormat(PsSaveFormat saveFormat)](#setSaveFormat-com.aspose.eps.device.PsSaveFormat-) | 結果ファイルの保存形式を指定します |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTransparent(boolean transparent)](#setTransparent-boolean-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsSaveOptions() {#PsSaveOptions--}
+```
+public PsSaveOptions()
+```
+
+
+PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ suppressErrors (true) と debug (false) のデフォルト値を設定します。
+
+### PsSaveOptions(boolean supressErrors) {#PsSaveOptions-boolean-}
+```
+public PsSaveOptions(boolean supressErrors)
+```
+
+
+PdfSaveOptions クラスの新しいインスタンスを初期化し、フラグ debug (false) のデフォルト値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public Color getBackgroundColor()
+```
+
+
+
+
+**Returns:**
+java.awt.Color - 背景色
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getEmbedFontsAs() {#getEmbedFontsAs--}
+```
+public String getEmbedFontsAs()
+```
+
+
+
+
+**Returns:**
+java.lang.String - PS ドキュメントにフォントを埋め込むフォントのタイプ
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getMargins() {#getMargins--}
+```
+public Insets getMargins()
+```
+
+
+
+
+**Returns:**
+java.awt.Insets - ページの余白
+### getPageSize() {#getPageSize--}
+```
+public Dimension getPageSize()
+```
+
+
+
+
+**Returns:**
+java.awt.Dimension - ページのサイズ
+### getSaveFormat() {#getSaveFormat--}
+```
+public PsSaveFormat getSaveFormat()
+```
+
+
+
+
+**Returns:**
+[PsSaveFormat](../../com.aspose.eps.device/pssaveformat) - save format of resulting file
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isEmbedFonts() {#isEmbedFonts--}
+```
+public boolean isEmbedFonts()
+```
+
+
+PS ドキュメントに使用されたフォントを埋め込むかどうかを示します
+
+**Returns:**
+boolean - embedFonts フラグの値
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+
+
+**Returns:**
+boolean - 背景が透明かどうかを示します
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBackgroundColor(Color backgroundColor) {#setBackgroundColor-java.awt.Color-}
+```
+public void setBackgroundColor(Color backgroundColor)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| backgroundColor | java.awt.Color | 背景色を指定します |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setEmbedFonts(boolean embedFonts) {#setEmbedFonts-boolean-}
+```
+public void setEmbedFonts(boolean embedFonts)
+```
+
+
+PS ドキュメントに使用されたフォントを埋め込むかどうかを指定します
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| embedFonts | boolean | embedFonts フラグ |
+
+### setEmbedFontsAs(String embedFontsAs) {#setEmbedFontsAs-java.lang.String-}
+```
+public void setEmbedFontsAs(String embedFontsAs)
+```
+
+
+PS ドキュメントにフォントを埋め込むフォントタイプを指定します
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| embedFontsAs | java.lang.String | フォントタイプ |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setMargins(Insets margins) {#setMargins-java.awt.Insets-}
+```
+public void setMargins(Insets margins)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 余白 | java.awt.Insets | ページの余白を指定します |
+
+### setPageSize(Dimension pageSize) {#setPageSize-java.awt.Dimension-}
+```
+public void setPageSize(Dimension pageSize)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pageSize | java.awt.Dimension | ページのサイズを指定します |
+
+### setSaveFormat(PsSaveFormat saveFormat) {#setSaveFormat-com.aspose.eps.device.PsSaveFormat-}
+```
+public void setSaveFormat(PsSaveFormat saveFormat)
+```
+
+
+結果ファイルの保存形式を指定します
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveFormat | [PsSaveFormat](../../com.aspose.eps.device/pssaveformat) | 結果ファイルの形式 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTransparent(boolean transparent) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean transparent)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 透明 | boolean | 背景が透明かどうかを指定します |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.device/smoothingmode/_index.md
+++ b/japanese/java/com.aspose.eps.device/smoothingmode/_index.md
@@ -1,0 +1,259 @@
+---
+title: "SmoothingMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "スムージングモード列挙体。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.eps.device/smoothingmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum SmoothingMode extends Enum<SmoothingMode>
+```
+
+スムージングモード列挙体。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ANTIALIAS](#ANTIALIAS) | アンチエイリアス平滑化モード |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 高品質だが低速の平滑化モード |
+| [HIGH_SPEED](#HIGH-SPEED) | 高速だが低品質の平滑化モード |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTIALIAS {#ANTIALIAS}
+```
+public static final SmoothingMode ANTIALIAS
+```
+
+
+アンチエイリアス平滑化モード
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final SmoothingMode HIGH_QUALITY
+```
+
+
+高品質だが低速の平滑化モード
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final SmoothingMode HIGH_SPEED
+```
+
+
+高速だが低品質の平滑化モード
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static SmoothingMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[SmoothingMode](../../com.aspose.eps.device/smoothingmode)
+### values() {#values--}
+```
+public static SmoothingMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.eps.device.SmoothingMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.device/textdevice/_index.md
+++ b/japanese/java/com.aspose.eps.device/textdevice/_index.md
@@ -1,0 +1,1357 @@
+---
+title: "TextDevice"
+second_title: "Aspose.Page for Java API リファレンス"
+description: 
+type: docs
+weight: 13
+url: /ja/java/com.aspose.eps.device/textdevice/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.Device](../../com.aspose.page/device)
+
+**All Implemented Interfaces:**
+[com.aspose.page.IMultiPageDevice](../../com.aspose.page/imultipagedevice)
+```
+public class TextDevice extends Device implements IMultiPageDevice
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TextDevice()](#TextDevice--) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [DEFAULT_SIZE](#DEFAULT-SIZE) |  |
+| [EMIT_ERRORS](#EMIT-ERRORS) |  |
+| [EMIT_WARNINGS](#EMIT-WARNINGS) |  |
+| [VERSION](#VERSION) | 現在のデバイスバージョンです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [closePage()](#closePage--) |  |
+| [create()](#create--) |  |
+| [dispose()](#dispose--) |  |
+| [draw(Shape path)](#draw-java.awt.Shape-) | パスを描画します。 |
+| [drawArc(float x, float y, float width, float height, float startAngle, float arcAngle)](#drawArc-float-float-float-float-float-float-) | 円弧を描画します。 |
+| [drawImage(BufferedImage image, AffineTransform transform, Color bkg)](#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-) | 割り当てられた変換と背景で画像を描画します。 |
+| [drawLine(float x1, float y1, float x2, float y2)](#drawLine-float-float-float-float-) | 線分を描画します。 |
+| [drawOval(float x, float y, float width, float height)](#drawOval-float-float-float-float-) | 楕円を描画します。 |
+| [drawPolygon(float[] xPoints, float[] yPoints, int nPoints)](#drawPolygon-float---float---int-) | 多角形を描画します。 |
+| [drawPolygon(int[] xPoints, int[] yPoints, int nPoints)](#drawPolygon-int---int---int-) | 多角形を描画します。 |
+| [drawPolyline(float[] xPoints, float[] yPoints, int nPoints)](#drawPolyline-float---float---int-) | ポリラインを描画します。 |
+| [drawPolyline(int[] xPoints, int[] yPoints, int nPoints)](#drawPolyline-int---int---int-) | ポリラインを描画します。 |
+| [drawRect(float x, float y, float width, float height)](#drawRect-float-float-float-float-) | 矩形を描画します。 |
+| [drawRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)](#drawRoundRect-float-float-float-float-float-float-) | 丸角長方形を描画します。 |
+| [drawString(String str, float x, float y)](#drawString-java.lang.String-float-float-) |  |
+| [endDocument()](#endDocument--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fill(Shape path)](#fill-java.awt.Shape-) | パスを塗りつぶします。 |
+| [fillArc(float x, float y, float width, float height, float startAngle, float arcAngle)](#fillArc-float-float-float-float-float-float-) | 円弧を塗りつぶします。 |
+| [fillOval(float x, float y, float width, float height)](#fillOval-float-float-float-float-) | 楕円を塗りつぶします。 |
+| [fillPolygon(float[] xPoints, float[] yPoints, int nPoints)](#fillPolygon-float---float---int-) | 多角形を塗りつぶします。 |
+| [fillPolygon(int[] xPoints, int[] yPoints, int nPoints)](#fillPolygon-int---int---int-) | 多角形を塗りつぶします。 |
+| [fillRect(float x, float y, float width, float height)](#fillRect-float-float-float-float-) | 長方形を塗りつぶします。 |
+| [fillRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)](#fillRoundRect-float-float-float-float-float-float-) | 丸角長方形を描画します。 |
+| [getBackground()](#getBackground--) | ページの現在の背景を取得します。 |
+| [getCharTM()](#getCharTM--) | 現在の文字変換を取得します。 |
+| [getClass()](#getClass--) |  |
+| [getCreator()](#getCreator--) | 結果として得られるデバイス出力の作成者を取得します。 |
+| [getCurrentPageNumber()](#getCurrentPageNumber--) |  |
+| [getFont()](#getFont--) | 現在のフォントを取得します。 |
+| [getOpacity()](#getOpacity--) | 現在の不透明度を取得します。 |
+| [getOpacityMask()](#getOpacityMask--) | 現在の不透明度マスクを取得します。 |
+| [getPages()](#getPages--) |  |
+| [getPaint()](#getPaint--) | 現在のペイントを取得します。 |
+| [getProperties()](#getProperties--) | メタデータを含むデバイスプロパティを取得します。 |
+| [getProperty(String key)](#getProperty-java.lang.String-) | 文字列プロパティの値を取得します。 |
+| [getPropertyColor(String key)](#getPropertyColor-java.lang.String-) | 色プロパティの値を取得します。 |
+| [getPropertyDouble(String key)](#getPropertyDouble-java.lang.String-) | double プロパティの値を取得します。 |
+| [getPropertyInt(String key)](#getPropertyInt-java.lang.String-) | 整数プロパティの値を取得します。 |
+| [getPropertyMargins(String key)](#getPropertyMargins-java.lang.String-) | 余白プロパティの値を取得します。 |
+| [getPropertyMatrix(String key)](#getPropertyMatrix-java.lang.String-) | 行列プロパティの値を取得します。 |
+| [getPropertyRectangle(String key)](#getPropertyRectangle-java.lang.String-) | 長方形プロパティの値を取得します。 |
+| [getPropertySize(String key)](#getPropertySize-java.lang.String-) | サイズプロパティの値を取得します。 |
+| [getSaveOptions()](#getSaveOptions--) | 保存オプションを返します。 |
+| [getSize()](#getSize--) | ページのサイズを取得します。 |
+| [getStroke()](#getStroke--) | 現在のストロークを取得します。 |
+| [getText()](#getText--) |  |
+| [getText(int startPage, int endPage)](#getText-int-int-) |  |
+| [getTextRenderingMode()](#getTextRenderingMode--) | 現在のテキスト描画モードを取得します。 |
+| [getTextStrokeWidth()](#getTextStrokeWidth--) | 現在のテキストストローク幅を取得します。 |
+| [getTransform()](#getTransform--) | 現在の変換を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [initClip()](#initClip--) | デバイスのクリップを初期化します。 |
+| [initPageNumbers()](#initPageNumbers--) |  |
+| [isDirectRGB()](#isDirectRGB--) |  |
+| [isMainDocument()](#isMainDocument--) |  |
+| [isProperty(String key)](#isProperty-java.lang.String-) | ブールプロパティの値を取得します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [openPage(float width, float height)](#openPage-float-float-) |  |
+| [openPage(String title)](#openPage-java.lang.String-) |  |
+| [renew()](#renew--) |  |
+| [renewForMerge(boolean mainDocument)](#renewForMerge-boolean-) |  |
+| [reset()](#reset--) |  |
+| [reset(boolean zeroPageNumbers)](#reset-boolean-) |  |
+| [rotate(double theta)](#rotate-double-) | 現在の変換行列を回転させます。 |
+| [rotate(double theta, double x, double y)](#rotate-double-double-double-) | 現在の変換行列を点の周りで回転させます。 |
+| [scale(double x, double y)](#scale-double-double-) | 現在の変換行列を拡大縮小します。 |
+| [setBackground(Color background)](#setBackground-java.awt.Color-) | ページの現在の背景を指定します。 |
+| [setCharTM(AffineTransform charTM)](#setCharTM-java.awt.geom.AffineTransform-) | 文字の変換を指定します。 |
+| [setClip(Shape clipPath)](#setClip-java.awt.Shape-) | デバイスのクリップを指定します。 |
+| [setCreator(String creator)](#setCreator-java.lang.String-) | 結果として得られるデバイス出力の作成者を指定します。 |
+| [setFont(ITrFont font)](#setFont-com.aspose.page.ITrFont-) | フォントを指定します。 |
+| [setOpacity(float opacity)](#setOpacity-float-) | 不透明度を指定します。 |
+| [setOpacityMask(Paint opacityMask)](#setOpacityMask-java.awt.Paint-) | 不透明度マスクを指定します。 |
+| [setPaint(Paint paint)](#setPaint-java.awt.Paint-) | ペイントを指定します。 |
+| [setProperties(UserProperties props)](#setProperties-com.aspose.page.UserProperties-) | メタデータを含むデバイスプロパティを指定します。 |
+| [setSaveOptions(SaveOptions options)](#setSaveOptions-com.aspose.page.SaveOptions-) | レンダリングプロセスの管理オプションを指定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) |  |
+| [setStroke(Stroke stroke)](#setStroke-java.awt.Stroke-) | ストロークを指定します。 |
+| [setTextRenderingMode(TextRenderingMode textRenderingMode)](#setTextRenderingMode-com.aspose.page.TextRenderingMode-) | テキスト描画モードを指定します。 |
+| [setTextStrokeWidth(float textStrokeWidth)](#setTextStrokeWidth-float-) | テキストストローク幅を指定します。 |
+| [setTransform(AffineTransform transform)](#setTransform-java.awt.geom.AffineTransform-) | 現在の変換を指定します。 |
+| [shear(double shx, double shy)](#shear-double-double-) | 現在の変換行列をせん断します。 |
+| [startDocument()](#startDocument--) |  |
+| [toString()](#toString--) |  |
+| [transform(AffineTransform transform)](#transform-java.awt.geom.AffineTransform-) | 現在の変換行列を変換します。 |
+| [translate(double x, double y)](#translate-double-double-) | 現在の変換行列を平行移動します。 |
+| [updatePageParameters(IMultiPageDevice device)](#updatePageParameters-com.aspose.page.IMultiPageDevice-) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+| [writeComment(String comment)](#writeComment-java.lang.String-) | コメントを書き込みます。 |
+| [writeString(ITrFont font, String str)](#writeString-com.aspose.page.ITrFont-java.lang.String-) | 指定されたフォントで文字列を書き出します。 |
+| [writeWarning(String warning)](#writeWarning-java.lang.String-) |  |
+### TextDevice() {#TextDevice--}
+```
+public TextDevice()
+```
+
+
+### DEFAULT_SIZE {#DEFAULT-SIZE}
+```
+public static final Dimension DEFAULT_SIZE
+```
+
+
+### EMIT_ERRORS {#EMIT-ERRORS}
+```
+public static final String EMIT_ERRORS
+```
+
+
+### EMIT_WARNINGS {#EMIT-WARNINGS}
+```
+public static final String EMIT_WARNINGS
+```
+
+
+### VERSION {#VERSION}
+```
+public static String VERSION
+```
+
+
+現在のデバイスバージョンです。
+
+### closePage() {#closePage--}
+```
+public void closePage()
+```
+
+
+ページがレンダリングされた後、デバイスの必要な準備を行います。
+
+### create() {#create--}
+```
+public Device create()
+```
+
+
+このデバイスのコピーを作成します。
+
+**Returns:**
+[Device](../../com.aspose.page/device)
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+デバイスを破棄します。
+
+### draw(Shape path) {#draw-java.awt.Shape-}
+```
+public void draw(Shape path)
+```
+
+
+パスを描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.awt.Shape | 描画するパス。 |
+
+### drawArc(float x, float y, float width, float height, float startAngle, float arcAngle) {#drawArc-float-float-float-float-float-float-}
+```
+public void drawArc(float x, float y, float width, float height, float startAngle, float arcAngle)
+```
+
+
+円弧を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 弧の中心のX座標。 |
+| y | float | 弧の中心のY座標。 |
+| width | float | 外接矩形の幅。 |
+| height | float | 外接矩形の高さ。 |
+| startAngle | float | 弧の開始角度。 |
+| arcAngle | float | 弧の角度。 |
+
+### drawImage(BufferedImage image, AffineTransform transform, Color bkg) {#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-}
+```
+public void drawImage(BufferedImage image, AffineTransform transform, Color bkg)
+```
+
+
+割り当てられた変換と背景で画像を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 描画する画像。 |
+| transform | java.awt.geom.AffineTransform | 変換。 |
+| bkg | java.awt.Color | 背景色。 |
+
+### drawLine(float x1, float y1, float x2, float y2) {#drawLine-float-float-float-float-}
+```
+public void drawLine(float x1, float y1, float x2, float y2)
+```
+
+
+線分を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x1 | float | セグメントの開始点のX座標。 |
+| y1 | float | セグメントの開始点のY座標。 |
+| x2 | float | セグメントの終了点のX座標。 |
+| y2 | float | セグメントの終了点のY座標。 |
+
+### drawOval(float x, float y, float width, float height) {#drawOval-float-float-float-float-}
+```
+public void drawOval(float x, float y, float width, float height)
+```
+
+
+楕円を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 楕円の中心のX座標。 |
+| y | float | 楕円の中心のY座標。 |
+| width | float | 外接矩形の幅。 |
+| height | float | 外接矩形の高さ。 |
+
+### drawPolygon(float[] xPoints, float[] yPoints, int nPoints) {#drawPolygon-float---float---int-}
+```
+public void drawPolygon(float[] xPoints, float[] yPoints, int nPoints)
+```
+
+
+多角形を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xPoints | float[] | 点のX座標。 |
+| yPoints | float[] | 点のY座標。 |
+| nPoints | int | 点の数です。 |
+
+### drawPolygon(int[] xPoints, int[] yPoints, int nPoints) {#drawPolygon-int---int---int-}
+```
+public void drawPolygon(int[] xPoints, int[] yPoints, int nPoints)
+```
+
+
+多角形を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xPoints | int[] | 点のX座標。 |
+| yPoints | int[] | 点のY座標。 |
+| nPoints | int | 点の数です。 |
+
+### drawPolyline(float[] xPoints, float[] yPoints, int nPoints) {#drawPolyline-float---float---int-}
+```
+public void drawPolyline(float[] xPoints, float[] yPoints, int nPoints)
+```
+
+
+ポリラインを描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xPoints | float[] | 点のX座標。 |
+| yPoints | float[] | 点のY座標。 |
+| nPoints | int | 点の数です。 |
+
+### drawPolyline(int[] xPoints, int[] yPoints, int nPoints) {#drawPolyline-int---int---int-}
+```
+public void drawPolyline(int[] xPoints, int[] yPoints, int nPoints)
+```
+
+
+ポリラインを描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xPoints | int[] | 点のX座標。 |
+| yPoints | int[] | 点のY座標。 |
+| nPoints | int | 点の数です。 |
+
+### drawRect(float x, float y, float width, float height) {#drawRect-float-float-float-float-}
+```
+public void drawRect(float x, float y, float width, float height)
+```
+
+
+矩形を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 矩形の左上隅のX座標。 |
+| y | float | 矩形の左上隅のY座標。 |
+| width | float | 矩形の幅。 |
+| height | float | 矩形の高さ。 |
+
+### drawRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight) {#drawRoundRect-float-float-float-float-float-float-}
+```
+public void drawRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)
+```
+
+
+丸角長方形を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 矩形の左上隅のX座標。 |
+| y | float | 矩形の左上隅のY座標。 |
+| width | float | 矩形の幅。 |
+| height | float | 矩形の高さ。 |
+| arcWidth | float | 矩形の角を丸める弧の外接矩形の幅。 |
+| arcHeight | float | 矩形の角を丸める弧の外接矩形の高さ。 |
+
+### drawString(String str, float x, float y) {#drawString-java.lang.String-float-float-}
+```
+public void drawString(String str, float x, float y)
+```
+
+
+指定された点に文字列を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| str | java.lang.String |  |
+| x | float |  |
+| y | float |  |
+
+### endDocument() {#endDocument--}
+```
+public void endDocument()
+```
+
+
+ドキュメントがレンダリングされた後、デバイスの必要な準備を行います。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fill(Shape path) {#fill-java.awt.Shape-}
+```
+public void fill(Shape path)
+```
+
+
+パスを塗りつぶします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.awt.Shape | 塗りつぶすパス。 |
+
+### fillArc(float x, float y, float width, float height, float startAngle, float arcAngle) {#fillArc-float-float-float-float-float-float-}
+```
+public void fillArc(float x, float y, float width, float height, float startAngle, float arcAngle)
+```
+
+
+円弧を塗りつぶします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 弧の中心のX座標。 |
+| y | float | 弧の中心のY座標。 |
+| width | float | 外接矩形の幅。 |
+| height | float | 外接矩形の高さ。 |
+| startAngle | float | 弧の開始角度。 |
+| arcAngle | float | 弧の角度。 |
+
+### fillOval(float x, float y, float width, float height) {#fillOval-float-float-float-float-}
+```
+public void fillOval(float x, float y, float width, float height)
+```
+
+
+楕円を塗りつぶします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 楕円の中心のX座標。 |
+| y | float | 楕円の中心のY座標。 |
+| width | float | 外接矩形の幅。 |
+| height | float | 外接矩形の高さ。 |
+
+### fillPolygon(float[] xPoints, float[] yPoints, int nPoints) {#fillPolygon-float---float---int-}
+```
+public void fillPolygon(float[] xPoints, float[] yPoints, int nPoints)
+```
+
+
+多角形を塗りつぶします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xPoints | float[] | 点のX座標。 |
+| yPoints | float[] | 点のY座標。 |
+| nPoints | int | 点の数です。 |
+
+### fillPolygon(int[] xPoints, int[] yPoints, int nPoints) {#fillPolygon-int---int---int-}
+```
+public void fillPolygon(int[] xPoints, int[] yPoints, int nPoints)
+```
+
+
+多角形を塗りつぶします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xPoints | int[] | 点のX座標。 |
+| yPoints | int[] | 点のY座標。 |
+| nPoints | int | 点の数です。 |
+
+### fillRect(float x, float y, float width, float height) {#fillRect-float-float-float-float-}
+```
+public void fillRect(float x, float y, float width, float height)
+```
+
+
+長方形を塗りつぶします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 矩形の左上隅のX座標。 |
+| y | float | 矩形の左上隅のY座標。 |
+| width | float | 矩形の幅。 |
+| height | float | 矩形の高さ。 |
+
+### fillRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight) {#fillRoundRect-float-float-float-float-float-float-}
+```
+public void fillRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)
+```
+
+
+丸角長方形を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | 矩形の左上隅のX座標。 |
+| y | float | 矩形の左上隅のY座標。 |
+| width | float | 矩形の幅。 |
+| height | float | 矩形の高さ。 |
+| arcWidth | float | 矩形の角を丸める弧の外接矩形の幅。 |
+| arcHeight | float | 矩形の角を丸める弧の外接矩形の高さ。 |
+
+### getBackground() {#getBackground--}
+```
+public Color getBackground()
+```
+
+
+ページの現在の背景を取得します。
+
+**Returns:**
+java.awt.Color - ページの現在の背景
+### getCharTM() {#getCharTM--}
+```
+public AffineTransform getCharTM()
+```
+
+
+現在の文字変換を取得します。
+
+**Returns:**
+java.awt.geom.AffineTransform - 現在の文字変換。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+結果として得られるデバイス出力の作成者を取得します。
+
+**Returns:**
+java.lang.String - 作成者の値。
+### getCurrentPageNumber() {#getCurrentPageNumber--}
+```
+public int getCurrentPageNumber()
+```
+
+
+現在のページ番号を取得します。
+
+**Returns:**
+int
+### getFont() {#getFont--}
+```
+public ITrFont getFont()
+```
+
+
+現在のフォントを取得します。
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - Current font.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+現在の不透明度を取得します。
+
+**Returns:**
+float - 現在の不透明度。
+### getOpacityMask() {#getOpacityMask--}
+```
+public Paint getOpacityMask()
+```
+
+
+現在の不透明度マスクを取得します。
+
+**Returns:**
+java.awt.Paint - 現在の不透明度マスク。
+### getPages() {#getPages--}
+```
+public List<String> getPages()
+```
+
+
+
+
+**Returns:**
+java.util.List<java.lang.String>
+### getPaint() {#getPaint--}
+```
+public Paint getPaint()
+```
+
+
+現在のペイントを取得します。
+
+**Returns:**
+java.awt.Paint - 現在の塗料です。
+### getProperties() {#getProperties--}
+```
+public UserProperties getProperties()
+```
+
+
+メタデータを含むデバイスプロパティを取得します。
+
+**Returns:**
+[UserProperties](../../com.aspose.page/userproperties) - Device properties.
+### getProperty(String key) {#getProperty-java.lang.String-}
+```
+public String getProperty(String key)
+```
+
+
+文字列プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.lang.String - プロパティの値。
+### getPropertyColor(String key) {#getPropertyColor-java.lang.String-}
+```
+public Color getPropertyColor(String key)
+```
+
+
+色プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Color - プロパティの値。
+### getPropertyDouble(String key) {#getPropertyDouble-java.lang.String-}
+```
+public double getPropertyDouble(String key)
+```
+
+
+double プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+double - プロパティの値。
+### getPropertyInt(String key) {#getPropertyInt-java.lang.String-}
+```
+public int getPropertyInt(String key)
+```
+
+
+整数プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+int - プロパティの値。
+### getPropertyMargins(String key) {#getPropertyMargins-java.lang.String-}
+```
+public Insets getPropertyMargins(String key)
+```
+
+
+余白プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Insets - プロパティの値。
+### getPropertyMatrix(String key) {#getPropertyMatrix-java.lang.String-}
+```
+public AffineTransform getPropertyMatrix(String key)
+```
+
+
+行列プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.geom.AffineTransform - プロパティの値。
+### getPropertyRectangle(String key) {#getPropertyRectangle-java.lang.String-}
+```
+public Rectangle getPropertyRectangle(String key)
+```
+
+
+長方形プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Rectangle - プロパティの値。
+### getPropertySize(String key) {#getPropertySize-java.lang.String-}
+```
+public Dimension getPropertySize(String key)
+```
+
+
+サイズプロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Dimension - プロパティの値。
+### getSaveOptions() {#getSaveOptions--}
+```
+public SaveOptions getSaveOptions()
+```
+
+
+保存オプションを返します。
+
+**Returns:**
+[SaveOptions](../../com.aspose.page/saveoptions) - The save options.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページのサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページのサイズ。
+### getStroke() {#getStroke--}
+```
+public Stroke getStroke()
+```
+
+
+現在のストロークを取得します。
+
+**Returns:**
+java.awt.Stroke - 現在のストローク。
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getText(int startPage, int endPage) {#getText-int-int-}
+```
+public String getText(int startPage, int endPage)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| startPage | int |  |
+| endPage | int |  |
+
+**Returns:**
+java.lang.String
+### getTextRenderingMode() {#getTextRenderingMode--}
+```
+public TextRenderingMode getTextRenderingMode()
+```
+
+
+現在のテキスト描画モードを取得します。
+
+**Returns:**
+[TextRenderingMode](../../com.aspose.page/textrenderingmode) - Current text rendering mode.
+### getTextStrokeWidth() {#getTextStrokeWidth--}
+```
+public float getTextStrokeWidth()
+```
+
+
+現在のテキストストローク幅を取得します。
+
+**Returns:**
+float - 現在のテキストストローク幅。
+### getTransform() {#getTransform--}
+```
+public AffineTransform getTransform()
+```
+
+
+現在の変換を取得します。
+
+**Returns:**
+java.awt.geom.AffineTransform - 現在の変換。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initClip() {#initClip--}
+```
+public void initClip()
+```
+
+
+デバイスのクリップを初期化します。
+
+### initPageNumbers() {#initPageNumbers--}
+```
+public void initPageNumbers()
+```
+
+
+レンダリングするページ数を初期化します。
+
+### isDirectRGB() {#isDirectRGB--}
+```
+public boolean isDirectRGB()
+```
+
+
+デバイスが直接RGBモード（RGB）を使用しているかどうかを示します。
+
+**Returns:**
+boolean
+### isMainDocument() {#isMainDocument--}
+```
+public boolean isMainDocument()
+```
+
+
+
+
+**Returns:**
+boolean
+### isProperty(String key) {#isProperty-java.lang.String-}
+```
+public boolean isProperty(String key)
+```
+
+
+ブールプロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+boolean - プロパティの値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### openPage(float width, float height) {#openPage-float-float-}
+```
+public boolean openPage(float width, float height)
+```
+
+
+ページのレンダリング前にデバイスの必要な準備を行います。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float |  |
+| height | float |  |
+
+**Returns:**
+boolean
+### openPage(String title) {#openPage-java.lang.String-}
+```
+public boolean openPage(String title)
+```
+
+
+ページのレンダリング前にデバイスの必要な準備を行います。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| タイトル | java.lang.String |  |
+
+**Returns:**
+boolean
+### renew() {#renew--}
+```
+public void renew()
+```
+
+
+ドキュメント全体の初期状態にデバイスをリセットします。出力ストリームのリセットに使用されます。
+
+### renewForMerge(boolean mainDocument) {#renewForMerge-boolean-}
+```
+public void renewForMerge(boolean mainDocument)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| mainDocument | boolean |  |
+
+### reset() {#reset--}
+```
+public void reset()
+```
+
+
+ページの初期状態にデバイスをリセットします。
+
+### reset(boolean zeroPageNumbers) {#reset-boolean-}
+```
+public void reset(boolean zeroPageNumbers)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| zeroPageNumbers | boolean |  |
+
+### rotate(double theta) {#rotate-double-}
+```
+public void rotate(double theta)
+```
+
+
+現在の変換行列を回転させます。writeTransform(Transform) を呼び出します。正の角度 theta で回転させると、正の x 軸上の点が正の y 軸方向へ回転します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| theta | double | 回転させるラジアン単位の角度。 |
+
+### rotate(double theta, double x, double y) {#rotate-double-double-double-}
+```
+public void rotate(double theta, double x, double y)
+```
+
+
+現在の変換行列を点の周りで回転させます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| theta | double | ラジアン単位の回転角。 |
+| x | double | 点の X 座標。 |
+| y | double | 点のY座標。 |
+
+### scale(double x, double y) {#scale-double-double-}
+```
+public void scale(double x, double y)
+```
+
+
+現在の変換行列をスケールします。Calls writeTransform(Transform).
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | double | X軸のスケール。 |
+| y | double | Y軸のスケール。 |
+
+### setBackground(Color background) {#setBackground-java.awt.Color-}
+```
+public void setBackground(Color background)
+```
+
+
+ページの現在の背景を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 背景 | java.awt.Color | ページの背景。 |
+
+### setCharTM(AffineTransform charTM) {#setCharTM-java.awt.geom.AffineTransform-}
+```
+public void setCharTM(AffineTransform charTM)
+```
+
+
+文字の変換を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| charTM | java.awt.geom.AffineTransform | \\u0421haracters 変換。 |
+
+### setClip(Shape clipPath) {#setClip-java.awt.Shape-}
+```
+public void setClip(Shape clipPath)
+```
+
+
+デバイスのクリップを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| clipPath | java.awt.Shape | クリッピングパス。 |
+
+### setCreator(String creator) {#setCreator-java.lang.String-}
+```
+public void setCreator(String creator)
+```
+
+
+結果として得られるデバイス出力の作成者を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 作成者 | java.lang.String | 作成者の値。 |
+
+### setFont(ITrFont font) {#setFont-com.aspose.page.ITrFont-}
+```
+public void setFont(ITrFont font)
+```
+
+
+フォントを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| font | [ITrFont](../../com.aspose.page/itrfont) | フォント。 |
+
+### setOpacity(float opacity) {#setOpacity-float-}
+```
+public void setOpacity(float opacity)
+```
+
+
+不透明度を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 不透明度 | float | 不透明度。 |
+
+### setOpacityMask(Paint opacityMask) {#setOpacityMask-java.awt.Paint-}
+```
+public void setOpacityMask(Paint opacityMask)
+```
+
+
+不透明度マスクを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| opacityMask | java.awt.Paint | 不透明度マスク。 |
+
+### setPaint(Paint paint) {#setPaint-java.awt.Paint-}
+```
+public void setPaint(Paint paint)
+```
+
+
+ペイントを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| paint | java.awt.Paint | ペイント。 |
+
+### setProperties(UserProperties props) {#setProperties-com.aspose.page.UserProperties-}
+```
+public void setProperties(UserProperties props)
+```
+
+
+メタデータを含むデバイスプロパティを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| props | [UserProperties](../../com.aspose.page/userproperties) | デバイスプロパティ。 |
+
+### setSaveOptions(SaveOptions options) {#setSaveOptions-com.aspose.page.SaveOptions-}
+```
+public void setSaveOptions(SaveOptions options)
+```
+
+
+レンダリングプロセスの管理オプションを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | レンダリングプロセスを管理するオプション。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページのサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension |  |
+
+### setStroke(Stroke stroke) {#setStroke-java.awt.Stroke-}
+```
+public void setStroke(Stroke stroke)
+```
+
+
+ストロークを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| stroke | java.awt.Stroke | ストローク。 |
+
+### setTextRenderingMode(TextRenderingMode textRenderingMode) {#setTextRenderingMode-com.aspose.page.TextRenderingMode-}
+```
+public void setTextRenderingMode(TextRenderingMode textRenderingMode)
+```
+
+
+テキスト描画モードを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| textRenderingMode | [TextRenderingMode](../../com.aspose.page/textrenderingmode) | テキストレンダリングモード。 |
+
+### setTextStrokeWidth(float textStrokeWidth) {#setTextStrokeWidth-float-}
+```
+public void setTextStrokeWidth(float textStrokeWidth)
+```
+
+
+テキストストローク幅を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| textStrokeWidth | float | テキストストローク幅。 |
+
+### setTransform(AffineTransform transform) {#setTransform-java.awt.geom.AffineTransform-}
+```
+public void setTransform(AffineTransform transform)
+```
+
+
+現在の変換を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| transform | java.awt.geom.AffineTransform | 変換.. |
+
+### shear(double shx, double shy) {#shear-double-double-}
+```
+public void shear(double shx, double shy)
+```
+
+
+現在の変換行列をシアーします。writeTransform(Transform) を呼び出します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| shx | double | X 軸のシアー。 |
+| shy | double | Y 軸のシアー。 |
+
+### startDocument() {#startDocument--}
+```
+public void startDocument()
+```
+
+
+ドキュメントのレンダリング開始前にデバイスの必要な準備を行います。
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+デバイスタイプの名前を返します。
+
+**Returns:**
+java.lang.String
+### transform(AffineTransform transform) {#transform-java.awt.geom.AffineTransform-}
+```
+public void transform(AffineTransform transform)
+```
+
+
+現在の変換行列を変換します。writeTransform(Transform) を呼び出します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| transform | java.awt.geom.AffineTransform | 適用される変換。 |
+
+### translate(double x, double y) {#translate-double-double-}
+```
+public void translate(double x, double y)
+```
+
+
+現在の変換行列を平行移動します。writeTransform(Transform) を呼び出します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | double | X 軸の平行移動。 |
+| y | double | Y 軸の平行移動。 |
+
+### updatePageParameters(IMultiPageDevice device) {#updatePageParameters-com.aspose.page.IMultiPageDevice-}
+```
+public void updatePageParameters(IMultiPageDevice device)
+```
+
+
+他のマルチページデバイスからページパラメータを更新します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| device | [IMultiPageDevice](../../com.aspose.page/imultipagedevice) |  |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+
+### writeComment(String comment) {#writeComment-java.lang.String-}
+```
+public void writeComment(String comment)
+```
+
+
+コメントを書き込みます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| コメント | java.lang.String | 書き込むコメント。 |
+
+### writeString(ITrFont font, String str) {#writeString-com.aspose.page.ITrFont-java.lang.String-}
+```
+public void writeString(ITrFont font, String str)
+```
+
+
+指定されたフォントで文字列を書き出します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| font | [ITrFont](../../com.aspose.page/itrfont) | 指定されたフォント。 |
+| str | java.lang.String | 文字列。 |
+
+### writeWarning(String warning) {#writeWarning-java.lang.String-}
+```
+public void writeWarning(String warning)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 警告 | java.lang.String |  |
+

--- a/japanese/java/com.aspose.eps.plugins/_index.md
+++ b/japanese/java/com.aspose.eps.plugins/_index.md
@@ -1,0 +1,20 @@
+---
+title: "com.aspose.eps.plugins"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.eps.plugins には EPS プラグインクラスが含まれています。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.eps.plugins/
+---
+
+ **com.aspose.eps.plugins**  には EPS プラグインクラスが含まれています。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [PsConverter](../com.aspose.eps.plugins/psconverter) | PsConverter プラグインを表します。 |
+| [PsConverterOptions](../com.aspose.eps.plugins/psconverteroptions) | [PsConverter](../com.aspose.eps.plugins/psconverter) プラグインのオプションの基本クラスを表します。 |
+| [PsConverterToImageOptions](../com.aspose.eps.plugins/psconvertertoimageoptions) | [PsConverter](../com.aspose.eps.plugins/psconverter) プラグインの PS/EPS から画像への変換オプションを表します。 |
+| [PsConverterToPdfOptions](../com.aspose.eps.plugins/psconvertertopdfoptions) | [PsConverter](../com.aspose.eps.plugins/psconverter) プラグインの PS/EPS から PDF への変換オプションを表します。 |

--- a/japanese/java/com.aspose.eps.plugins/psconverter/_index.md
+++ b/japanese/java/com.aspose.eps.plugins/psconverter/_index.md
@@ -1,0 +1,175 @@
+---
+title: "PsConverter"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PsConverter プラグインを表します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.eps.plugins/psconverter/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPlugin](../../com.aspose.page.plugins/iplugin)
+```
+public class PsConverter implements IPlugin
+```
+
+PsConverter プラグインを表します。
+
+この例は、PS/EPS ファイルを PDF ドキュメントに変換する方法を示しています。
+
+// PsConverter を作成 PsConverter converter = new PsConverter(); // 出力データタイプをファイルに設定する PsConverterToPdfOptions オブジェクトを作成 PsConverterToPdfOptions opt = new PsConverterToPdfOptions(); // 入力ファイルパスを追加 opt.addDataSource(new FileDataSource(inputPath)); // 出力ファイルパスを設定 opt.addSaveDataSource(new FileDataSource(outputPath)); // 変換プロセスを開始 ResultContainer results = converter.process(opt);
+
+この例は、PS/EPS ファイルを画像に変換し、ファイルとして出力する方法を示しています。
+
+// PsConverter を作成 PsConverter converter = new PsConverter(); // JPEG ターゲット画像フォーマットで PsConverterToImageOptions を作成します。結果画像のデフォルトフォーマットは PNG です。 // また、結果画像のサイズ、解像度、スムージングモード、JPEG 画像フォーマットの品質レベルを設定できます。 PsConverterToImageOptions opt = new PsConverterToImageOptions(ImageFormat.Jpeg); // 入力ファイルパスを追加 opt.addDataSource(new FileDataSource(inputPath)); // 入力 PS ファイルが複数ページの場合、結果は次の名前形式の画像ファイル集合になります: [\"outputPath\" の拡張子なし][ページ番号（0 から開始）].[\"outputPath\" の拡張子] opt.addSaveDataSource(new FileDataSource(outputPath)); // 変換プロセスを開始 converter.process(opt);
+
+この例は、PS/EPS ファイルを画像に変換し、バイト配列として出力する方法を示しています。
+
+バイト配列出力データソース (byte [][]) では、1 つのバイト配列が 1 ページの画像を含みます。そのため、1 ページ文書の場合、結果は [1][] 配列となり、複数ページ文書の場合、結果は [入力 PS 文書のページ数][] 配列となります。 // PsConverter を作成 PsConverter converter = new PsConverter(); // JPEG ターゲット画像フォーマットで PsConverterToImageOptions を作成します。結果画像のデフォルトフォーマットは PNG です。 // また、結果画像のサイズ、解像度、スムージングモード、JPEG 画像フォーマットの品質レベルを設定できます。 PsConverterToImageOptions opt = new PsConverterToImageOptions(ImageImageFormat.Jpeg); // 入力ファイルパスを追加 opt.addDataSource(new FileDataSource(inputPath)); // 入力 PS ファイルが複数ページの場合、結果は次の名前形式の画像ファイル集合になります: [\"outputPath\" の拡張子なし][ページ番号（0 から開始）].[\"outputPath\" の拡張子] opt.addSaveDataSource(new ByteArrayDataSource()); // 変換プロセスを開始 converter.process(opt); // 結果のバイト配列を取得 byte[][] imagesBytes = (byte [][]) ((ByteArrayResult)results.ResultCollection[0]).Data;
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsConverter()](#PsConverter--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [dispose()](#dispose--) | IDisposable の実装。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [process(IPluginOptions options)](#process-com.aspose.page.plugins.IPluginOptions-) | 指定されたパラメータで PsConverter の処理を開始します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverter() {#PsConverter--}
+```
+public PsConverter()
+```
+
+
+### dispose() {#dispose--}
+```
+public final void dispose()
+```
+
+
+IDisposable の実装。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### process(IPluginOptions options) {#process-com.aspose.page.plugins.IPluginOptions-}
+```
+public final ResultContainer process(IPluginOptions options)
+```
+
+
+指定されたパラメータで PsConverter の処理を開始します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [IPluginOptions](../../com.aspose.page.plugins/ipluginoptions) | PsConverter 用の指示を含むオプションオブジェクトです。 |
+
+**Returns:**
+[ResultContainer](../../com.aspose.page.plugins/resultcontainer) - An ResultContainer object containing the result of the operation.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.plugins/psconverteroptions/_index.md
+++ b/japanese/java/com.aspose.eps.plugins/psconverteroptions/_index.md
@@ -1,0 +1,299 @@
+---
+title: "PsConverterOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグインのオプションの基底クラスを表します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.eps.plugins/psconverteroptions/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPluginOptions](../../com.aspose.page.plugins/ipluginoptions), [com.aspose.page.plugins.IDataContainer](../../com.aspose.page.plugins/idatacontainer), [com.aspose.page.plugins.ISaveInstruction](../../com.aspose.page.plugins/isaveinstruction)
+```
+public class PsConverterOptions implements IPluginOptions, IDataContainer, ISaveInstruction
+```
+
+プラグイン [PsConverter](../../com.aspose.eps.plugins/psconverter) 用オプションの基底クラスを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | PsConverter プラグインのデータコレクションに新しいデータソースを追加します。 |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | PsConverterOptions プラグインのデータコレクションに新しいデータソースを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | PsConverterOptions プラグインのデータコレクションを返します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOperationName()](#getOperationName--) | 操作名を返します。 |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 保存操作結果のために追加されたターゲットのコレクションを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+PsConverter プラグインのデータコレクションに新しいデータソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 追加するデータ ソース。 |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+PsConverterOptions プラグインのデータコレクションに新しいデータソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 保存操作結果のためのデータ ソース（ファイルまたはストリーム）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+PsConverterOptions プラグインのデータコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOperationName() {#getOperationName--}
+```
+public String getOperationName()
+```
+
+
+操作名を返します。
+
+**Returns:**
+java.lang.String
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+保存操作結果のために追加されたターゲットのコレクションを取得します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.plugins/psconvertertoimageoptions/_index.md
+++ b/japanese/java/com.aspose.eps.plugins/psconvertertoimageoptions/_index.md
@@ -1,0 +1,452 @@
+---
+title: "PsConverterToImageOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグイン用の PS/EPS から画像へのコンバータオプションを表します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.eps.plugins/psconvertertoimageoptions/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.eps.plugins.PsConverterOptions](../../com.aspose.eps.plugins/psconverteroptions)
+```
+public class PsConverterToImageOptions extends PsConverterOptions
+```
+
+プラグイン [PsConverter](../../com.aspose.eps.plugins/psconverter) 用の PS/EPS から画像へのコンバータオプションを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsConverterToImageOptions()](#PsConverterToImageOptions--) | 新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+| [PsConverterToImageOptions(ImageFormat imageFormat)](#PsConverterToImageOptions-com.aspose.page.ImageFormat-) | 画像フォーマットを指定して新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+| [PsConverterToImageOptions(Dimension size)](#PsConverterToImageOptions-java.awt.Dimension-) | 結果画像のサイズを指定して新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+| [PsConverterToImageOptions(ImageFormat imageFormat, Dimension size)](#PsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-) | 画像フォーマットを指定して新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | PsConverter プラグインのデータコレクションに新しいデータソースを追加します。 |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | PsConverterOptions プラグインのデータコレクションに新しいデータソースを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | PsConverterOptions プラグインのデータコレクションを返します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageFormat()](#getImageFormat--) | 画像形式を取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOperationName()](#getOperationName--) | 操作名を返します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 保存操作結果のために追加されたターゲットのコレクションを取得します。 |
+| [getSize()](#getSize--) | 結果画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | 画像のレンダリングに使用するスムージングモードを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageFormat(ImageFormat imageFormat)](#setImageFormat-com.aspose.page.ImageFormat-) | 画像形式を取得します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setResolution(int resolution)](#setResolution-int-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 結果画像のサイズを設定します。 |
+| [setSmoothingMode(SmoothingMode smoothingMode)](#setSmoothingMode-com.aspose.eps.device.SmoothingMode-) | 画像のレンダリングに使用するスムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterToImageOptions() {#PsConverterToImageOptions--}
+```
+public PsConverterToImageOptions()
+```
+
+
+新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+### PsConverterToImageOptions(ImageFormat imageFormat) {#PsConverterToImageOptions-com.aspose.page.ImageFormat-}
+```
+public PsConverterToImageOptions(ImageFormat imageFormat)
+```
+
+
+画像フォーマットを指定して新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 結果画像のフォーマット。 |
+
+### PsConverterToImageOptions(Dimension size) {#PsConverterToImageOptions-java.awt.Dimension-}
+```
+public PsConverterToImageOptions(Dimension size)
+```
+
+
+結果画像のサイズを指定して新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 結果画像のサイズ。 |
+
+### PsConverterToImageOptions(ImageFormat imageFormat, Dimension size) {#PsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-}
+```
+public PsConverterToImageOptions(ImageFormat imageFormat, Dimension size)
+```
+
+
+画像フォーマットを指定して新しい [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 結果画像のフォーマット。 |
+| size | java.awt.Dimension |  |
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+PsConverter プラグインのデータコレクションに新しいデータソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 追加するデータ ソース。 |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+PsConverterOptions プラグインのデータコレクションに新しいデータソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 保存操作結果のためのデータ ソース（ファイルまたはストリーム）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+PsConverterOptions プラグインのデータコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageFormat() {#getImageFormat--}
+```
+public ImageFormat getImageFormat()
+```
+
+
+画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat) - An image format.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+操作名を返します。
+
+**Returns:**
+java.lang.String
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+int - 画像の解像度。
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+保存操作結果のために追加されたターゲットのコレクションを取得します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+結果画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - 画像のサイズ。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+画像のレンダリングに使用するスムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.eps.device/smoothingmode) - A smoothing mode.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageFormat(ImageFormat imageFormat) {#setImageFormat-com.aspose.page.ImageFormat-}
+```
+public void setImageFormat(ImageFormat imageFormat)
+```
+
+
+画像形式を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 結果画像のフォーマット。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setResolution(int resolution) {#setResolution-int-}
+```
+public void setResolution(int resolution)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 解像度 | int | 結果画像の解像度。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+結果画像のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 結果画像のサイズ。 |
+
+### setSmoothingMode(SmoothingMode smoothingMode) {#setSmoothingMode-com.aspose.eps.device.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode smoothingMode)
+```
+
+
+画像のレンダリングに使用するスムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| smoothingMode | [SmoothingMode](../../com.aspose.eps.device/smoothingmode) | 平滑化モード。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps.plugins/psconvertertopdfoptions/_index.md
+++ b/japanese/java/com.aspose.eps.plugins/psconvertertopdfoptions/_index.md
@@ -1,0 +1,309 @@
+---
+title: "PsConverterToPdfOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグイン用の PS/EPS から PDF へのコンバータオプションを表します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.eps.plugins/psconvertertopdfoptions/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.eps.plugins.PsConverterOptions](../../com.aspose.eps.plugins/psconverteroptions)
+```
+public class PsConverterToPdfOptions extends PsConverterOptions
+```
+
+プラグイン [PsConverter](../../com.aspose.eps.plugins/psconverter) 用の PS/EPS から PDF へのコンバータオプションを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsConverterToPdfOptions()](#PsConverterToPdfOptions--) | 新しい [PsConverterToPdfOptions](../../com.aspose.eps.plugins/psconvertertopdfoptions) オブジェクトのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | PsConverter プラグインのデータコレクションに新しいデータソースを追加します。 |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | PsConverterOptions プラグインのデータコレクションに新しいデータソースを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | PsConverterOptions プラグインのデータコレクションを返します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOperationName()](#getOperationName--) | 操作名を返します。 |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 保存操作結果のために追加されたターゲットのコレクションを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterToPdfOptions() {#PsConverterToPdfOptions--}
+```
+public PsConverterToPdfOptions()
+```
+
+
+新しい [PsConverterToPdfOptions](../../com.aspose.eps.plugins/psconvertertopdfoptions) オブジェクトのインスタンスを初期化します。
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+PsConverter プラグインのデータコレクションに新しいデータソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 追加するデータ ソース。 |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+PsConverterOptions プラグインのデータコレクションに新しいデータソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 保存操作結果のためのデータ ソース（ファイルまたはストリーム）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+PsConverterOptions プラグインのデータコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+操作名を返します。
+
+**Returns:**
+java.lang.String
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+保存操作結果のために追加されたターゲットのコレクションを取得します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/_index.md
+++ b/japanese/java/com.aspose.eps/_index.md
@@ -1,0 +1,31 @@
+---
+title: "com.aspose.eps"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.eps は、PS/EPS ファイルを扱うすべてのクラスのルートパッケージです。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.eps/
+---
+
+**com.aspose.eps** は、PS/EPS ファイルを扱うすべてのクラスのルートパッケージです。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [FontConstants](../com.aspose.eps/fontconstants) | このクラスは、フォントを保存するための定数セットを定義します。 |
+| [HatchPaintLibrary](../com.aspose.eps/hatchpaintlibrary) | GDI+ ハッチブラシを XPS および PDF に書き込むのに適した画像に変換します。 |
+| [LoadOptions](../com.aspose.eps/loadoptions) | ドキュメント読み込みオプションの基本クラスです。 |
+| [PageConstants](../com.aspose.eps/pageconstants) | このクラスは、ページを記述する定数のセットを定義します。 |
+| [PsConverterException](../com.aspose.eps/psconverterexception) | このクラスは、PS ファイルが PDF ドキュメントに変換される際にスローされるエラーに関する情報を含みます。 |
+| [PsConverterLicenseException](../com.aspose.eps/psconverterlicenseexception) | このクラスは、Aspose.Page 製品のライセンスに関連するエラーに関する情報を含みます。 |
+| [PsDocument](../com.aspose.eps/psdocument) | このクラスは PS/EPS ドキュメントをカプセル化します。 |
+| [PsDocumentException](../com.aspose.eps/psdocumentexception) | このクラスは、PS ファイルが作成、完了、保存される際にスローされるエラーに関する情報を含みます。 |
+| [PsLoadOptions](../com.aspose.eps/psloadoptions) | PS ドキュメントの読み込みオプション。 |
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| --- | --- |
+| [HatchStyle](../com.aspose.eps/hatchstyle) | .NET で使用されるハッチスタイルの名前を格納します。 |

--- a/japanese/java/com.aspose.eps/fontconstants/_index.md
+++ b/japanese/java/com.aspose.eps/fontconstants/_index.md
@@ -1,0 +1,184 @@
+---
+title: "FontConstants"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、フォントを保存するための定数セットを定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.eps/fontconstants/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontConstants
+```
+
+このクラスは、フォントを保存するための定数セットを定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [EMBED_FONTS](#EMBED-FONTS) | 保存されたドキュメントにフォントを埋め込むかどうかを示すプロパティのキー |
+| [EMBED_FONTS_AS](#EMBED-FONTS-AS) | ドキュメントを保存するときに使用するフォントの種類を示すプロパティのキー |
+| [EMBED_FONTS_TRUETYPE](#EMBED-FONTS-TRUETYPE) | "TrueType" フォントタイプの値（"EMBED\_FONTS\_AS" キー） |
+| [EMBED_FONTS_TYPE1](#EMBED-FONTS-TYPE1) | "Type3" フォントタイプの値（"EMBED\_FONTS\_AS" キー） |
+| [EMBED_FONTS_TYPE3](#EMBED-FONTS-TYPE3) | "Type3" フォントタイプの値（"EMBED\_FONTS\_AS" キー） |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEmbedFontsAsList()](#getEmbedFontsAsList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMBED_FONTS {#EMBED-FONTS}
+```
+public static final String EMBED_FONTS
+```
+
+
+保存されたドキュメントにフォントを埋め込むかどうかを示すプロパティのキー
+
+### EMBED_FONTS_AS {#EMBED-FONTS-AS}
+```
+public static final String EMBED_FONTS_AS
+```
+
+
+ドキュメントを保存するときに使用するフォントの種類を示すプロパティのキー
+
+### EMBED_FONTS_TRUETYPE {#EMBED-FONTS-TRUETYPE}
+```
+public static final String EMBED_FONTS_TRUETYPE
+```
+
+
+"TrueType" フォントタイプの値（"EMBED\_FONTS\_AS" キー）
+
+### EMBED_FONTS_TYPE1 {#EMBED-FONTS-TYPE1}
+```
+public static final String EMBED_FONTS_TYPE1
+```
+
+
+"Type3" フォントタイプの値（"EMBED\_FONTS\_AS" キー）
+
+### EMBED_FONTS_TYPE3 {#EMBED-FONTS-TYPE3}
+```
+public static final String EMBED_FONTS_TYPE3
+```
+
+
+"Type3" フォントタイプの値（"EMBED\_FONTS\_AS" キー）
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmbedFontsAsList() {#getEmbedFontsAsList--}
+```
+public static final String[] getEmbedFontsAsList()
+```
+
+
+
+
+**Returns:**
+java.lang.String[] - 利用可能な "EMBED\_FONTS\_AS" 値
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/hatchpaintlibrary/_index.md
+++ b/japanese/java/com.aspose.eps/hatchpaintlibrary/_index.md
@@ -1,0 +1,153 @@
+---
+title: "HatchPaintLibrary"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "GDI ハッチブラシを XPS および PDF に書き込むのに適した画像に変換します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.eps/hatchpaintlibrary/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HatchPaintLibrary
+```
+
+GDI+ ハッチブラシを XPS および PDF に書き込むのに適した画像に変換します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [HatchSize](#HatchSize) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHatchTexturePaint(HatchStyle style, Color foreColor, Color backColor)](#getHatchTexturePaint-com.aspose.eps.HatchStyle-java.awt.Color-java.awt.Color-) | ハッチスタイルに従ってハッチパターンをカプセル化した TexturePaint を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HatchSize {#HatchSize}
+```
+public static final int HatchSize
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHatchTexturePaint(HatchStyle style, Color foreColor, Color backColor) {#getHatchTexturePaint-com.aspose.eps.HatchStyle-java.awt.Color-java.awt.Color-}
+```
+public static TexturePaint getHatchTexturePaint(HatchStyle style, Color foreColor, Color backColor)
+```
+
+
+ハッチスタイルに従ってハッチパターンをカプセル化した TexturePaint を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| style | [HatchStyle](../../com.aspose.eps/hatchstyle) | ハッチスタイルです。 |
+| foreColor | java.awt.Color | 前景色です。 |
+| backColor | java.awt.Color | 背景色です。 |
+
+**Returns:**
+java.awt.TexturePaint - ハッチテクスチャパターンを返します
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/hatchstyle/_index.md
+++ b/japanese/java/com.aspose.eps/hatchstyle/_index.md
@@ -1,0 +1,635 @@
+---
+title: "HatchStyle"
+second_title: "Aspose.Page for Java API リファレンス"
+description: ".NET で使用されるハッチスタイルの名前を格納します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.eps/hatchstyle/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum HatchStyle extends Enum<HatchStyle>
+```
+
+.NET で使用されるハッチスタイルの名前を格納します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BackwardDiagonal](#BackwardDiagonal) |  |
+| [Cross](#Cross) |  |
+| [DarkDownwardDiagonal](#DarkDownwardDiagonal) |  |
+| [DarkHorizontal](#DarkHorizontal) |  |
+| [DarkUpwardDiagonal](#DarkUpwardDiagonal) |  |
+| [DarkVertical](#DarkVertical) |  |
+| [DashedDownwardDiagonal](#DashedDownwardDiagonal) |  |
+| [DashedHorizontal](#DashedHorizontal) |  |
+| [DashedUpwardDiagonal](#DashedUpwardDiagonal) |  |
+| [DashedVertical](#DashedVertical) |  |
+| [DiagonalBrick](#DiagonalBrick) |  |
+| [DiagonalCross](#DiagonalCross) |  |
+| [Divot](#Divot) |  |
+| [DottedDiamond](#DottedDiamond) |  |
+| [DottedGrid](#DottedGrid) |  |
+| [ForwardDiagonal](#ForwardDiagonal) |  |
+| [Horizontal](#Horizontal) |  |
+| [HorizontalBrick](#HorizontalBrick) |  |
+| [LargeCheckerBoard](#LargeCheckerBoard) |  |
+| [LargeConfetti](#LargeConfetti) |  |
+| [LargeGrid](#LargeGrid) |  |
+| [LightDownwardDiagonal](#LightDownwardDiagonal) |  |
+| [LightHorizontal](#LightHorizontal) |  |
+| [LightUpwardDiagonal](#LightUpwardDiagonal) |  |
+| [LightVertical](#LightVertical) |  |
+| [Max](#Max) |  |
+| [Min](#Min) |  |
+| [NarrowHorizontal](#NarrowHorizontal) |  |
+| [NarrowVertical](#NarrowVertical) |  |
+| [OutlinedDiamond](#OutlinedDiamond) |  |
+| [Percent05](#Percent05) |  |
+| [Percent10](#Percent10) |  |
+| [Percent20](#Percent20) |  |
+| [Percent25](#Percent25) |  |
+| [Percent30](#Percent30) |  |
+| [Percent40](#Percent40) |  |
+| [Percent50](#Percent50) |  |
+| [Percent60](#Percent60) |  |
+| [Percent70](#Percent70) |  |
+| [Percent75](#Percent75) |  |
+| [Percent80](#Percent80) |  |
+| [Percent90](#Percent90) |  |
+| [Plaid](#Plaid) |  |
+| [Shingle](#Shingle) |  |
+| [SmallCheckerBoard](#SmallCheckerBoard) |  |
+| [SmallConfetti](#SmallConfetti) |  |
+| [SmallGrid](#SmallGrid) |  |
+| [SolidDiamond](#SolidDiamond) |  |
+| [Sphere](#Sphere) |  |
+| [Trellis](#Trellis) |  |
+| [Vertical](#Vertical) |  |
+| [Wave](#Wave) |  |
+| [Weave](#Weave) |  |
+| [WideDownwardDiagonal](#WideDownwardDiagonal) |  |
+| [WideUpwardDiagonal](#WideUpwardDiagonal) |  |
+| [ZigZag](#ZigZag) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [getValue()](#getValue--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BackwardDiagonal {#BackwardDiagonal}
+```
+public static final HatchStyle BackwardDiagonal
+```
+
+
+### Cross {#Cross}
+```
+public static final HatchStyle Cross
+```
+
+
+### DarkDownwardDiagonal {#DarkDownwardDiagonal}
+```
+public static final HatchStyle DarkDownwardDiagonal
+```
+
+
+### DarkHorizontal {#DarkHorizontal}
+```
+public static final HatchStyle DarkHorizontal
+```
+
+
+### DarkUpwardDiagonal {#DarkUpwardDiagonal}
+```
+public static final HatchStyle DarkUpwardDiagonal
+```
+
+
+### DarkVertical {#DarkVertical}
+```
+public static final HatchStyle DarkVertical
+```
+
+
+### DashedDownwardDiagonal {#DashedDownwardDiagonal}
+```
+public static final HatchStyle DashedDownwardDiagonal
+```
+
+
+### DashedHorizontal {#DashedHorizontal}
+```
+public static final HatchStyle DashedHorizontal
+```
+
+
+### DashedUpwardDiagonal {#DashedUpwardDiagonal}
+```
+public static final HatchStyle DashedUpwardDiagonal
+```
+
+
+### DashedVertical {#DashedVertical}
+```
+public static final HatchStyle DashedVertical
+```
+
+
+### DiagonalBrick {#DiagonalBrick}
+```
+public static final HatchStyle DiagonalBrick
+```
+
+
+### DiagonalCross {#DiagonalCross}
+```
+public static final HatchStyle DiagonalCross
+```
+
+
+### Divot {#Divot}
+```
+public static final HatchStyle Divot
+```
+
+
+### DottedDiamond {#DottedDiamond}
+```
+public static final HatchStyle DottedDiamond
+```
+
+
+### DottedGrid {#DottedGrid}
+```
+public static final HatchStyle DottedGrid
+```
+
+
+### ForwardDiagonal {#ForwardDiagonal}
+```
+public static final HatchStyle ForwardDiagonal
+```
+
+
+### Horizontal {#Horizontal}
+```
+public static final HatchStyle Horizontal
+```
+
+
+### HorizontalBrick {#HorizontalBrick}
+```
+public static final HatchStyle HorizontalBrick
+```
+
+
+### LargeCheckerBoard {#LargeCheckerBoard}
+```
+public static final HatchStyle LargeCheckerBoard
+```
+
+
+### LargeConfetti {#LargeConfetti}
+```
+public static final HatchStyle LargeConfetti
+```
+
+
+### LargeGrid {#LargeGrid}
+```
+public static final HatchStyle LargeGrid
+```
+
+
+### LightDownwardDiagonal {#LightDownwardDiagonal}
+```
+public static final HatchStyle LightDownwardDiagonal
+```
+
+
+### LightHorizontal {#LightHorizontal}
+```
+public static final HatchStyle LightHorizontal
+```
+
+
+### LightUpwardDiagonal {#LightUpwardDiagonal}
+```
+public static final HatchStyle LightUpwardDiagonal
+```
+
+
+### LightVertical {#LightVertical}
+```
+public static final HatchStyle LightVertical
+```
+
+
+### Max {#Max}
+```
+public static final HatchStyle Max
+```
+
+
+### Min {#Min}
+```
+public static final HatchStyle Min
+```
+
+
+### NarrowHorizontal {#NarrowHorizontal}
+```
+public static final HatchStyle NarrowHorizontal
+```
+
+
+### NarrowVertical {#NarrowVertical}
+```
+public static final HatchStyle NarrowVertical
+```
+
+
+### OutlinedDiamond {#OutlinedDiamond}
+```
+public static final HatchStyle OutlinedDiamond
+```
+
+
+### Percent05 {#Percent05}
+```
+public static final HatchStyle Percent05
+```
+
+
+### Percent10 {#Percent10}
+```
+public static final HatchStyle Percent10
+```
+
+
+### Percent20 {#Percent20}
+```
+public static final HatchStyle Percent20
+```
+
+
+### Percent25 {#Percent25}
+```
+public static final HatchStyle Percent25
+```
+
+
+### Percent30 {#Percent30}
+```
+public static final HatchStyle Percent30
+```
+
+
+### Percent40 {#Percent40}
+```
+public static final HatchStyle Percent40
+```
+
+
+### Percent50 {#Percent50}
+```
+public static final HatchStyle Percent50
+```
+
+
+### Percent60 {#Percent60}
+```
+public static final HatchStyle Percent60
+```
+
+
+### Percent70 {#Percent70}
+```
+public static final HatchStyle Percent70
+```
+
+
+### Percent75 {#Percent75}
+```
+public static final HatchStyle Percent75
+```
+
+
+### Percent80 {#Percent80}
+```
+public static final HatchStyle Percent80
+```
+
+
+### Percent90 {#Percent90}
+```
+public static final HatchStyle Percent90
+```
+
+
+### Plaid {#Plaid}
+```
+public static final HatchStyle Plaid
+```
+
+
+### Shingle {#Shingle}
+```
+public static final HatchStyle Shingle
+```
+
+
+### SmallCheckerBoard {#SmallCheckerBoard}
+```
+public static final HatchStyle SmallCheckerBoard
+```
+
+
+### SmallConfetti {#SmallConfetti}
+```
+public static final HatchStyle SmallConfetti
+```
+
+
+### SmallGrid {#SmallGrid}
+```
+public static final HatchStyle SmallGrid
+```
+
+
+### SolidDiamond {#SolidDiamond}
+```
+public static final HatchStyle SolidDiamond
+```
+
+
+### Sphere {#Sphere}
+```
+public static final HatchStyle Sphere
+```
+
+
+### Trellis {#Trellis}
+```
+public static final HatchStyle Trellis
+```
+
+
+### Vertical {#Vertical}
+```
+public static final HatchStyle Vertical
+```
+
+
+### Wave {#Wave}
+```
+public static final HatchStyle Wave
+```
+
+
+### Weave {#Weave}
+```
+public static final HatchStyle Weave
+```
+
+
+### WideDownwardDiagonal {#WideDownwardDiagonal}
+```
+public static final HatchStyle WideDownwardDiagonal
+```
+
+
+### WideUpwardDiagonal {#WideUpwardDiagonal}
+```
+public static final HatchStyle WideUpwardDiagonal
+```
+
+
+### ZigZag {#ZigZag}
+```
+public static final HatchStyle ZigZag
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static HatchStyle valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[HatchStyle](../../com.aspose.eps/hatchstyle)
+### values() {#values--}
+```
+public static HatchStyle[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.eps.HatchStyle[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/loadoptions/_index.md
+++ b/japanese/java/com.aspose.eps/loadoptions/_index.md
@@ -1,0 +1,124 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメント読み込みオプションの基本クラスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.eps/loadoptions/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class LoadOptions
+```
+
+ドキュメント読み込みオプションの基本クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/pageconstants/_index.md
+++ b/japanese/java/com.aspose.eps/pageconstants/_index.md
@@ -1,0 +1,449 @@
+---
+title: "PageConstants"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、ページを記述する定数のセットを定義します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.eps/pageconstants/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class PageConstants
+```
+
+このクラスは、ページを記述する定数のセットを定義します。さまざまな余白、向き、リスケーリング、標準ページサイズ用の便利なオブジェクトが提供されています。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BACKGROUND](#BACKGROUND) | 背景キー |
+| [BACKGROUND_COLOR](#BACKGROUND-COLOR) | 背景色キー |
+| [FIT_TO_PAGE](#FIT-TO-PAGE) | コンテンツをページに合わせるキー |
+| [MARGINS_LARGE](#MARGINS-LARGE) | "Large"ページ余白の値 |
+| [MARGINS_MEDIUM](#MARGINS-MEDIUM) | "Medium"ページ余白の値 |
+| [MARGINS_SMALL](#MARGINS-SMALL) | "Small"ページ余白の値 |
+| [MARGINS_ZERO](#MARGINS-ZERO) | "Zero"ページ余白の値 |
+| [ORIENTATION](#ORIENTATION) | ページの向き（Portrait または Landscape）を指定するキー。 |
+| [ORIENTATION_BEST_FIT](#ORIENTATION-BEST-FIT) | "Best fit"向きの値 |
+| [ORIENTATION_LANDSCAPE](#ORIENTATION-LANDSCAPE) | "Landscape"向きの値 |
+| [ORIENTATION_PORTRAIT](#ORIENTATION-PORTRAIT) | "Portrait"向きの値 |
+| [PAGE_MARGINS](#PAGE-MARGINS) | ページ余白キー |
+| [PAGE_SIZE](#PAGE-SIZE) | ページサイズキー |
+| [SIZE_A3](#SIZE-A3) | "A3" ページサイズの値 |
+| [SIZE_A4](#SIZE-A4) | "A4" ページサイズの値 |
+| [SIZE_A5](#SIZE-A5) | "A5" ページサイズの値 |
+| [SIZE_A6](#SIZE-A6) | "A6" ページサイズの値 |
+| [SIZE_EXECUTIVE](#SIZE-EXECUTIVE) | "Executive" ページサイズの値 |
+| [SIZE_INTERNATIONAL](#SIZE-INTERNATIONAL) | "International" ページサイズの値 |
+| [SIZE_LEDGER](#SIZE-LEDGER) | "Ledger" ページサイズの値 |
+| [SIZE_LEGAL](#SIZE-LEGAL) | "Legal" ページサイズの値 |
+| [SIZE_LETTER](#SIZE-LETTER) | "Letter" ページサイズの値 |
+| [TRANSPARENT](#TRANSPARENT) | 透明な背景キー |
+| [VIEWING_ORIENTATION](#VIEWING-ORIENTATION) | ページ上のコンテンツの向きを区別する回転行列のための表示向きキー。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMargins(Insets insets, String orientation)](#getMargins-java.awt.Insets-java.lang.String-) | 指定された向きでページ余白を計算する |
+| [getMargins(String size)](#getMargins-java.lang.String-) |  |
+| [getOrientationList()](#getOrientationList--) |  |
+| [getSize(Dimension size, String orientation)](#getSize-java.awt.Dimension-java.lang.String-) | 指定されたページ向きでページサイズを計算する |
+| [getSize(String size)](#getSize-java.lang.String-) | "Portrait" ページ向きでページサイズを計算する |
+| [getSize(String size, String orientation)](#getSize-java.lang.String-java.lang.String-) | 指定されたページ向きでページサイズを計算する |
+| [getSizeList()](#getSizeList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BACKGROUND {#BACKGROUND}
+```
+public static final String BACKGROUND
+```
+
+
+背景キー
+
+### BACKGROUND_COLOR {#BACKGROUND-COLOR}
+```
+public static final String BACKGROUND_COLOR
+```
+
+
+背景色キー
+
+### FIT_TO_PAGE {#FIT-TO-PAGE}
+```
+public static final String FIT_TO_PAGE
+```
+
+
+コンテンツをページに合わせるキー
+
+### MARGINS_LARGE {#MARGINS-LARGE}
+```
+public static final String MARGINS_LARGE
+```
+
+
+"Large"ページ余白の値
+
+### MARGINS_MEDIUM {#MARGINS-MEDIUM}
+```
+public static final String MARGINS_MEDIUM
+```
+
+
+"Medium"ページ余白の値
+
+### MARGINS_SMALL {#MARGINS-SMALL}
+```
+public static final String MARGINS_SMALL
+```
+
+
+"Small"ページ余白の値
+
+### MARGINS_ZERO {#MARGINS-ZERO}
+```
+public static final String MARGINS_ZERO
+```
+
+
+"Zero"ページ余白の値
+
+### ORIENTATION {#ORIENTATION}
+```
+public static final String ORIENTATION
+```
+
+
+ページの向き（Portrait または Landscape）を指定するキー。
+
+### ORIENTATION_BEST_FIT {#ORIENTATION-BEST-FIT}
+```
+public static final String ORIENTATION_BEST_FIT
+```
+
+
+"Best fit"向きの値
+
+### ORIENTATION_LANDSCAPE {#ORIENTATION-LANDSCAPE}
+```
+public static final String ORIENTATION_LANDSCAPE
+```
+
+
+"Landscape"向きの値
+
+### ORIENTATION_PORTRAIT {#ORIENTATION-PORTRAIT}
+```
+public static final String ORIENTATION_PORTRAIT
+```
+
+
+"Portrait"向きの値
+
+### PAGE_MARGINS {#PAGE-MARGINS}
+```
+public static final String PAGE_MARGINS
+```
+
+
+ページ余白キー
+
+### PAGE_SIZE {#PAGE-SIZE}
+```
+public static final String PAGE_SIZE
+```
+
+
+ページサイズキー
+
+### SIZE_A3 {#SIZE-A3}
+```
+public static final String SIZE_A3
+```
+
+
+"A3" ページサイズの値
+
+### SIZE_A4 {#SIZE-A4}
+```
+public static final String SIZE_A4
+```
+
+
+"A4" ページサイズの値
+
+### SIZE_A5 {#SIZE-A5}
+```
+public static final String SIZE_A5
+```
+
+
+"A5" ページサイズの値
+
+### SIZE_A6 {#SIZE-A6}
+```
+public static final String SIZE_A6
+```
+
+
+"A6" ページサイズの値
+
+### SIZE_EXECUTIVE {#SIZE-EXECUTIVE}
+```
+public static final String SIZE_EXECUTIVE
+```
+
+
+"Executive" ページサイズの値
+
+### SIZE_INTERNATIONAL {#SIZE-INTERNATIONAL}
+```
+public static final String SIZE_INTERNATIONAL
+```
+
+
+"International" ページサイズの値
+
+### SIZE_LEDGER {#SIZE-LEDGER}
+```
+public static final String SIZE_LEDGER
+```
+
+
+"Ledger" ページサイズの値
+
+### SIZE_LEGAL {#SIZE-LEGAL}
+```
+public static final String SIZE_LEGAL
+```
+
+
+"Legal" ページサイズの値
+
+### SIZE_LETTER {#SIZE-LETTER}
+```
+public static final String SIZE_LETTER
+```
+
+
+"Letter" ページサイズの値
+
+### TRANSPARENT {#TRANSPARENT}
+```
+public static final String TRANSPARENT
+```
+
+
+透明な背景キー
+
+### VIEWING_ORIENTATION {#VIEWING-ORIENTATION}
+```
+public static final String VIEWING_ORIENTATION
+```
+
+
+ページ上のコンテンツの向きを区別する回転行列のための表示向きキー。デフォルトの表示向き行列は単位行列です。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMargins(Insets insets, String orientation) {#getMargins-java.awt.Insets-java.lang.String-}
+```
+public static final Insets getMargins(Insets insets, String orientation)
+```
+
+
+指定された向きでページ余白を計算する
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インセット | java.awt.Insets | 元の余白 |
+| 向き | java.lang.String | ページの向き |
+
+**Returns:**
+java.awt.Insets - 指定された向きの事前定義されたページ余白
+### getMargins(String size) {#getMargins-java.lang.String-}
+```
+public static final Insets getMargins(String size)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.lang.String | 事前定義されたページサイズ |
+
+**Returns:**
+java.awt.Insets - 事前定義されたページ余白
+### getOrientationList() {#getOrientationList--}
+```
+public static final String[] getOrientationList()
+```
+
+
+
+
+**Returns:**
+java.lang.String[] - 利用可能な向きの値
+### getSize(Dimension size, String orientation) {#getSize-java.awt.Dimension-java.lang.String-}
+```
+public static final Dimension getSize(Dimension size, String orientation)
+```
+
+
+指定されたページ向きでページサイズを計算する
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 元のページサイズ |
+| 向き | java.lang.String | ページの向き |
+
+**Returns:**
+java.awt.Dimension - 計算されたページサイズ
+### getSize(String size) {#getSize-java.lang.String-}
+```
+public static final Dimension getSize(String size)
+```
+
+
+"Portrait" ページ向きでページサイズを計算する
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.lang.String | 事前定義されたページサイズ |
+
+**Returns:**
+java.awt.Dimension - 計算されたページサイズ
+### getSize(String size, String orientation) {#getSize-java.lang.String-java.lang.String-}
+```
+public static final Dimension getSize(String size, String orientation)
+```
+
+
+指定されたページ向きでページサイズを計算する
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.lang.String | 事前定義されたページサイズ |
+| 向き | java.lang.String | ページの向き |
+
+**Returns:**
+java.awt.Dimension - 計算されたページサイズ
+### getSizeList() {#getSizeList--}
+```
+public static final String[] getSizeList()
+```
+
+
+
+
+**Returns:**
+java.lang.String[] - 利用可能なページサイズの値
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/psconverterexception/_index.md
+++ b/japanese/java/com.aspose.eps/psconverterexception/_index.md
@@ -1,0 +1,289 @@
+---
+title: "PsConverterException"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、PS ファイルが PDF ドキュメントに変換される際にスローされるエラーに関する情報を含みます。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.eps/psconverterexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class PsConverterException extends Exception
+```
+
+このクラスは、PS ファイルが PDF ドキュメントに変換される際にスローされるエラーに関する情報を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsConverterException(String errorStr)](#PsConverterException-java.lang.String-) | errorStr 文字列から PsConverterException の新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterException(String errorStr) {#PsConverterException-java.lang.String-}
+```
+public PsConverterException(String errorStr)
+```
+
+
+errorStr 文字列から PsConverterException の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| errorStr | java.lang.String | 変換エラーの理由を説明する文字列です。 |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/psconverterlicenseexception/_index.md
+++ b/japanese/java/com.aspose.eps/psconverterlicenseexception/_index.md
@@ -1,0 +1,289 @@
+---
+title: "PsConverterLicenseException"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、Aspose.Page 製品のライセンスに関連するエラーに関する情報を含みます。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.eps/psconverterlicenseexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, [com.aspose.eps.PsConverterException](../../com.aspose.eps/psconverterexception)
+```
+public class PsConverterLicenseException extends PsConverterException
+```
+
+このクラスは、Aspose.Page 製品のライセンスに関連するエラーに関する情報を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsConverterLicenseException(String errorStr)](#PsConverterLicenseException-java.lang.String-) | errorStr 文字列から  PsConverterLicenseException  の新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterLicenseException(String errorStr) {#PsConverterLicenseException-java.lang.String-}
+```
+public PsConverterLicenseException(String errorStr)
+```
+
+
+errorStr 文字列から  PsConverterLicenseException  の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| errorStr | java.lang.String | 変換エラーの理由を説明する文字列です。 |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/psdocument/_index.md
+++ b/japanese/java/com.aspose.eps/psdocument/_index.md
@@ -1,0 +1,1432 @@
+---
+title: "PsDocument"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは PS/EPS ドキュメントをカプセル化します。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.eps/psdocument/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.Document](../../com.aspose.page/document)
+```
+public final class PsDocument extends Document
+```
+
+このクラスは PS/EPS ドキュメントをカプセル化します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsDocument()](#PsDocument--) | 空の  PsDocument  を初期化されたページで初期化します。 |
+| [PsDocument(String outPsFilePath, PsSaveOptions options)](#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | 空の  PsDocument  を初期化されたページで初期化します。 |
+| [PsDocument(OutputStream psStream, PsSaveOptions options)](#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | 空の  PsDocument  を初期化されたページで初期化します。 |
+| [PsDocument(String outPsFilePath, PsSaveOptions options, boolean multipaged)](#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-boolean-) | 空の  PsDocument  を初期化します。 |
+| [PsDocument(OutputStream psStream, PsSaveOptions options, boolean multipaged)](#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-boolean-) | 空の  PsDocument  を初期化します。 |
+| [PsDocument(String outPsFilePath, PsSaveOptions options, int numberOfPages)](#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-int-) | 事前にPostscriptドキュメントページ数が分かっている場合、空の  PsDocument  を初期化します。 |
+| [PsDocument(OutputStream psStream, PsSaveOptions options, int numberOfPages)](#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-int-) | 事前にPostscriptドキュメントページ数が分かっている場合、空の  PsDocument  を初期化します。 |
+| [PsDocument(String psFilePath)](#PsDocument-java.lang.String-) | 入力PS/EPSファイルで  PsDocument  を初期化します。 |
+| [PsDocument(InputStream psStream)](#PsDocument-java.io.InputStream-) | PS/EPSファイルのストリームで  PsDocument  を初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clip(Shape s)](#clip-java.awt.Shape-) | 現在のグラフィックス状態にクリップを追加します。 |
+| [clipAndNewPath(Shape s)](#clipAndNewPath-java.awt.Shape-) | 現在のグラフィックス状態にクリップを追加し、次に \"newpath\" 演算子を書き込みます。 |
+| [clipRectangle(Rectangle2D.Float rect)](#clipRectangle-java.awt.geom.Rectangle2D.Float-) | 現在のグラフィックス状態にクリッピング矩形を追加します。 |
+| [clipText(String text, Font font, float x, float y)](#clipText-java.lang.String-java.awt.Font-float-float-) | 指定されたフォントの指定テキストのアウトラインからクリップを追加します。 |
+| [closePage()](#closePage--) | 現在のページを完了します。 |
+| [convertType1FontToTTF(String type1FontFilePath, String outputDir)](#convertType1FontToTTF-java.lang.String-java.lang.String-) | Type 1 フントを TrueType に変換します。 |
+| [convertType3FontToTTF(String type3FontFilePath, OutputStream outputStream)](#convertType3FontToTTF-java.lang.String-java.io.OutputStream-) | Type 3 フントを TrueType に変換します。 |
+| [convertType3FontToTTF(String type3FontFilePath, String outputDir)](#convertType3FontToTTF-java.lang.String-java.lang.String-) | Type 3 フントを TrueType に変換します。 |
+| [cropEps(OutputStream epsStream, float[] cropBox)](#cropEps-java.io.OutputStream-float---) | 指定された  PsDocument  を EPS ファイルとしてトリミングします。 |
+| [draw(Shape shape)](#draw-java.awt.Shape-) | 任意のパスを描画します。 |
+| [drawExplicitImageMask(BufferedImage image24bpp, BufferedImage alphaMask1bpp, AffineTransform transform)](#drawExplicitImageMask-java.awt.image.BufferedImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-) | マスクされた画像を描画します。 |
+| [drawImage(BufferedImage image)](#drawImage-java.awt.image.BufferedImage-) | 画像を描画します。 |
+| [drawImage(BufferedImage image, AffineTransform transform, Color bkg)](#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-) | 背景付きで変換された画像を描画します。 |
+| [drawTransparentImage(BufferedImage image, AffineTransform transform, int transparencyThreshold)](#drawTransparentImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-int-) | 背景付きで変換された透明画像を描画します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [extractEpsBoundingBox()](#extractEpsBoundingBox--) | EPS ファイルを読み取り、%%BoundingBox コメントから EPS 画像のバウンディングボックスを抽出します。存在しない場合はデフォルトページサイズ (0, 0, 595, 842) の境界を使用します。 |
+| [extractEpsSize()](#extractEpsSize--) | EPS ファイルを読み取り、%%BoundingBox コメントから EPS 画像のサイズを抽出します。存在しない場合はデフォルトページサイズ (595, 842) を使用します。 |
+| [extractText(SaveOptions options, int startPage, int endPage)](#extractText-com.aspose.page.SaveOptions-int-int-) | PS ファイルからテキストを抽出します。 |
+| [fill(Shape shape)](#fill-java.awt.Shape-) | 任意のパスを塗りつぶす。 |
+| [fillAndStrokeText(String text, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [fillAndStrokeText(String text, float[] advances, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [fillAndStrokeText(String text, float[] advances, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [fillAndStrokeText(String text, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [fillText(String text, DrFont drFont, float x, float y)](#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, DrFont drFont, float x, float y, Paint fill)](#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, float[] advances, DrFont drFont, float x, float y)](#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, float[] advances, DrFont drFont, float x, float y, Paint fill)](#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, float[] advances, Font font, float x, float y)](#fillText-java.lang.String-float---java.awt.Font-float-float-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, float[] advances, Font font, float x, float y, Paint fill)](#fillText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, Font font, float x, float y)](#fillText-java.lang.String-java.awt.Font-float-float-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [fillText(String text, Font font, float x, float y, Paint fill)](#fillText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-) | グリフの内部を塗りつぶしてテキスト文字列を追加します。 |
+| [getClass()](#getClass--) |  |
+| [getInputStream()](#getInputStream--) |  |
+| [getNumberOfPages()](#getNumberOfPages--) | 結果の PDF ドキュメントのページ数を取得します。 |
+| [getPaint()](#getPaint--) | 現在のグラフィックス状態のペイントを取得します。 |
+| [getStroke()](#getStroke--) | 現在のグラフィックス状態のストロークを取得します。 |
+| [getXmpMetadata()](#getXmpMetadata--) | PS/EPS ファイルを読み取り、XMP メタデータが既に存在すれば抽出し、存在しなければ新しく追加します。 |
+| [hashCode()](#hashCode--) |  |
+| [isLicensed()](#isLicensed--) | Aspose.Page for Java 製品ライセンスがアクセスされ、有効かどうかを示します。 |
+| [merge(String[] filesForMerge, Device device, SaveOptions options)](#merge-java.lang.String---com.aspose.page.Device-com.aspose.page.SaveOptions-) | PS/EPS ファイルをデバイスにマージします。 |
+| [mergeToPdf(OutputStream pdfStream, String[] filesForMerge, SaveOptions options)](#mergeToPdf-java.io.OutputStream-java.lang.String---com.aspose.page.SaveOptions-) | PS/EPS ファイルをデバイスにマージします。 |
+| [mergeToPdf(String outPdfFilePath, String[] filesForMerge, SaveOptions options)](#mergeToPdf-java.lang.String-java.lang.String---com.aspose.page.SaveOptions-) | PS/EPS ファイルをデバイスにマージします。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [openPage(float width, float height)](#openPage-float-float-) | 新しいページを作成し、現在のページに設定します。 |
+| [openPage(String pageName)](#openPage-java.lang.String-) | ドキュメントのサイズで新しいページを作成し、現在のページに設定します。 |
+| [outlineText(String text, DrFont drFont, float x, float y)](#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, float[] advances, DrFont drFont, float x, float y)](#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, float[] advances, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, float[] advances, Font font, float x, float y)](#outlineText-java.lang.String-float---java.awt.Font-float-float-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, float[] advances, Font font, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, Font font, float x, float y)](#outlineText-java.lang.String-java.awt.Font-float-float-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [outlineText(String text, Font font, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-) | グリフの輪郭を描画してテキスト文字列を追加します。 |
+| [resizeEps(OutputStream epsStream, DimensionF newSizeInUnits, Units units)](#resizeEps-java.io.OutputStream-com.aspose.page.DimensionF-com.aspose.page.Units-) | 指定された PsDocument を EPS ファイルとしてサイズ変更します。 |
+| [rotate(float angleRadians)](#rotate-float-) | 原点を中心に反時計回りの回転を現在のグラフィックス状態に追加します（現在の行列を回転）。 |
+| [rotate(int angleDegrees)](#rotate-int-) | 原点を中心に反時計回りの回転を現在のグラフィックス状態に追加します（現在の行列を回転）。 |
+| [save()](#save--) | 指定された PsDocument を PS または EPS ファイルとして保存します。 |
+| [save(Device device, SaveOptions options)](#save-com.aspose.page.Device-com.aspose.page.SaveOptions-) | PS/EPS ファイルをデバイスに保存します。 |
+| [save(OutputStream epsStream)](#save-java.io.OutputStream-) | 指定された PsDocument をストリームに保存します。 |
+| [save(String outEpsFilePath)](#save-java.lang.String-) | 指定された PsDocument を EPS ファイルとして保存します。 |
+| [saveAsImage(ImageSaveOptions options)](#saveAsImage-com.aspose.eps.device.ImageSaveOptions-) | PS/EPS ファイルを画像ファイルに保存します。 |
+| [saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)](#saveAsImage-com.aspose.eps.device.ImageSaveOptions-java.lang.String-java.lang.String-) | PS/EPS ファイルを指定されたディレクトリの指定されたファイル名で画像ファイルに保存します。 |
+| [saveAsImagesBytes(ImageSaveOptions options)](#saveAsImagesBytes-com.aspose.eps.device.ImageSaveOptions-) | PS/EPS ファイルを画像のバイト配列に保存します。 |
+| [saveAsPdf(OutputStream pdfStream, PdfSaveOptions options)](#saveAsPdf-java.io.OutputStream-com.aspose.eps.device.PdfSaveOptions-) | PS/EPS ファイルを出力 PDF ストリームに保存します。 |
+| [saveAsPdf(String outPdfFilePath, PdfSaveOptions options)](#saveAsPdf-java.lang.String-com.aspose.eps.device.PdfSaveOptions-) | PS/EPS ファイルを PDF ファイルに保存します。 |
+| [saveImageAsEps(BufferedImage image, OutputStream epsStream, PsSaveOptions options)](#saveImageAsEps-java.awt.image.BufferedImage-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | BufferedImage オブジェクトを EPS ファイルに保存します。 |
+| [saveImageAsEps(BufferedImage image, String epsFilePath, PsSaveOptions options)](#saveImageAsEps-java.awt.image.BufferedImage-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | BufferedImage オブジェクトを EPS ファイルに保存します。 |
+| [saveImageAsEps(InputStream imageStream, OutputStream epsStream, PsSaveOptions options)](#saveImageAsEps-java.io.InputStream-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | 入力ストリームから PNG/JPEG/BMP/GIF 画像を EPS 出力ストリームに保存します。 |
+| [saveImageAsEps(String imageFilePath, String epsFilePath, PsSaveOptions options)](#saveImageAsEps-java.lang.String-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | ファイルから PNG/JPEG/BMP/GIF 画像を EPS ファイルに保存します。 |
+| [scale(float xScale, float yScale)](#scale-float-float-) | 現在のグラフィックス状態にスケールを追加します（現在の行列をスケール）。 |
+| [setInputStream(InputStream is)](#setInputStream-java.io.InputStream-) | 入力ストリームを指定します。 |
+| [setPageDevice(Map<String,Object> pageParams)](#setPageDevice-java.util.Map-java.lang.String-java.lang.Object--) | ページデバイスパラメータを設定します（演算子 "setpagedevice" の PostScript 仕様を参照）。 |
+| [setPageSize(float width, float height)](#setPageSize-float-float-) | ページサイズを設定します。 |
+| [setPaint(Paint paint)](#setPaint-java.awt.Paint-) | 現在のグラフィックス状態の塗りを設定します。 |
+| [setStroke(Stroke stroke)](#setStroke-java.awt.Stroke-) | 現在のグラフィックス状態のストロークを設定します。 |
+| [setTransform(AffineTransform matrix)](#setTransform-java.awt.geom.AffineTransform-) | 現在の変換をこれに設定します。 |
+| [shear(float shx, float shy)](#shear-float-float-) | 現在のグラフィックス状態にせん断変換を追加します（現在の行列をせん断）。 |
+| [toString()](#toString--) |  |
+| [transform(AffineTransform matrix)](#transform-java.awt.geom.AffineTransform-) | 現在のグラフィックス状態に変換を追加します（この行列を現在の行列と連結）。 |
+| [translate(float x, float y)](#translate-float-float-) | 現在のグラフィックス状態に平行移動を追加します（現在の行列を平行移動）。 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+| [writeGraphicsRestore()](#writeGraphicsRestore--) | 現在のグラフィックス状態の復元を書き込みます（演算子 "grestore" の PostScript 仕様を参照）。 |
+| [writeGraphicsSave()](#writeGraphicsSave--) | 現在のグラフィックス状態の保存を書き込みます（演算子 "gsave" の PostScript 仕様を参照）。 |
+### PsDocument() {#PsDocument--}
+```
+public PsDocument()
+```
+
+
+空の PsDocument を初期化されたページとともに初期化します。このコンストラクタは、PostScript ファイルに関連しない追加操作（例：フォント変換）のみで使用されます。
+
+### PsDocument(String outPsFilePath, PsSaveOptions options) {#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public PsDocument(String outPsFilePath, PsSaveOptions options)
+```
+
+
+空の  PsDocument  を初期化されたページで初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 出力 PS/EPS ファイルのパスです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript ファイルの保存を制御するパラメータのセットです。 |
+
+### PsDocument(OutputStream psStream, PsSaveOptions options) {#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public PsDocument(OutputStream psStream, PsSaveOptions options)
+```
+
+
+空の  PsDocument  を初期化されたページで初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| psStream | java.io.OutputStream | PS/EPS ファイルを保存するストリームです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript ファイルの保存を制御するパラメータのセットです。 |
+
+### PsDocument(String outPsFilePath, PsSaveOptions options, boolean multipaged) {#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-boolean-}
+```
+public PsDocument(String outPsFilePath, PsSaveOptions options, boolean multipaged)
+```
+
+
+空の  PsDocument  を初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 出力 PS/EPS ファイルのパスです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript ファイルの保存を制御するパラメータのセットです。 |
+| multipaged | boolean | false の場合、ページは初期化されません。この場合、ページの初期化は明示的な "openPage(width, height)" 呼び出しで実行する必要があります。 |
+
+### PsDocument(OutputStream psStream, PsSaveOptions options, boolean multipaged) {#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-boolean-}
+```
+public PsDocument(OutputStream psStream, PsSaveOptions options, boolean multipaged)
+```
+
+
+空の  PsDocument  を初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| psStream | java.io.OutputStream | PS/EPS ファイルを保存するストリームです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript ファイルの保存を制御するパラメータのセットです。 |
+| multipaged | boolean | false の場合、ページは初期化されません。この場合、ページの初期化は明示的な "openPage(width, height)" 呼び出しで実行する必要があります。 |
+
+### PsDocument(String outPsFilePath, PsSaveOptions options, int numberOfPages) {#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-int-}
+```
+public PsDocument(String outPsFilePath, PsSaveOptions options, int numberOfPages)
+```
+
+
+事前にPostscriptドキュメントページ数が分かっている場合、空の  PsDocument  を初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 出力 PS/EPS ファイルのパスです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript ファイルの保存を制御するパラメータのセットです。 |
+| numberOfPages | int | PostScript ドキュメントのページ数です。 |
+
+### PsDocument(OutputStream psStream, PsSaveOptions options, int numberOfPages) {#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-int-}
+```
+public PsDocument(OutputStream psStream, PsSaveOptions options, int numberOfPages)
+```
+
+
+事前にPostscriptドキュメントページ数が分かっている場合、空の  PsDocument  を初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| psStream | java.io.OutputStream | PS/EPS ファイルを保存するストリームです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript ファイルの保存を制御するパラメータのセットです。 |
+| numberOfPages | int | PostScript ドキュメントのページ数です。 |
+
+### PsDocument(String psFilePath) {#PsDocument-java.lang.String-}
+```
+public PsDocument(String psFilePath)
+```
+
+
+入力PS/EPSファイルで  PsDocument  を初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| psFilePath | java.lang.String | PS/EPS ファイルのパスです。 |
+
+### PsDocument(InputStream psStream) {#PsDocument-java.io.InputStream-}
+```
+public PsDocument(InputStream psStream)
+```
+
+
+PS/EPSファイルのストリームで  PsDocument  を初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| psStream | java.io.InputStream | PS/EPS ファイルのストリームです。 |
+
+### clip(Shape s) {#clip-java.awt.Shape-}
+```
+public void clip(Shape s)
+```
+
+
+現在のグラフィックス状態にクリップを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| s | java.awt.Shape | クリッピングパス。 |
+
+### clipAndNewPath(Shape s) {#clipAndNewPath-java.awt.Shape-}
+```
+public void clipAndNewPath(Shape s)
+```
+
+
+現在のグラフィックス状態にクリップを追加し、次に "newpath" 演算子を書き込みます。このクリッピングパスと、"charpath" 演算子でアウトライン化されたグリフなどの後続パスとの合流を回避するために必要です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| s | java.awt.Shape | クリッピングパス。 |
+
+### clipRectangle(Rectangle2D.Float rect) {#clipRectangle-java.awt.geom.Rectangle2D.Float-}
+```
+public void clipRectangle(Rectangle2D.Float rect)
+```
+
+
+現在のグラフィックス状態にクリッピング矩形を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| rect | java.awt.geom.Rectangle2D.Float | クリッピング矩形。 |
+
+### clipText(String text, Font font, float x, float y) {#clipText-java.lang.String-java.awt.Font-float-float-}
+```
+public void clipText(String text, Font font, float x, float y)
+```
+
+
+指定されたフォントの指定テキストのアウトラインからクリップを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | テキスト。 |
+| font | java.awt.Font | フォント。 |
+| x | float | テキスト位置の X 座標。 |
+| y | float |  |
+
+### closePage() {#closePage--}
+```
+public void closePage()
+```
+
+
+現在のページを完了します。
+
+### convertType1FontToTTF(String type1FontFilePath, String outputDir) {#convertType1FontToTTF-java.lang.String-java.lang.String-}
+```
+public void convertType1FontToTTF(String type1FontFilePath, String outputDir)
+```
+
+
+Type 1 フォントを TrueType に変換します。変換された TTF フォントファイルの名前は、入力の Type 1 フォントと同じで、拡張子は ".ttf" になります。TTF ファイルは割り当てられた出力ディレクトリに保存されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| type1FontFilePath | java.lang.String | Type 1 フォントファイルのパス.. |
+| outputDir | java.lang.String | 生成された TrueType フォントを保存する出力ディレクトリ。 |
+
+### convertType3FontToTTF(String type3FontFilePath, OutputStream outputStream) {#convertType3FontToTTF-java.lang.String-java.io.OutputStream-}
+```
+public void convertType3FontToTTF(String type3FontFilePath, OutputStream outputStream)
+```
+
+
+Type 3 フォントを TrueType に変換します。TTF ファイルは指定された出力ストリームに保存されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| type3FontFilePath | java.lang.String | Type 3 フォントファイルのパス。 |
+| outputStream | java.io.OutputStream | 生成された TrueType フォントを保存する出力ストリーム。 |
+
+### convertType3FontToTTF(String type3FontFilePath, String outputDir) {#convertType3FontToTTF-java.lang.String-java.lang.String-}
+```
+public void convertType3FontToTTF(String type3FontFilePath, String outputDir)
+```
+
+
+Type 3 フォントを TrueType に変換します。変換された TTF フォントファイルの名前は、入力の Type 3 フォントと同じで、拡張子は ".ttf" になります。TTF ファイルは割り当てられた出力ディレクトリに保存されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| type3FontFilePath | java.lang.String | Type 3 フォントファイルのパス.. |
+| outputDir | java.lang.String | 生成された TrueType フォントを保存する出力ディレクトリ。 |
+
+### cropEps(OutputStream epsStream, float[] cropBox) {#cropEps-java.io.OutputStream-float---}
+```
+public void cropEps(OutputStream epsStream, float[] cropBox)
+```
+
+
+指定された PsDocument を EPS ファイルとしてトリミングします。既存の %%BoundingBox を更新した初期 EPS ファイルを保存するか、または新しいものが作成されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| epsStream | java.io.OutputStream |  |
+| cropBox | float[] | クロップボックス (x0, y0, x, y) です。 |
+
+### draw(Shape shape) {#draw-java.awt.Shape-}
+```
+public void draw(Shape shape)
+```
+
+
+任意のパスを描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| shape | java.awt.Shape | 塗りつぶすパス。 |
+
+### drawExplicitImageMask(BufferedImage image24bpp, BufferedImage alphaMask1bpp, AffineTransform transform) {#drawExplicitImageMask-java.awt.image.BufferedImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-}
+```
+public void drawExplicitImageMask(BufferedImage image24bpp, BufferedImage alphaMask1bpp, AffineTransform transform)
+```
+
+
+マスクされた画像を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image24bpp | java.awt.image.BufferedImage | 描画する画像です。24bpp RGB 画像形式である必要があります。 |
+| alphaMask1bpp | java.awt.image.BufferedImage | 画像マスクです。1bpp 画像形式である必要があります。 |
+| transform | java.awt.geom.AffineTransform | 画像を変換する行列です。 |
+
+### drawImage(BufferedImage image) {#drawImage-java.awt.image.BufferedImage-}
+```
+public void drawImage(BufferedImage image)
+```
+
+
+画像を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 描画する画像です。 |
+
+### drawImage(BufferedImage image, AffineTransform transform, Color bkg) {#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-}
+```
+public void drawImage(BufferedImage image, AffineTransform transform, Color bkg)
+```
+
+
+背景付きで変換された画像を描画します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 描画する画像です。 |
+| transform | java.awt.geom.AffineTransform | 画像を変換する行列です。 |
+| bkg | java.awt.Color | 画像の背景です。 |
+
+### drawTransparentImage(BufferedImage image, AffineTransform transform, int transparencyThreshold) {#drawTransparentImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-int-}
+```
+public void drawTransparentImage(BufferedImage image, AffineTransform transform, int transparencyThreshold)
+```
+
+
+背景付きで変換された透過画像を描画します。画像にアルファチャンネルがない場合は不透明画像として描画されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 描画する画像です。 |
+| transform | java.awt.geom.AffineTransform | 画像を変換する行列です。 |
+| transparencyThreshold | int | 透過度ピクセルが完全に透過と解釈される閾値を定義するしきい値です。この閾値未満のすべての値は完全に不透明と解釈されます。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### extractEpsBoundingBox() {#extractEpsBoundingBox--}
+```
+public int[] extractEpsBoundingBox()
+```
+
+
+EPS ファイルを読み取り、%%BoundingBox コメントから EPS 画像のバウンディングボックスを抽出します。存在しない場合はデフォルトページサイズ (0, 0, 595, 842) の境界を使用します。
+
+**Returns:**
+int[] - EPS 画像のバウンディングボックスです。
+### extractEpsSize() {#extractEpsSize--}
+```
+public Dimension extractEpsSize()
+```
+
+
+EPS ファイルを読み取り、%%BoundingBox コメントから EPS 画像のサイズを抽出します。存在しない場合はデフォルトページサイズ (595, 842) を使用します。
+
+**Returns:**
+java.awt.Dimension - EPS 画像のサイズです。
+### extractText(SaveOptions options, int startPage, int endPage) {#extractText-com.aspose.page.SaveOptions-int-int-}
+```
+public String extractText(SaveOptions options, int startPage, int endPage)
+```
+
+
+PS ファイルからテキストを抽出します。TrueType フォント (Type 42) または TrueType フォントで構成された複合フォント (Type 0) で書かれたテキストに対してのみ機能します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 保存オプションです。 |
+| startPage | int | テキスト抽出を開始するページ（含む）です。 |
+| endPage | int | テキストを抽出する対象ページ（含む）です。 |
+
+**Returns:**
+java.lang.String - 選択された PS ファイルのページに含まれるテキストです。
+### fill(Shape shape) {#fill-java.awt.Shape-}
+```
+public void fill(Shape shape)
+```
+
+
+任意のパスを塗りつぶす。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| shape | java.awt.Shape | 塗りつぶすパス。 |
+
+### fillAndStrokeText(String text, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fillPaint | java.awt.Paint | グリフ内部の塗りに使用される塗料です。 |
+| strokePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### fillAndStrokeText(String text, float[] advances, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, float[] advances, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fillPaint | java.awt.Paint | グリフ内部の塗りに使用される塗料です。 |
+| strokePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### fillAndStrokeText(String text, float[] advances, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, float[] advances, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。advances はグリフ幅の配列で、その長さは文字列中のグリフ数と一致する必要があります。 |
+| advances | float[] |  |
+| font | java.awt.Font | テキスト描画に使用されるシステムフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fillPaint | java.awt.Paint | グリフ内部の塗りに使用される塗料です。 |
+| strokePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### fillAndStrokeText(String text, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+グリフの内部を塗りつぶし、グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| font | java.awt.Font | テキスト描画に使用されるシステムフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fillPaint | java.awt.Paint | グリフ内部の塗りに使用される塗料です。 |
+| strokePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### fillText(String text, DrFont drFont, float x, float y) {#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void fillText(String text, DrFont drFont, float x, float y)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### fillText(String text, DrFont drFont, float x, float y, Paint fill) {#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-}
+```
+public void fillText(String text, DrFont drFont, float x, float y, Paint fill)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fill | java.awt.Paint | グリフの塗装に使用される塗りです。 |
+
+### fillText(String text, float[] advances, DrFont drFont, float x, float y) {#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void fillText(String text, float[] advances, DrFont drFont, float x, float y)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### fillText(String text, float[] advances, DrFont drFont, float x, float y, Paint fill) {#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-}
+```
+public void fillText(String text, float[] advances, DrFont drFont, float x, float y, Paint fill)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fill | java.awt.Paint | グリフの塗装に使用される塗りです。 |
+
+### fillText(String text, float[] advances, Font font, float x, float y) {#fillText-java.lang.String-float---java.awt.Font-float-float-}
+```
+public void fillText(String text, float[] advances, Font font, float x, float y)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| font | java.awt.Font | テキスト描画に使用されるシステムフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### fillText(String text, float[] advances, Font font, float x, float y, Paint fill) {#fillText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-}
+```
+public void fillText(String text, float[] advances, Font font, float x, float y, Paint fill)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| font | java.awt.Font | テキスト描画に使用されるフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fill | java.awt.Paint | グリフの塗装に使用される塗りです。 |
+
+### fillText(String text, Font font, float x, float y) {#fillText-java.lang.String-java.awt.Font-float-float-}
+```
+public void fillText(String text, Font font, float x, float y)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| font | java.awt.Font | テキスト描画に使用されるシステムフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### fillText(String text, Font font, float x, float y, Paint fill) {#fillText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-}
+```
+public void fillText(String text, Font font, float x, float y, Paint fill)
+```
+
+
+グリフの内部を塗りつぶしてテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| font | java.awt.Font | テキスト描画に使用されるフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| fill | java.awt.Paint | グリフの塗装に使用される塗りです。 |
+
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInputStream() {#getInputStream--}
+```
+public InputStream getInputStream()
+```
+
+
+
+
+**Returns:**
+java.io.InputStream
+### getNumberOfPages() {#getNumberOfPages--}
+```
+public int getNumberOfPages()
+```
+
+
+結果の PDF ドキュメントのページ数を取得します。
+
+**Returns:**
+int - ページ数です。
+### getPaint() {#getPaint--}
+```
+public Paint getPaint()
+```
+
+
+現在のグラフィックス状態のペイントを取得します。
+
+**Returns:**
+java.awt.Paint - 現在の塗料です。
+### getStroke() {#getStroke--}
+```
+public Stroke getStroke()
+```
+
+
+現在のグラフィックス状態のストロークを取得します。
+
+**Returns:**
+java.awt.Stroke - 現在のストローク。
+### getXmpMetadata() {#getXmpMetadata--}
+```
+public XmpMetadata getXmpMetadata()
+```
+
+
+PS/EPS ファイルを読み取り、XMP メタデータが既に存在すれば抽出し、存在しなければ新しく追加します。
+
+**Returns:**
+[XmpMetadata](../../com.aspose.eps.xmp/xmpmetadata) - existing or new instance of XMP metadata.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isLicensed() {#isLicensed--}
+```
+public boolean isLicensed()
+```
+
+
+Aspose.Page for Java 製品ライセンスがアクセスされ、有効かどうかを示します。
+
+**Returns:**
+boolean - 真偽値
+### merge(String[] filesForMerge, Device device, SaveOptions options) {#merge-java.lang.String---com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public void merge(String[] filesForMerge, Device device, SaveOptions options)
+```
+
+
+PS/EPS ファイルをデバイスにマージします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | このファイルと出力デバイスにマージするための PS/EPS ファイル。 |
+| device | [Device](../../com.aspose.page/device) | 出力デバイス。 |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### mergeToPdf(OutputStream pdfStream, String[] filesForMerge, SaveOptions options) {#mergeToPdf-java.io.OutputStream-java.lang.String---com.aspose.page.SaveOptions-}
+```
+public void mergeToPdf(OutputStream pdfStream, String[] filesForMerge, SaveOptions options)
+```
+
+
+PS/EPS ファイルをデバイスにマージします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pdfStream | java.io.OutputStream | 出力 PDF ストリーム。 |
+| filesForMerge | java.lang.String[] | このファイルと出力デバイスにマージするための PS/EPS ファイル。 |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### mergeToPdf(String outPdfFilePath, String[] filesForMerge, SaveOptions options) {#mergeToPdf-java.lang.String-java.lang.String---com.aspose.page.SaveOptions-}
+```
+public void mergeToPdf(String outPdfFilePath, String[] filesForMerge, SaveOptions options)
+```
+
+
+PS/EPS ファイルをデバイスにマージします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 出力 PDF ファイルのパス。 |
+| filesForMerge | java.lang.String[] | このファイルと出力デバイスにマージするための PS/EPS ファイル。 |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### openPage(float width, float height) {#openPage-float-float-}
+```
+public void openPage(float width, float height)
+```
+
+
+新しいページを作成し、現在のページに設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 新しいページの幅。 |
+| height | float | 新しいページの高さ。 |
+
+### openPage(String pageName) {#openPage-java.lang.String-}
+```
+public void openPage(String pageName)
+```
+
+
+ドキュメントのサイズで新しいページを作成し、現在のページに設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pageName | java.lang.String | 新しいページの名前。null の場合、ページの名前はページの順序番号になります。 |
+
+### outlineText(String text, DrFont drFont, float x, float y) {#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void outlineText(String text, DrFont drFont, float x, float y)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### outlineText(String text, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| outlinePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### outlineText(String text, float[] advances, DrFont drFont, float x, float y) {#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void outlineText(String text, float[] advances, DrFont drFont, float x, float y)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### outlineText(String text, float[] advances, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, float[] advances, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| drFont | com.aspose.foundation.drawing.DrFont | DrFont はテキスト描画に使用されます。カスタムフォルダーにあるカスタムフォントと併用できます。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| outlinePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### outlineText(String text, float[] advances, Font font, float x, float y) {#outlineText-java.lang.String-float---java.awt.Font-float-float-}
+```
+public void outlineText(String text, float[] advances, Font font, float x, float y)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| font | java.awt.Font | テキスト描画に使用されるシステムフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### outlineText(String text, float[] advances, Font font, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, float[] advances, Font font, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| advances | float[] | グリフ幅の配列です。その長さは文字列中のグリフ数と一致する必要があります。 |
+| font | java.awt.Font | テキスト描画に使用されるフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| outlinePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### outlineText(String text, Font font, float x, float y) {#outlineText-java.lang.String-java.awt.Font-float-float-}
+```
+public void outlineText(String text, Font font, float x, float y)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| font | java.awt.Font | テキスト描画に使用されるシステムフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+
+### outlineText(String text, Font font, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, Font font, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+グリフの輪郭を描画してテキスト文字列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| text | java.lang.String | 追加するテキストです。 |
+| font | java.awt.Font | テキスト描画に使用されるフォントです。 |
+| x | float | テキスト原点の X 座標です。 |
+| y | float | テキスト原点の Y 座標です。 |
+| outlinePaint | java.awt.Paint | java.awt.Paint はグリフの輪郭塗装に使用されます。JDK の java.awt.Paint クラスの任意のサブクラスを使用できます。 |
+| stroke | java.awt.Stroke | グリフ輪郭の描画に使用されるストロークです。 |
+
+### resizeEps(OutputStream epsStream, DimensionF newSizeInUnits, Units units) {#resizeEps-java.io.OutputStream-com.aspose.page.DimensionF-com.aspose.page.Units-}
+```
+public void resizeEps(OutputStream epsStream, DimensionF newSizeInUnits, Units units)
+```
+
+
+指定された PsDocument を EPS ファイルとしてサイズ変更します。このメソッドは EPS サイズを抽出した後にのみ使用されます。既存の %%BoundingBox を更新した初期 EPS ファイルを保存するか、新しいものが作成されます。ページ変換行列も設定されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| epsStream | java.io.OutputStream |  |
+| newSizeInUnits | [DimensionF](../../com.aspose.page/dimensionf) | 割り当てられた単位での EPS 画像の新しいサイズ。 |
+| units | [Units](../../com.aspose.page/units) | 新しいサイズの単位。ポイント、インチ、ミリメートル、センチメートル、または元のサイズのパーセントを指定できます。 |
+
+### rotate(float angleRadians) {#rotate-float-}
+```
+public void rotate(float angleRadians)
+```
+
+
+原点を中心に反時計回りの回転を現在のグラフィックス状態に追加します（現在の行列を回転）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angleRadians | float | ラジアン単位の回転角度。 |
+
+### rotate(int angleDegrees) {#rotate-int-}
+```
+public void rotate(int angleDegrees)
+```
+
+
+原点を中心に反時計回りの回転を現在のグラフィックス状態に追加します（現在の行列を回転）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angleDegrees | int | 度単位の回転角度。 |
+
+### save() {#save--}
+```
+public void save()
+```
+
+
+指定された PsDocument を PS または EPS ファイルとして保存します。このメソッドは PsDocument が最初から作成された場合にのみ使用されます。
+
+### save(Device device, SaveOptions options) {#save-com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public void save(Device device, SaveOptions options)
+```
+
+
+PS/EPS ファイルをデバイスに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| device | [Device](../../com.aspose.page/device) | 出力デバイス。 |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### save(OutputStream epsStream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream epsStream)
+```
+
+
+指定された PsDocument をストリームに保存します。このメソッドは XMP メタデータを更新した後にのみ使用されます。既存のメタデータを更新した初期 EPS ファイルを保存するか、getMetadata メソッドを呼び出す際に新しく作成されたものを保存します。後者の場合、必要なすべての PostScript コードと EPS コメントが追加されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| epsStream | java.io.OutputStream | 出力 EPS ファイルのストリーム。 |
+
+### save(String outEpsFilePath) {#save-java.lang.String-}
+```
+public void save(String outEpsFilePath)
+```
+
+
+指定された PsDocument を EPS ファイルとして保存します。このメソッドは XMP メタデータを更新した後にのみ使用されます。既存のメタデータを更新した初期 EPS ファイルを保存するか、getMetadata メソッドを呼び出す際に新しく作成されたものを保存します。後者の場合、必要なすべての PostScript コードと EPS コメントが追加されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outEpsFilePath | java.lang.String | 出力 EPS ファイルパスです。 |
+
+### saveAsImage(ImageSaveOptions options) {#saveAsImage-com.aspose.eps.device.ImageSaveOptions-}
+```
+public void saveAsImage(ImageSaveOptions options)
+```
+
+
+PS/EPS ファイルを画像ファイルに保存します。出力ディレクトリとファイル名は入力 PS ファイルと同じになります。ファイル拡張子は \"options\" パラメータの画像形式に対応します。ドキュメントが FileInputStream から派生していないストリームで初期化された場合、画像ファイルはデフォルトのファイル名テンプレートで現在のフォルダーに保存されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.eps.device/imagesaveoptions) | 画像保存に必要なパラメータと、変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate) {#saveAsImage-com.aspose.eps.device.ImageSaveOptions-java.lang.String-java.lang.String-}
+```
+public void saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)
+```
+
+
+指定されたディレクトリに、指定されたファイル名で PS/EPS ファイルを画像ファイルに保存します。ファイル拡張子は \"options\" パラメータの画像形式に対応します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.eps.device/imagesaveoptions) | 画像保存に必要なパラメータと、変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+| outDir | java.lang.String | 画像ファイルが保存される出力ディレクトリです。 |
+| fileNameTemplate | java.lang.String | 画像のファイル名テンプレート（拡張子なし）。入力 PS/EPS ファイルが 1 ページの場合は正確にそのファイル名になります。それ以外の場合は \"\\_[n]\" となり、\"n\" は 0 から始まるページ番号です。サフィックスがこのテンプレートに付加されます。ファイル拡張子は \"option\" パラメータの画像形式に対応します。 |
+
+### saveAsImagesBytes(ImageSaveOptions options) {#saveAsImagesBytes-com.aspose.eps.device.ImageSaveOptions-}
+```
+public byte[][] saveAsImagesBytes(ImageSaveOptions options)
+```
+
+
+PS/EPS ファイルを画像のバイト配列に保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.eps.device/imagesaveoptions) | 画像保存に必要なパラメータと、変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+**Returns:**
+byte[][] - 画像バイト。1 ページにつき 1 つのバイト配列です。
+### saveAsPdf(OutputStream pdfStream, PdfSaveOptions options) {#saveAsPdf-java.io.OutputStream-com.aspose.eps.device.PdfSaveOptions-}
+```
+public void saveAsPdf(OutputStream pdfStream, PdfSaveOptions options)
+```
+
+
+PS/EPS ファイルを出力 PDF ストリームに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pdfStream | java.io.OutputStream | 出力 PDF ストリーム。 |
+| options | [PdfSaveOptions](../../com.aspose.eps.device/pdfsaveoptions) | 変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### saveAsPdf(String outPdfFilePath, PdfSaveOptions options) {#saveAsPdf-java.lang.String-com.aspose.eps.device.PdfSaveOptions-}
+```
+public void saveAsPdf(String outPdfFilePath, PdfSaveOptions options)
+```
+
+
+PS/EPS ファイルを PDF ファイルに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 出力 PDF ファイルのパス。 |
+| options | [PdfSaveOptions](../../com.aspose.eps.device/pdfsaveoptions) | 変換中にスローされたエラーの出力を指定するフラグを含みます。 |
+
+### saveImageAsEps(BufferedImage image, OutputStream epsStream, PsSaveOptions options) {#saveImageAsEps-java.awt.image.BufferedImage-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(BufferedImage image, OutputStream epsStream, PsSaveOptions options)
+```
+
+
+BufferedImage オブジェクトを EPS ファイルに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 画像です。 |
+| epsStream | java.io.OutputStream | EPS 出力ストリームです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 変換中にスローされたエラーの出力を指定するパラメータを含みます。 |
+
+### saveImageAsEps(BufferedImage image, String epsFilePath, PsSaveOptions options) {#saveImageAsEps-java.awt.image.BufferedImage-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(BufferedImage image, String epsFilePath, PsSaveOptions options)
+```
+
+
+BufferedImage オブジェクトを EPS ファイルに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 画像です。 |
+| epsFilePath | java.lang.String | EPS ファイルパスです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 変換中にスローされたエラーの出力を指定するパラメータを含みます。 |
+
+### saveImageAsEps(InputStream imageStream, OutputStream epsStream, PsSaveOptions options) {#saveImageAsEps-java.io.InputStream-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(InputStream imageStream, OutputStream epsStream, PsSaveOptions options)
+```
+
+
+入力ストリームから PNG/JPEG/BMP/GIF 画像を EPS 出力ストリームに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageStream | java.io.InputStream | 画像入力ストリームです。 |
+| epsStream | java.io.OutputStream | EPS 出力ストリームです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 変換中にスローされたエラーの出力を指定するパラメータを含みます。 |
+
+### saveImageAsEps(String imageFilePath, String epsFilePath, PsSaveOptions options) {#saveImageAsEps-java.lang.String-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(String imageFilePath, String epsFilePath, PsSaveOptions options)
+```
+
+
+ファイルから PNG/JPEG/BMP/GIF 画像を EPS ファイルに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFilePath | java.lang.String | 画像ファイルパスです。 |
+| epsFilePath | java.lang.String | EPS ファイルパスです。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 変換中にスローされたエラーの出力を指定するパラメータを含みます。 |
+
+### scale(float xScale, float yScale) {#scale-float-float-}
+```
+public void scale(float xScale, float yScale)
+```
+
+
+現在のグラフィックス状態にスケールを追加します（現在の行列をスケール）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| xScale | float | X 軸のスケールです。 |
+| yScale | float | Y 軸のスケールです。 |
+
+### setInputStream(InputStream is) {#setInputStream-java.io.InputStream-}
+```
+public void setInputStream(InputStream is)
+```
+
+
+入力ストリームを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| is | java.io.InputStream | PS/EPS ファイルの入力ストリームです。 |
+
+### setPageDevice(Map<String,Object> pageParams) {#setPageDevice-java.util.Map-java.lang.String-java.lang.Object--}
+```
+public void setPageDevice(Map<String,Object> pageParams)
+```
+
+
+ページデバイスパラメータを設定します（演算子 \"setpagedevice\" の PostScript 仕様を参照）。これにはページサイズやカラーなどが含まれます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pageParams | java.util.Map<java.lang.String,java.lang.Object> | ページのパラメータ。この辞書にはページサイズや色などが含まれます。 |
+
+### setPageSize(float width, float height) {#setPageSize-float-float-}
+```
+public void setPageSize(float width, float height)
+```
+
+
+ページサイズを設定します。1つのドキュメント内で異なるサイズのページを作成するには、このメソッドの直後に  setPageDevice  メソッドを使用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 結果の PostScript ファイルにおけるページの幅。 |
+| height | float | 結果の PostScript ファイルにおけるページの高さ。 |
+
+### setPaint(Paint paint) {#setPaint-java.awt.Paint-}
+```
+public void setPaint(Paint paint)
+```
+
+
+現在のグラフィックス状態の塗りを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| paint | java.awt.Paint | ペイントです。JDK に存在する  Paint  クラスの任意のサブクラスを使用できます。 |
+
+### setStroke(Stroke stroke) {#setStroke-java.awt.Stroke-}
+```
+public void setStroke(Stroke stroke)
+```
+
+
+現在のグラフィックス状態のストロークを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| stroke | java.awt.Stroke | ストロークです。 |
+
+### setTransform(AffineTransform matrix) {#setTransform-java.awt.geom.AffineTransform-}
+```
+public void setTransform(AffineTransform matrix)
+```
+
+
+現在の変換をこれに設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| matrix | java.awt.geom.AffineTransform | 変換です。 |
+
+### shear(float shx, float shy) {#shear-float-float-}
+```
+public void shear(float shx, float shy)
+```
+
+
+現在のグラフィックス状態にせん断変換を追加します（現在の行列をせん断）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| shx | float | X 軸方向のせん断です。 |
+| shy | float | Y 軸方向のせん断です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(AffineTransform matrix) {#transform-java.awt.geom.AffineTransform-}
+```
+public void transform(AffineTransform matrix)
+```
+
+
+現在のグラフィックス状態に変換を追加します（この行列を現在の行列と連結）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| matrix | java.awt.geom.AffineTransform | 変換です。 |
+
+### translate(float x, float y) {#translate-float-float-}
+```
+public void translate(float x, float y)
+```
+
+
+現在のグラフィックス状態に平行移動を追加します（現在の行列を平行移動）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| x | float | X 方向への平行移動です。 |
+| y | float | Y 方向への平行移動です。 |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+
+### writeGraphicsRestore() {#writeGraphicsRestore--}
+```
+public void writeGraphicsRestore()
+```
+
+
+現在のグラフィックス状態の復元を書き込みます（演算子 "grestore" の PostScript 仕様を参照）。
+
+### writeGraphicsSave() {#writeGraphicsSave--}
+```
+public void writeGraphicsSave()
+```
+
+
+現在のグラフィックス状態の保存を書き込みます（演算子 "gsave" の PostScript 仕様を参照）。
+

--- a/japanese/java/com.aspose.eps/psdocumentexception/_index.md
+++ b/japanese/java/com.aspose.eps/psdocumentexception/_index.md
@@ -1,0 +1,289 @@
+---
+title: "PsDocumentException"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、PS ファイルが作成、完了、保存される際にスローされるエラーに関する情報を含みます。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.eps/psdocumentexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class PsDocumentException extends Exception
+```
+
+このクラスは、PS ファイルが作成、完了、保存される際にスローされるエラーに関する情報を含みます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsDocumentException(String errorStr)](#PsDocumentException-java.lang.String-) | errorStr 文字列から PsDocumentException の新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsDocumentException(String errorStr) {#PsDocumentException-java.lang.String-}
+```
+public PsDocumentException(String errorStr)
+```
+
+
+errorStr 文字列から PsDocumentException の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| errorStr | java.lang.String | エラーの原因を説明する文字列です。 |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.eps/psloadoptions/_index.md
+++ b/japanese/java/com.aspose.eps/psloadoptions/_index.md
@@ -1,0 +1,137 @@
+---
+title: "PsLoadOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PS ドキュメントの読み込みオプション。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.eps/psloadoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.eps.LoadOptions](../../com.aspose.eps/loadoptions)
+```
+public class PsLoadOptions extends LoadOptions
+```
+
+PS ドキュメントの読み込みオプション。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PsLoadOptions()](#PsLoadOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsLoadOptions() {#PsLoadOptions--}
+```
+public PsLoadOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/_index.md
+++ b/japanese/java/com.aspose.page.plugins/_index.md
@@ -1,0 +1,43 @@
+---
+title: "com.aspose.page.plugins"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.page.plugins には、すべての Aspose.Page プラグインに共通するインターフェイスとクラスが含まれています。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.page.plugins/
+---
+
+この **com.aspose.page.plugins** は、すべての Aspose.Page プラグインに共通するインターフェイスとクラスを含みます。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [ByteArrayDataSource](../com.aspose.page.plugins/bytearraydatasource) |  |
+| [ByteArrayResult](../com.aspose.page.plugins/bytearrayresult) | バイト配列の形式で操作結果を表します。 |
+| [DataType](../com.aspose.page.plugins/datatype) | プラグイン処理用のデータの可能なタイプを表します。 |
+| [FileDataSource](../com.aspose.page.plugins/filedatasource) | プラグインの読み込みおよび保存操作のためのファイルデータソースを表します。 |
+| [FileResult](../com.aspose.page.plugins/fileresult) | ファイルへの文字列パスの形式で操作結果を表します。 |
+| [PluginExceptionMessages](../com.aspose.page.plugins/pluginexceptionmessages) | このクラスは、プラグインからスローされた例外で使用されるメッセージのストレージを表します。 |
+| [ResultContainer](../com.aspose.page.plugins/resultcontainer) | プラグインの処理結果コレクションを含むコンテナを表します。 |
+| [StreamDataSource](../com.aspose.page.plugins/streamdatasource) | プラグインの読み込みおよび保存操作のためのストリームデータソースを表します。 |
+| [StreamResult](../com.aspose.page.plugins/streamresult) | ストリームの形式で操作結果を表します。 |
+| [StringResult](../com.aspose.page.plugins/stringresult) | 文字列の形式で操作結果を表します。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IDataContainer](../com.aspose.page.plugins/idatacontainer) | 具体的なデータコンテナ（プラグインオプション）が実装すべき共通メソッドを定義する汎用データコンテナインターフェイス。 |
+| [IDataSource](../com.aspose.page.plugins/idatasource) | 具体的なデータソースが実装すべき共通メンバーを定義する汎用データソースインターフェイス。 |
+| [IOperationResult](../com.aspose.page.plugins/ioperationresult) | 具体的なプラグイン操作結果が実装すべき共通メソッドを定義する汎用操作結果インターフェイス。 |
+| [IPlugin](../com.aspose.page.plugins/iplugin) | 具体的なプラグインが実装すべき共通メソッドを定義する汎用プラグインインターフェイス。 |
+| [IPluginOptions](../com.aspose.page.plugins/ipluginoptions) | 具体的なプラグインオプションが実装すべき共通メソッドを定義する汎用プラグインオプションインターフェイス。 |
+| [ISaveInstruction](../com.aspose.page.plugins/isaveinstruction) | 具体的なプラグインオプションが実装すべき共通メンバーを定義する汎用保存指示インターフェイス。 |
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| --- | --- |
+| [Plugin](../com.aspose.page.plugins/plugin) | 可能なプラグインを表します。 |

--- a/japanese/java/com.aspose.page.plugins/bytearraydatasource/_index.md
+++ b/japanese/java/com.aspose.page.plugins/bytearraydatasource/_index.md
@@ -1,0 +1,147 @@
+---
+title: "ByteArrayDataSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: 
+type: docs
+weight: 10
+url: /ja/java/com.aspose.page.plugins/bytearraydatasource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IDataSource](../../com.aspose.page.plugins/idatasource)
+```
+public final class ByteArrayDataSource implements IDataSource
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ByteArrayDataSource()](#ByteArrayDataSource--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataType()](#getDataType--) | データ ソースのタイプ（ファイル）。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteArrayDataSource() {#ByteArrayDataSource--}
+```
+public ByteArrayDataSource()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataType() {#getDataType--}
+```
+public final int getDataType()
+```
+
+
+データ ソースのタイプ（ファイル）。
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/bytearrayresult/_index.md
+++ b/japanese/java/com.aspose.page.plugins/bytearrayresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "ByteArrayResult"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "バイト配列の形式で操作結果を表します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.page.plugins/bytearrayresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public class ByteArrayResult implements IOperationResult
+```
+
+バイト配列の形式で操作結果を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ByteArrayResult(byte[][] data)](#ByteArrayResult-byte-----) | バイト配列の配列を使用して新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 生データを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 結果がバイト配列かどうかを示します。 |
+| [isFile()](#isFile--) | 結果が出力ファイルへのパスかどうかを示します。 |
+| [isStream()](#isStream--) | 結果が出力ストリームかどうかを示します。 |
+| [isString()](#isString--) | 結果がテキスト文字列かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 結果をファイルに変換しようとします。 |
+| [toStream()](#toStream--) | 結果をストリームオブジェクトに変換しようとします。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteArrayResult(byte[][] data) {#ByteArrayResult-byte-----}
+```
+public ByteArrayResult(byte[][] data)
+```
+
+
+バイト配列の配列を使用して新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| データ | byte[][] | バイトの配列の配列です。文書を画像に変換するために使用されます。1つのバイト配列は1ページの画像のバイトを含みます。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+生データを取得します。
+
+**Returns:**
+java.lang.Object - 出力データを表すオブジェクト。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+結果がバイト配列かどうかを示します。
+
+**Returns:**
+boolean - 結果がバイト配列の場合は true、そうでない場合は false。
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+結果が出力ファイルへのパスかどうかを示します。
+
+**Returns:**
+boolean - 結果がファイルの場合は true、そうでない場合は false。
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+結果が出力ストリームかどうかを示します。
+
+**Returns:**
+boolean - 結果がストリームオブジェクトの場合は true、そうでない場合は false。
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+結果がテキスト文字列かどうかを示します。
+
+**Returns:**
+boolean - 結果が文字列の場合は true、そうでない場合は false。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+結果をファイルに変換しようとします。
+
+**Returns:**
+java.lang.String - 結果がファイルの場合の出力ファイルへのパスを表す文字列、そうでない場合は null。
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+結果をストリームオブジェクトに変換しようとします。
+
+**Returns:**
+java.io.OutputStream - 結果がストリームの場合の出力データを表すストリームオブジェクト、そうでない場合は null。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/datatype/_index.md
+++ b/japanese/java/com.aspose.page.plugins/datatype/_index.md
@@ -1,0 +1,542 @@
+---
+title: "DataType"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグイン処理用のデータの可能なタイプを表します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.page.plugins/datatype/
+---
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class DataType extends System.Enum
+```
+
+プラグイン処理用のデータの可能なタイプを表します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ByteArray](#ByteArray) | データ型はストリームです。 |
+| [EnumSeparatorCharArray](#EnumSeparatorCharArray) |  |
+| [File](#File) | データ型は、そのパスで表されるファイルです。 |
+| [Stream](#Stream) | データ型はストリームです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [Clone()](#Clone--) |  |
+| [CloneTo(T arg0)](#CloneTo-T-) |  |
+| [CloneTo(System.Enum arg0)](#CloneTo-com.aspose.ms.System.Enum-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [format(System.Type arg0, Object arg1, String arg2)](#format-com.aspose.ms.System.Type-java.lang.Object-java.lang.String-) |  |
+| [format(Class<?> arg0, long arg1, String arg2)](#format-java.lang.Class----long-java.lang.String-) |  |
+| [getClass()](#getClass--) |  |
+| [getName(Class<?> arg0, long arg1)](#getName-java.lang.Class----long-) |  |
+| [getNames(System.Type arg0)](#getNames-com.aspose.ms.System.Type-) |  |
+| [getNames(Class<?> arg0)](#getNames-java.lang.Class----) |  |
+| [getUnderlyingType(System.Type arg0)](#getUnderlyingType-com.aspose.ms.System.Type-) |  |
+| [getUnderlyingType(Class<?> arg0)](#getUnderlyingType-java.lang.Class----) |  |
+| [getValue(Class<?> arg0, String arg1)](#getValue-java.lang.Class----java.lang.String-) |  |
+| [getValues(System.Type arg0)](#getValues-com.aspose.ms.System.Type-) |  |
+| [get_Caption()](#get-Caption--) |  |
+| [get_Value()](#get-Value--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isDefined(System.Type arg0, Object arg1)](#isDefined-com.aspose.ms.System.Type-java.lang.Object-) |  |
+| [isDefined(System.Type arg0, String arg1)](#isDefined-com.aspose.ms.System.Type-java.lang.String-) |  |
+| [isDefined(System.Type arg0, long arg1)](#isDefined-com.aspose.ms.System.Type-long-) |  |
+| [isDefined(Class<?> arg0, long arg1)](#isDefined-java.lang.Class----long-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [parse(System.Type arg0, String arg1)](#parse-com.aspose.ms.System.Type-java.lang.String-) |  |
+| [parse(System.Type arg0, String arg1, Boolean arg2)](#parse-com.aspose.ms.System.Type-java.lang.String-java.lang.Boolean-) |  |
+| [parse(Class<?> arg0, String arg1)](#parse-java.lang.Class----java.lang.String-) |  |
+| [parse(Class<?> arg0, String arg1, Boolean arg2)](#parse-java.lang.Class----java.lang.String-java.lang.Boolean-) |  |
+| [register(System.Enum.AbstractEnum arg0)](#register-com.aspose.ms.System.Enum.AbstractEnum-) |  |
+| [toObject(System.Type arg0, Object arg1)](#toObject-com.aspose.ms.System.Type-java.lang.Object-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteArray {#ByteArray}
+```
+public static final int ByteArray
+```
+
+
+データ型はストリームです。
+
+### EnumSeparatorCharArray {#EnumSeparatorCharArray}
+```
+public static final char[] EnumSeparatorCharArray
+```
+
+
+### File {#File}
+```
+public static final int File
+```
+
+
+データ型は、そのパスで表されるファイルです。
+
+### Stream {#Stream}
+```
+public static final int Stream
+```
+
+
+データ型はストリームです。
+
+### Clone() {#Clone--}
+```
+public System.Enum Clone()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Enum
+### CloneTo(T arg0) {#CloneTo-T-}
+```
+public abstract void CloneTo(T arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | T |  |
+
+### CloneTo(System.Enum arg0) {#CloneTo-com.aspose.ms.System.Enum-}
+```
+public void CloneTo(System.Enum arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Enum |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### format(System.Type arg0, Object arg1, String arg2) {#format-com.aspose.ms.System.Type-java.lang.Object-java.lang.String-}
+```
+public static String format(System.Type arg0, Object arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.lang.String |  |
+
+**Returns:**
+java.lang.String
+### format(Class<?> arg0, long arg1, String arg2) {#format-java.lang.Class----long-java.lang.String-}
+```
+public static String format(Class<?> arg0, long arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+| arg2 | java.lang.String |  |
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName(Class<?> arg0, long arg1) {#getName-java.lang.Class----long-}
+```
+public static String getName(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+java.lang.String
+### getNames(System.Type arg0) {#getNames-com.aspose.ms.System.Type-}
+```
+public static String[] getNames(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+java.lang.String[]
+### getNames(Class<?> arg0) {#getNames-java.lang.Class----}
+```
+public static Collection<String> getNames(Class<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+
+**Returns:**
+java.util.Collection<java.lang.String>
+### getUnderlyingType(System.Type arg0) {#getUnderlyingType-com.aspose.ms.System.Type-}
+```
+public static System.Type getUnderlyingType(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+com.aspose.ms.System.Type
+### getUnderlyingType(Class<?> arg0) {#getUnderlyingType-java.lang.Class----}
+```
+public static Class<? extends Number> getUnderlyingType(Class<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+
+**Returns:**
+java.lang.Class<? extends java.lang.Number>
+### getValue(Class<?> arg0, String arg1) {#getValue-java.lang.Class----java.lang.String-}
+```
+public static long getValue(Class<?> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### getValues(System.Type arg0) {#getValues-com.aspose.ms.System.Type-}
+```
+public static System.Array getValues(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+com.aspose.ms.System.Array
+### get_Caption() {#get-Caption--}
+```
+public String get_Caption()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### get_Value() {#get-Value--}
+```
+public long get_Value()
+```
+
+
+
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDefined(System.Type arg0, Object arg1) {#isDefined-com.aspose.ms.System.Type-java.lang.Object-}
+```
+public static boolean isDefined(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### isDefined(System.Type arg0, String arg1) {#isDefined-com.aspose.ms.System.Type-java.lang.String-}
+```
+public static boolean isDefined(System.Type arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+boolean
+### isDefined(System.Type arg0, long arg1) {#isDefined-com.aspose.ms.System.Type-long-}
+```
+public static boolean isDefined(System.Type arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | long |  |
+
+**Returns:**
+boolean
+### isDefined(Class<?> arg0, long arg1) {#isDefined-java.lang.Class----long-}
+```
+public static boolean isDefined(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### parse(System.Type arg0, String arg1) {#parse-com.aspose.ms.System.Type-java.lang.String-}
+```
+public static long parse(System.Type arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### parse(System.Type arg0, String arg1, Boolean arg2) {#parse-com.aspose.ms.System.Type-java.lang.String-java.lang.Boolean-}
+```
+public static long parse(System.Type arg0, String arg1, Boolean arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.Boolean |  |
+
+**Returns:**
+long
+### parse(Class<?> arg0, String arg1) {#parse-java.lang.Class----java.lang.String-}
+```
+public static long parse(Class<?> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### parse(Class<?> arg0, String arg1, Boolean arg2) {#parse-java.lang.Class----java.lang.String-java.lang.Boolean-}
+```
+public static long parse(Class<?> arg0, String arg1, Boolean arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.Boolean |  |
+
+**Returns:**
+long
+### register(System.Enum.AbstractEnum arg0) {#register-com.aspose.ms.System.Enum.AbstractEnum-}
+```
+public static void register(System.Enum.AbstractEnum arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Enum.AbstractEnum |  |
+
+### toObject(System.Type arg0, Object arg1) {#toObject-com.aspose.ms.System.Type-java.lang.Object-}
+```
+public static Object toObject(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/filedatasource/_index.md
+++ b/japanese/java/com.aspose.page.plugins/filedatasource/_index.md
@@ -1,0 +1,167 @@
+---
+title: "FileDataSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグインの読み込みおよび保存操作のためのファイルデータソースを表します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.page.plugins/filedatasource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IDataSource](../../com.aspose.page.plugins/idatasource)
+```
+public final class FileDataSource implements IDataSource
+```
+
+プラグインの読み込みおよび保存操作のためのファイルデータソースを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FileDataSource(String path)](#FileDataSource-java.lang.String-) | 指定されたパスで新しいファイル データ ソースを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataType()](#getDataType--) | データ ソースのタイプ（ファイル）。 |
+| [getPath()](#getPath--) | 現在のデータ ソースのファイルへのパスを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileDataSource(String path) {#FileDataSource-java.lang.String-}
+```
+public FileDataSource(String path)
+```
+
+
+指定されたパスで新しいファイル データ ソースを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.lang.String | ソース ファイルへのパスを表す文字列です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataType() {#getDataType--}
+```
+public final int getDataType()
+```
+
+
+データ ソースのタイプ（ファイル）。
+
+**Returns:**
+int
+### getPath() {#getPath--}
+```
+public final String getPath()
+```
+
+
+現在のデータ ソースのファイルへのパスを取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/fileresult/_index.md
+++ b/japanese/java/com.aspose.page.plugins/fileresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "FileResult"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ファイルへの文字列パスの形式で操作結果を表します。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.page.plugins/fileresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public final class FileResult implements IOperationResult
+```
+
+ファイルへの文字列パスの形式で操作結果を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [FileResult(String path)](#FileResult-java.lang.String-) | 指定された出力ファイルへのパスで新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 生データを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 結果がバイト配列かどうかを示します。 |
+| [isFile()](#isFile--) | 結果が出力ファイルへのパスかどうかを示します。 |
+| [isStream()](#isStream--) | 結果が出力ストリームかどうかを示します。 |
+| [isString()](#isString--) | 結果がテキスト文字列かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 結果をファイルに変換しようとします。 |
+| [toStream()](#toStream--) | 結果をストリームオブジェクトに変換しようとします。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileResult(String path) {#FileResult-java.lang.String-}
+```
+public FileResult(String path)
+```
+
+
+指定された出力ファイルへのパスで新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.lang.String | ファイルへのパス。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+生データを取得します。
+
+**Returns:**
+java.lang.Object - 出力データを表すオブジェクト。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+結果がバイト配列かどうかを示します。
+
+**Returns:**
+boolean - 結果がバイト配列の場合は true、そうでない場合は false。
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+結果が出力ファイルへのパスかどうかを示します。
+
+**Returns:**
+boolean - 結果がファイルの場合は true、そうでない場合は false。
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+結果が出力ストリームかどうかを示します。
+
+**Returns:**
+boolean - 結果がストリームオブジェクトの場合は true、そうでない場合は false。
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+結果がテキスト文字列かどうかを示します。
+
+**Returns:**
+boolean - 結果が文字列の場合は true、そうでない場合は false。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+結果をファイルに変換しようとします。
+
+**Returns:**
+java.lang.String - 結果がファイルの場合の出力ファイルへのパスを表す文字列、そうでない場合は null。
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+結果をストリームオブジェクトに変換しようとします。
+
+**Returns:**
+java.io.OutputStream - 結果がストリームの場合の出力データを表すストリームオブジェクト、そうでない場合は null。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/idatacontainer/_index.md
+++ b/japanese/java/com.aspose.page.plugins/idatacontainer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IDataContainer"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "具体的なデータコンテナプラグインオプションが実装すべき共通メソッドを定義する、一般的なデータコンテナインターフェイスです。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.page.plugins/idatacontainer/
+---```
+public interface IDataContainer
+```
+
+General data container interface that defines common methods that concrete data container (plugin options) should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | Adds new data source to the collection |
+| [getDataCollection()](#getDataCollection--) | Gets collection of data sources |
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public abstract void addDataSource(IDataSource dataSource)
+```
+
+
+Adds new data source to the collection
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) |  |
+
+### getDataCollection() {#getDataCollection--}
+```
+public abstract List<IDataSource> getDataCollection()
+```
+
+
+Gets collection of data sources
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>

--- a/japanese/java/com.aspose.page.plugins/idatasource/_index.md
+++ b/japanese/java/com.aspose.page.plugins/idatasource/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IDataSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "具体的なデータソースが実装すべき共通メンバーを定義する汎用データソースインターフェイス。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.page.plugins/idatasource/
+---```
+public interface IDataSource
+```
+
+General data source interface that defines common members that concrete data sources should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getDataType()](#getDataType--) | Type of data source (file or stream). |
+### getDataType() {#getDataType--}
+```
+public abstract int getDataType()
+```
+
+
+Type of data source (file or stream).
+
+**Returns:**
+int

--- a/japanese/java/com.aspose.page.plugins/ioperationresult/_index.md
+++ b/japanese/java/com.aspose.page.plugins/ioperationresult/_index.md
@@ -1,0 +1,93 @@
+---
+title: "IOperationResult"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "具体的なプラグイン操作結果が実装すべき共通メソッドを定義する汎用操作結果インターフェイス。"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.page.plugins/ioperationresult/
+---```
+public interface IOperationResult
+```
+
+General operation result interface that defines common methods that concrete plugin operation result should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getData()](#getData--) | Gets raw data. |
+| [isByteArray()](#isByteArray--) | Indicates whether the result is a bytes array. |
+| [isFile()](#isFile--) | Indicates whether the result is a path to an output file. |
+| [isStream()](#isStream--) | Indicates whether the result is an output stream. |
+| [isString()](#isString--) | Indicates whether the result is a text string. |
+| [toFile()](#toFile--) | Tries to convert the result to the file. |
+| [toStream()](#toStream--) | Tries to convert the result to a stream object. |
+### getData() {#getData--}
+```
+public abstract Object getData()
+```
+
+
+Gets raw data.
+
+**Returns:**
+java.lang.Object - An object representing output data.
+### isByteArray() {#isByteArray--}
+```
+public abstract boolean isByteArray()
+```
+
+
+Indicates whether the result is a bytes array.
+
+**Returns:**
+boolean -  true  if the result is a bytes array; otherwise  false .
+### isFile() {#isFile--}
+```
+public abstract boolean isFile()
+```
+
+
+Indicates whether the result is a path to an output file.
+
+**Returns:**
+boolean - true if the result is a file; otherwise false.
+### isStream() {#isStream--}
+```
+public abstract boolean isStream()
+```
+
+
+Indicates whether the result is an output stream.
+
+**Returns:**
+boolean - true if the result is a stream object; otherwise false.
+### isString() {#isString--}
+```
+public abstract boolean isString()
+```
+
+
+Indicates whether the result is a text string.
+
+**Returns:**
+boolean - true if the result is a string; otherwise false.
+### toFile() {#toFile--}
+```
+public abstract String toFile()
+```
+
+
+Tries to convert the result to the file.
+
+**Returns:**
+java.lang.String - A string representing the path to the output file if the result is file; otherwise null.
+### toStream() {#toStream--}
+```
+public abstract OutputStream toStream()
+```
+
+
+Tries to convert the result to a stream object.
+
+**Returns:**
+java.io.OutputStream - A stream object representing the output data if the result is stream; otherwise  null .

--- a/japanese/java/com.aspose.page.plugins/iplugin/_index.md
+++ b/japanese/java/com.aspose.page.plugins/iplugin/_index.md
@@ -1,0 +1,32 @@
+---
+title: "IPlugin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "具体的なプラグインが実装すべき共通メソッドを定義する汎用プラグインインターフェイス。"
+type: docs
+weight: 23
+url: /ja/java/com.aspose.page.plugins/iplugin/
+---```
+public interface IPlugin
+```
+
+General plugin interface that defines common methods that concrete plugin should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [process(IPluginOptions options)](#process-com.aspose.page.plugins.IPluginOptions-) | Charges a plugin to process with defined options |
+### process(IPluginOptions options) {#process-com.aspose.page.plugins.IPluginOptions-}
+```
+public abstract ResultContainer process(IPluginOptions options)
+```
+
+
+Charges a plugin to process with defined options
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| options | [IPluginOptions](../../com.aspose.page.plugins/ipluginoptions) | An options object containing instructions for the plugin |
+
+**Returns:**
+[ResultContainer](../../com.aspose.page.plugins/resultcontainer) - An ResultContainer object containing the result of the processing

--- a/japanese/java/com.aspose.page.plugins/ipluginoptions/_index.md
+++ b/japanese/java/com.aspose.page.plugins/ipluginoptions/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IPluginOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "具体的なプラグインオプションが実装すべき共通メソッドを定義する汎用プラグインオプションインターフェイス。"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.page.plugins/ipluginoptions/
+---```
+public interface IPluginOptions
+```
+
+General plugin option interface that defines common methods that concrete plugin option should implement.

--- a/japanese/java/com.aspose.page.plugins/isaveinstruction/_index.md
+++ b/japanese/java/com.aspose.page.plugins/isaveinstruction/_index.md
@@ -1,0 +1,41 @@
+---
+title: "ISaveInstruction"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "具体的なプラグインオプションが実装すべき共通メンバーを定義する汎用保存指示インターフェイス。"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.page.plugins/isaveinstruction/
+---```
+public interface ISaveInstruction
+```
+
+General save instruction interface that defines common members that concrete plugin option should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | Adds new result save target |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | Gets the collection of added targets (file or stream data sources) for saving operation results. |
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public abstract void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+Adds new result save target
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | Target (file or stream data source) for saving operation results. |
+
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public abstract List<IDataSource> getSaveTargetsCollection()
+```
+
+
+Gets the collection of added targets (file or stream data sources) for saving operation results.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>

--- a/japanese/java/com.aspose.page.plugins/plugin/_index.md
+++ b/japanese/java/com.aspose.page.plugins/plugin/_index.md
@@ -1,0 +1,253 @@
+---
+title: "Plugin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "可能なプラグインを表します。"
+type: docs
+weight: 26
+url: /ja/java/com.aspose.page.plugins/plugin/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum Plugin extends Enum<Plugin>
+```
+
+可能なプラグインを表します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) |  |
+| [PsConverter](#PsConverter) |  |
+| [XpsConverter](#XpsConverter) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final Plugin None
+```
+
+
+### PsConverter {#PsConverter}
+```
+public static final Plugin PsConverter
+```
+
+
+### XpsConverter {#XpsConverter}
+```
+public static final Plugin XpsConverter
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static Plugin valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Plugin](../../com.aspose.page.plugins/plugin)
+### values() {#values--}
+```
+public static Plugin[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.plugins.Plugin[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/pluginexceptionmessages/_index.md
+++ b/japanese/java/com.aspose.page.plugins/pluginexceptionmessages/_index.md
@@ -1,0 +1,174 @@
+---
+title: "PluginExceptionMessages"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、プラグインからスローされた例外で使用されるメッセージのストレージを表します。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.page.plugins/pluginexceptionmessages/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class PluginExceptionMessages
+```
+
+このクラスは、プラグインからスローされた例外で使用されるメッセージのストレージを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PluginExceptionMessages()](#PluginExceptionMessages--) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [MustNotBeNull](#MustNotBeNull) |  |
+| [UnsupportedDataType](#UnsupportedDataType) |  |
+| [UnsupportedOutputDataType](#UnsupportedOutputDataType) |  |
+| [WrongOptionTypePsConverter](#WrongOptionTypePsConverter) |  |
+| [WrongOptionTypeXpsConverter](#WrongOptionTypeXpsConverter) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PluginExceptionMessages() {#PluginExceptionMessages--}
+```
+public PluginExceptionMessages()
+```
+
+
+### MustNotBeNull {#MustNotBeNull}
+```
+public static final String MustNotBeNull
+```
+
+
+### UnsupportedDataType {#UnsupportedDataType}
+```
+public static final String UnsupportedDataType
+```
+
+
+### UnsupportedOutputDataType {#UnsupportedOutputDataType}
+```
+public static final String UnsupportedOutputDataType
+```
+
+
+### WrongOptionTypePsConverter {#WrongOptionTypePsConverter}
+```
+public static final String WrongOptionTypePsConverter
+```
+
+
+### WrongOptionTypeXpsConverter {#WrongOptionTypeXpsConverter}
+```
+public static final String WrongOptionTypeXpsConverter
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/resultcontainer/_index.md
+++ b/japanese/java/com.aspose.page.plugins/resultcontainer/_index.md
@@ -1,0 +1,148 @@
+---
+title: "ResultContainer"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグインの処理結果コレクションを含むコンテナを表します。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.page.plugins/resultcontainer/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class ResultContainer
+```
+
+プラグインの処理結果コレクションを含むコンテナを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ResultContainer()](#ResultContainer--) | 新しい結果コンテナを初期化します |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getResultCollection()](#getResultCollection--) | 操作結果のコレクションを取得します |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResultContainer() {#ResultContainer--}
+```
+public ResultContainer()
+```
+
+
+新しい結果コンテナを初期化します
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getResultCollection() {#getResultCollection--}
+```
+public final List<IOperationResult> getResultCollection()
+```
+
+
+操作結果のコレクションを取得します
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IOperationResult>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/streamdatasource/_index.md
+++ b/japanese/java/com.aspose.page.plugins/streamdatasource/_index.md
@@ -1,0 +1,189 @@
+---
+title: "StreamDataSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグインの読み込みおよび保存操作のためのストリームデータソースを表します。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.page.plugins/streamdatasource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IDataSource](../../com.aspose.page.plugins/idatasource)
+```
+public final class StreamDataSource implements IDataSource
+```
+
+プラグインの読み込みおよび保存操作のためのストリームデータソースを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StreamDataSource(Object data)](#StreamDataSource-java.lang.Object-) | 指定されたストリームオブジェクトで新しいストリーム データ ソースを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 現在のデータ ソースのストリームオブジェクトを取得します。 |
+| [getDataType()](#getDataType--) | データ ソースのタイプ（ストリーム）。 |
+| [getInputStream()](#getInputStream--) |  |
+| [getOutputStream()](#getOutputStream--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamDataSource(Object data) {#StreamDataSource-java.lang.Object-}
+```
+public StreamDataSource(Object data)
+```
+
+
+指定されたストリームオブジェクトで新しいストリーム データ ソースを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| データ | java.lang.Object | ストリームオブジェクト |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+現在のデータ ソースのストリームオブジェクトを取得します。
+
+**Returns:**
+java.lang.Object
+### getDataType() {#getDataType--}
+```
+public final int getDataType()
+```
+
+
+データ ソースのタイプ（ストリーム）。
+
+**Returns:**
+int
+### getInputStream() {#getInputStream--}
+```
+public final InputStream getInputStream()
+```
+
+
+
+
+**Returns:**
+java.io.InputStream
+### getOutputStream() {#getOutputStream--}
+```
+public final OutputStream getOutputStream()
+```
+
+
+
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/streamresult/_index.md
+++ b/japanese/java/com.aspose.page.plugins/streamresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "StreamResult"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ストリームの形式で操作結果を表します。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.page.plugins/streamresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public final class StreamResult implements IOperationResult
+```
+
+ストリームの形式で操作結果を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StreamResult(OutputStream stream)](#StreamResult-java.io.OutputStream-) | 指定されたストリームオブジェクトで新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 生データを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 結果がバイト配列かどうかを示します。 |
+| [isFile()](#isFile--) | 結果が出力ファイルへのパスかどうかを示します。 |
+| [isStream()](#isStream--) | 結果が出力ファイルへのパスかどうかを示します。 |
+| [isString()](#isString--) | 結果が文字列かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 結果をファイルに変換しようとします。 |
+| [toStream()](#toStream--) | 結果をストリームオブジェクトに変換しようとします。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamResult(OutputStream stream) {#StreamResult-java.io.OutputStream-}
+```
+public StreamResult(OutputStream stream)
+```
+
+
+指定されたストリームオブジェクトで新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | ストリームオブジェクト |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+生データを取得します。
+
+**Returns:**
+java.lang.Object - 出力データを表すオブジェクト。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+結果がバイト配列かどうかを示します。
+
+**Returns:**
+boolean - 結果がバイト配列の場合は true、そうでない場合は false。
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+結果が出力ファイルへのパスかどうかを示します。
+
+**Returns:**
+boolean - 結果がファイルの場合は true、そうでない場合は false。
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+結果が出力ファイルへのパスかどうかを示します。
+
+**Returns:**
+boolean - 結果がストリームオブジェクトの場合は true、そうでない場合は false。
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+結果が文字列かどうかを示します。
+
+**Returns:**
+boolean - 結果が文字列の場合は true、そうでない場合は false。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+結果をファイルに変換しようとします。
+
+**Returns:**
+java.lang.String - 結果がファイルの場合の出力ファイルへのパスを表す文字列、そうでない場合は null。
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+結果をストリームオブジェクトに変換しようとします。
+
+**Returns:**
+java.io.OutputStream - 結果がストリームの場合の出力データを表すストリームオブジェクト、そうでない場合は null。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page.plugins/stringresult/_index.md
+++ b/japanese/java/com.aspose.page.plugins/stringresult/_index.md
@@ -1,0 +1,233 @@
+---
+title: "StringResult"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "文字列の形式で操作結果を表します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.page.plugins/stringresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public final class StringResult implements IOperationResult
+```
+
+文字列の形式で操作結果を表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StringResult(String result)](#StringResult-java.lang.String-) | 文字列で新しい StringResult インスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 生データを取得します。 |
+| [getText()](#getText--) | 結果の文字列表現を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 結果がバイト配列かどうかを示します。 |
+| [isFile()](#isFile--) | 結果が出力ファイルへのパスかどうかを示します。 |
+| [isStream()](#isStream--) | 結果が出力ファイルへのパスかどうかを示します。 |
+| [isString()](#isString--) | 結果が文字列かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 結果をファイルに変換しようとします。 |
+| [toStream()](#toStream--) | 結果をストリームオブジェクトに変換しようとします。 |
+| [toString()](#toString--) | 結果を文字列に変換しようとします。 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringResult(String result) {#StringResult-java.lang.String-}
+```
+public StringResult(String result)
+```
+
+
+文字列で新しい StringResult インスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 結果 | java.lang.String | 結果を表す文字列 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+生データを取得します。
+
+**Returns:**
+java.lang.Object - 出力データを表すオブジェクト。
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+結果の文字列表現を返します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+結果がバイト配列かどうかを示します。
+
+**Returns:**
+boolean - 結果がバイト配列の場合は true、そうでない場合は false。
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+結果が出力ファイルへのパスかどうかを示します。
+
+**Returns:**
+boolean - 結果がファイルの場合は true、そうでない場合は false。
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+結果が出力ファイルへのパスかどうかを示します。
+
+**Returns:**
+boolean - 結果がストリームオブジェクトの場合は true、そうでない場合は false。
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+結果が文字列かどうかを示します。
+
+**Returns:**
+boolean - 結果が文字列の場合は true、そうでない場合は false。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+結果をファイルに変換しようとします。
+
+**Returns:**
+java.lang.String - 結果がファイルの場合の出力ファイルへのパスを表す文字列、そうでない場合は null。
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+結果をストリームオブジェクトに変換しようとします。
+
+**Returns:**
+java.io.OutputStream - 結果がストリームの場合の出力データを表すストリームオブジェクト、そうでない場合は null。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+結果を文字列に変換しようとします。
+
+**Returns:**
+java.lang.String - 結果が文字列の場合はテキスト内容を表す文字列です。それ以外の場合は base.ToString() を返します。
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/_index.md
+++ b/japanese/java/com.aspose.page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "com.aspose.page"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Aspose.Page は、Aspose.Page ライブラリのすべてのクラスのルートパッケージであり、Device のように直接含まれるものや、いくつかのサブパッケージを介して間接的に含まれるものがあります。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.page/
+---
+
+**Aspose.Page** は、Aspose.Page ライブラリのすべてのクラスのルートパッケージであり、**Device** のように直接含まれるものや、いくつかのサブパッケージを介して間接的に含まれるものがあります。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [AsposePageException](../com.aspose.page/asposepageexception) | Aspose.Page アプリケーションの実行中に発生するエラーを表します。 |
+| [DimensionF](../com.aspose.page/dimensionf) | `Dimension` クラスは、コンポーネントの幅と高さ（単精度）を単一のオブジェクトにカプセル化します。 |
+| [Document](../com.aspose.page/document) | すべてのカプセル化されたドキュメントのスーパークラスです。 |
+| [ExternalFontCache](../com.aspose.page/externalfontcache) | このクラスを使用して、Device が受け入れる形式でフォントのカプセル化を取得します。 |
+| [License](../com.aspose.page/license) | コンポーネントをライセンスするためのメソッドを提供します。 |
+| [Metered](../com.aspose.page/metered) | メーターキーを設定するためのメソッドを提供します。 |
+| [SaveOptions](../com.aspose.page/saveoptions) | このクラスは、変換プロセスの管理に必要なオプションを含んでいます。 |
+| [TransformedStroke](../com.aspose.page/transformedstroke) | 変換を含むストロークです。 |
+| [UserProperties](../com.aspose.page/userproperties) | 型付きプロパティの設定と取得を可能にする特別なプロパティクラスです。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IGlyph](../com.aspose.page/iglyph) | このインターフェイスは、グリフの主要パラメータへのアクセスを提供します。 |
+| [IInteractiveDevice](../com.aspose.page/iinteractivedevice) | インタラクティブ機能の処理メソッドを定義するインターフェイスです。 |
+| [IMultiPageSaveOptions](../com.aspose.page/imultipagesaveoptions) | 変換用のページ番号設定インターフェイスを定義します。 |
+| [ITrFont](../com.aspose.page/itrfont) | このインターフェイスは、フォントの主要パラメータへのアクセスを提供します。 |
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| --- | --- |
+| [ImageFormat](../com.aspose.page/imageformat) | この列挙は、PS/EPS から画像への変換でサポートされる画像フォーマットの可能な名前を含みます。 |
+| [TextRenderingMode](../com.aspose.page/textrenderingmode) | この列挙は、テキストレンダリングモードの可能な値を含みます。 |
+| [Units](../com.aspose.page/units) | この列挙は、サイズ単位の可能な値を含みます。 |

--- a/japanese/java/com.aspose.page/asposepageexception/_index.md
+++ b/japanese/java/com.aspose.page/asposepageexception/_index.md
@@ -1,0 +1,271 @@
+---
+title: "AsposePageException"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Aspose.Page アプリケーションの実行中に発生するエラーを表します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.page/asposepageexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException
+```
+public class AsposePageException extends RuntimeException
+```
+
+Aspose.Page アプリケーションの実行中に発生するエラーを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/dimensionf/_index.md
+++ b/japanese/java/com.aspose.page/dimensionf/_index.md
@@ -1,0 +1,295 @@
+---
+title: "DimensionF"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Dimension クラスは、コンポーネントの幅と高さを単精度で単一のオブジェクトにカプセル化します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.page/dimensionf/
+---
+**Inheritance:**
+java.lang.Object, java.awt.geom.Dimension2D
+
+**All Implemented Interfaces:**
+java.io.Serializable
+```
+public class DimensionF extends Dimension2D implements Serializable
+```
+
+`Dimension` クラスは、コンポーネントの幅と高さ（単精度）を単一のオブジェクトにカプセル化します。
+
+通常、`width` と `height` の値は負でない整数です。次元を作成できるコンストラクタは、これらのプロパティに負の値を設定することを防ぎません。`width` または `height` の値が負の場合、他のオブジェクトで定義された一部のメソッドの動作は未定義です。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DimensionF()](#DimensionF--) | `Dimension` の幅がゼロで高さがゼロのインスタンスを作成します。 |
+| [DimensionF(DimensionF d)](#DimensionF-com.aspose.page.DimensionF-) | 指定された次元と同じ幅と高さを持つ `Dimension` のインスタンスを作成します。 |
+| [DimensionF(float width, float height)](#DimensionF-float-float-) | `Dimension` を構築し、指定された幅と指定された高さで初期化します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [height](#height) | height 次元; 負の値を使用できます。 |
+| [width](#width) | width 次元; 負の値を使用できます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) | 2 つの dimension オブジェクトが等しい値かどうかを確認します。 |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | \{@inheritDoc\} |
+| [getSize()](#getSize--) | この `Dimension` オブジェクトのサイズを取得します。 |
+| [getWidth()](#getWidth--) | \{@inheritDoc\} |
+| [hashCode()](#hashCode--) | この `Dimension` のハッシュコードを返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(DimensionF d)](#setSize-com.aspose.page.DimensionF-) | この `Dimension` オブジェクトのサイズを指定されたサイズに設定します。 |
+| [setSize(double width, double height)](#setSize-double-double-) | この `Dimension` オブジェクトのサイズを、指定された幅と高さ（倍精度）に設定します。 |
+| [setSize(float width, float height)](#setSize-float-float-) | この `Dimension` オブジェクトのサイズを、指定された幅と高さに設定します。 |
+| [setSize(Dimension2D arg0)](#setSize-java.awt.geom.Dimension2D-) |  |
+| [toString()](#toString--) | この `Dimension` オブジェクトの `height` と `width` フィールドの値を表す文字列を返します。 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DimensionF() {#DimensionF--}
+```
+public DimensionF()
+```
+
+
+`Dimension` の幅がゼロで高さがゼロのインスタンスを作成します。
+
+### DimensionF(DimensionF d) {#DimensionF-com.aspose.page.DimensionF-}
+```
+public DimensionF(DimensionF d)
+```
+
+
+指定された次元と同じ幅と高さを持つ `Dimension` のインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| d | [DimensionF](../../com.aspose.page/dimensionf) | `width` と `height` の値に対する指定された次元 |
+
+### DimensionF(float width, float height) {#DimensionF-float-float-}
+```
+public DimensionF(float width, float height)
+```
+
+
+`Dimension` を構築し、指定された幅と指定された高さで初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 指定された幅 |
+| height | float | 指定された高さ |
+
+### height {#height}
+```
+public float height
+```
+
+
+height 次元; 負の値を使用できます。
+
+### width {#width}
+```
+public float width
+```
+
+
+width 次元; 負の値を使用できます。
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+2 つの dimension オブジェクトが等しい値かどうかを確認します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getSize() {#getSize--}
+```
+public DimensionF getSize()
+```
+
+
+この `Dimension` オブジェクトのサイズを取得します。このメソッドは完全性のために含まれており、`Component` に定義された `getSize` メソッドと同等です。
+
+**Returns:**
+[DimensionF](../../com.aspose.page/dimensionf) - the size of this dimension, a new instance of `Dimension` with the same width and height
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+この `Dimension` のハッシュコードを返します。
+
+**Returns:**
+int - この `Dimension` のハッシュコード
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(DimensionF d) {#setSize-com.aspose.page.DimensionF-}
+```
+public void setSize(DimensionF d)
+```
+
+
+この `Dimension` オブジェクトのサイズを指定されたサイズに設定します。このメソッドは完全性のために含まれており、`Component` に定義された `setSize` メソッドと同等です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| d | [DimensionF](../../com.aspose.page/dimensionf) | この `Dimension` オブジェクトの新しいサイズ |
+
+### setSize(double width, double height) {#setSize-double-double-}
+```
+public void setSize(double width, double height)
+```
+
+
+この `Dimension` オブジェクトのサイズを、指定された幅と高さ（倍精度）に設定します。`width` または `height` が `Integer.MAX_VALUE` より大きい場合、`Integer.MAX_VALUE` にリセットされることに注意してください。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | double | `Dimension` オブジェクトの新しい幅 |
+| height | double | `Dimension` オブジェクトの新しい高さ |
+
+### setSize(float width, float height) {#setSize-float-float-}
+```
+public void setSize(float width, float height)
+```
+
+
+この `Dimension` オブジェクトのサイズを指定された幅と高さに設定します。このメソッドは完全性のために含まれており、`Component` に定義された `setSize` メソッドと同等です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | この `Dimension` オブジェクトの新しい幅 |
+| height | float | この `Dimension` オブジェクトの新しい高さ |
+
+### setSize(Dimension2D arg0) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.awt.geom.Dimension2D |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+この `Dimension` オブジェクトの `height` と `width` フィールドの値を文字列で返します。このメソッドはデバッグ目的でのみ使用されることを意図しており、返される文字列の内容や形式は実装間で異なる場合があります。返される文字列は空になることがありますが、`null` になることはありません。
+
+**Returns:**
+java.lang.String - この `Dimension` オブジェクトの文字列表現
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/document/_index.md
+++ b/japanese/java/com.aspose.page/document/_index.md
@@ -1,0 +1,161 @@
+---
+title: "ドキュメント"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "すべてのカプセル化されたドキュメントのスーパークラスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.page/document/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Document
+```
+
+すべてのカプセル化されたドキュメントのスーパークラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Document()](#Document--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isLicensed()](#isLicensed--) | Aspose.Page for Java 製品ライセンスがアクセスされ、有効かどうかを示します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [save(Device device, SaveOptions options)](#save-com.aspose.page.Device-com.aspose.page.SaveOptions-) | このドキュメントをデバイスに保存します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Document() {#Document--}
+```
+public Document()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isLicensed() {#isLicensed--}
+```
+public boolean isLicensed()
+```
+
+
+Aspose.Page for Java 製品ライセンスがアクセスされ、有効かどうかを示します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### save(Device device, SaveOptions options) {#save-com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public abstract void save(Device device, SaveOptions options)
+```
+
+
+このドキュメントをデバイスに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| device | [Device](../../com.aspose.page/device) | 出力デバイス。 |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | オプション。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/externalfontcache/_index.md
+++ b/japanese/java/com.aspose.page/externalfontcache/_index.md
@@ -1,0 +1,298 @@
+---
+title: "ExternalFontCache"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスを使用して、Device が受け入れる形式でフォントのカプセル化を取得します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.page/externalfontcache/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class ExternalFontCache
+```
+
+このクラスを使用して、Device が受け入れる形式でフォントのカプセル化を取得します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ExternalFontCache()](#ExternalFontCache--) |  |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [DEFAULT_SIZE](#DEFAULT-SIZE) | デフォルトのフォントサイズです。 |
+| [DEFAULT_STYLE](#DEFAULT-STYLE) | デフォルトのフォントスタイルです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [FetchTrFont(String familyName)](#FetchTrFont-java.lang.String-) | フォントファミリ名、デフォルトサイズ (1) およびデフォルトスタイル (PLAIN) で DrFont を取得します。 |
+| [FetchTrFont(String familyName, int style)](#FetchTrFont-java.lang.String-int-) | フォントファミリ名、デフォルトサイズ (1) とスタイルで DrFont を取得します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fetchDrFont(String familyName, float sizePoints, int style)](#fetchDrFont-java.lang.String-float-int-) | フォントファミリ名、サイズ、スタイルで DrFont を取得します。 |
+| [fetchDrFont(String familyName, float sizePoints, int style, int fontCapitals)](#fetchDrFont-java.lang.String-float-int-int-) | フォントファミリ名、サイズ、スタイル、フォント大文字で DrFont を取得します。 |
+| [fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName)](#fetchDrFont-java.lang.String-float-int-java.lang.String-) | フォントファミリ名、サイズ、スタイル、代替フォントファミリ名で DrFont を取得します。 |
+| [fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName, int fontCapitals)](#fetchDrFont-java.lang.String-float-int-java.lang.String-int-) | フォントファミリ名、サイズ、スタイル、フォント大文字、代替フォントファミリ名で DrFont を取得します。 |
+| [fetchTTFont(String familyName, int style, String altFamilyName)](#fetchTTFont-java.lang.String-int-java.lang.String-) | フォントファミリ名、スタイル、代替フォントファミリ名で TTFont を取得します。 |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] additionalFontFolders)](#setAdditionalFontsFolders-java.lang.String---) | 追加のフォントフォルダーを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ExternalFontCache() {#ExternalFontCache--}
+```
+public ExternalFontCache()
+```
+
+
+### DEFAULT_SIZE {#DEFAULT-SIZE}
+```
+public static final float DEFAULT_SIZE
+```
+
+
+デフォルトのフォントサイズです。
+
+### DEFAULT_STYLE {#DEFAULT-STYLE}
+```
+public static final int DEFAULT_STYLE
+```
+
+
+デフォルトのフォントスタイルです。
+
+### FetchTrFont(String familyName) {#FetchTrFont-java.lang.String-}
+```
+public DrFont FetchTrFont(String familyName)
+```
+
+
+フォントファミリ名、デフォルトサイズ (1) およびデフォルトスタイル (PLAIN) で DrFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont。
+### FetchTrFont(String familyName, int style) {#FetchTrFont-java.lang.String-int-}
+```
+public DrFont FetchTrFont(String familyName, int style)
+```
+
+
+フォントファミリ名、デフォルトサイズ (1) とスタイルで DrFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+| スタイル | int | フォントスタイル。 |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont。
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fetchDrFont(String familyName, float sizePoints, int style) {#fetchDrFont-java.lang.String-float-int-}
+```
+public static DrFont fetchDrFont(String familyName, float sizePoints, int style)
+```
+
+
+フォントファミリ名、サイズ、スタイルで DrFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+| sizePoints | float | ポイント単位のフォントサイズ（1ポイントはインチの1/72です）。 |
+| スタイル | int | フォントスタイル。 |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont。
+### fetchDrFont(String familyName, float sizePoints, int style, int fontCapitals) {#fetchDrFont-java.lang.String-float-int-int-}
+```
+public DrFont fetchDrFont(String familyName, float sizePoints, int style, int fontCapitals)
+```
+
+
+フォントファミリ名、サイズ、スタイル、フォント大文字で DrFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+| sizePoints | float | ポイント単位のフォントサイズ（1ポイントはインチの1/72です）。 |
+| スタイル | int | フォントスタイル。 |
+| fontCapitals | int | フォントの大文字。 |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont。
+### fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName) {#fetchDrFont-java.lang.String-float-int-java.lang.String-}
+```
+public DrFont fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName)
+```
+
+
+フォントファミリ名、サイズ、スタイル、代替フォントファミリ名で DrFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+| sizePoints | float | ポイント単位のフォントサイズ（1ポイントはインチの1/72です）。 |
+| スタイル | int | フォントスタイル。 |
+| altFamilyName | java.lang.String | 代替フォントファミリ名。 |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont。
+### fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName, int fontCapitals) {#fetchDrFont-java.lang.String-float-int-java.lang.String-int-}
+```
+public DrFont fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName, int fontCapitals)
+```
+
+
+フォントファミリ名、サイズ、スタイル、フォント大文字、代替フォントファミリ名で DrFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+| sizePoints | float | ポイント単位のフォントサイズ（1ポイントはインチの1/72です）。 |
+| スタイル | int | フォントスタイル。 |
+| altFamilyName | java.lang.String | 代替フォントファミリ名。 |
+| fontCapitals | int | フォントの大文字。 |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont。
+### fetchTTFont(String familyName, int style, String altFamilyName) {#fetchTTFont-java.lang.String-int-java.lang.String-}
+```
+public TTFont fetchTTFont(String familyName, int style, String altFamilyName)
+```
+
+
+フォントファミリ名、スタイル、代替フォントファミリ名で TTFont を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| familyName | java.lang.String | フォントファミリ名です。 |
+| スタイル | int | フォントスタイル。 |
+| altFamilyName | java.lang.String | 代替フォントファミリ名。 |
+
+**Returns:**
+com.aspose.foundation.truetype.TTFont - TTFont。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] additionalFontFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public static void setAdditionalFontsFolders(String[] additionalFontFolders)
+```
+
+
+追加のフォントフォルダーを指定します。OS が使用するフォントフォルダーはデフォルトで ExternalFont Cache に使用されます。これらを定義する必要はありません、
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| additionalFontFolders | java.lang.String[] | 追加のフォントフォルダーの配列です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/iglyph/_index.md
+++ b/japanese/java/com.aspose.page/iglyph/_index.md
@@ -1,0 +1,71 @@
+---
+title: "IGlyph"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このインターフェイスは、グリフの主要パラメータへのアクセスを提供します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.page/iglyph/
+---```
+public interface IGlyph
+```
+
+This interface give access to main parameters of glyph.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAdvanceWidth()](#getAdvanceWidth--) | Gets advanced width of the glyph. |
+| [getCharCode()](#getCharCode--) | Gets char code of the glyph. |
+| [getCharName()](#getCharName--) | Gets character name. |
+| [getGlyphVector()](#getGlyphVector--) | Gets glyphs vectors. |
+| [getLeftSideBearing()](#getLeftSideBearing--) | Gets left side bearing of the glyph. |
+### getAdvanceWidth() {#getAdvanceWidth--}
+```
+public abstract float getAdvanceWidth()
+```
+
+
+Gets advanced width of the glyph.
+
+**Returns:**
+float - Advanced width.
+### getCharCode() {#getCharCode--}
+```
+public abstract char getCharCode()
+```
+
+
+Gets char code of the glyph.
+
+**Returns:**
+char - A char code.
+### getCharName() {#getCharName--}
+```
+public abstract String getCharName()
+```
+
+
+Gets character name.
+
+**Returns:**
+java.lang.String - Character name
+### getGlyphVector() {#getGlyphVector--}
+```
+public abstract GlyphVector getGlyphVector()
+```
+
+
+Gets glyphs vectors.
+
+**Returns:**
+java.awt.font.GlyphVector - Glyphs vectors.
+### getLeftSideBearing() {#getLeftSideBearing--}
+```
+public abstract float getLeftSideBearing()
+```
+
+
+Gets left side bearing of the glyph.
+
+**Returns:**
+float - Left side bearing of the glyph.

--- a/japanese/java/com.aspose.page/iinteractivedevice/_index.md
+++ b/japanese/java/com.aspose.page/iinteractivedevice/_index.md
@@ -1,0 +1,75 @@
+---
+title: "IInteractiveDevice"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "インタラクティブ機能の処理メソッドを定義するインターフェイスです。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.page/iinteractivedevice/
+---```
+public interface IInteractiveDevice
+```
+
+The interface defining interactive features processing methods.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [addOutline(int outlineLevel, String description)](#addOutline-int-java.lang.String-) | Adds an outline item with the last object as its target. |
+| [addOutline(Point2D origin, int outlineLevel, String description)](#addOutline-java.awt.geom.Point2D-int-java.lang.String-) | Adds an outline item with the origin point as its target. |
+| [setHyperlinkTarget(int targetPageNumber)](#setHyperlinkTarget-int-) | Set the hyperlink with a page number as its target. |
+| [setHyperlinkTarget(String targetUri)](#setHyperlinkTarget-java.lang.String-) | Set the hyperlink with an external URI as its target. |
+### addOutline(int outlineLevel, String description) {#addOutline-int-java.lang.String-}
+```
+public abstract void addOutline(int outlineLevel, String description)
+```
+
+
+Adds an outline item with the last object as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| outlineLevel | int | The outline level. |
+| description | java.lang.String | The item description. |
+
+### addOutline(Point2D origin, int outlineLevel, String description) {#addOutline-java.awt.geom.Point2D-int-java.lang.String-}
+```
+public abstract void addOutline(Point2D origin, int outlineLevel, String description)
+```
+
+
+Adds an outline item with the origin point as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| origin | java.awt.geom.Point2D | The target origin. |
+| outlineLevel | int | The outline level. |
+| description | java.lang.String | The item description. |
+
+### setHyperlinkTarget(int targetPageNumber) {#setHyperlinkTarget-int-}
+```
+public abstract void setHyperlinkTarget(int targetPageNumber)
+```
+
+
+Set the hyperlink with a page number as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| targetPageNumber | int | The target page number. |
+
+### setHyperlinkTarget(String targetUri) {#setHyperlinkTarget-java.lang.String-}
+```
+public abstract void setHyperlinkTarget(String targetUri)
+```
+
+
+Set the hyperlink with an external URI as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| targetUri | java.lang.String | The target external URI. |
+

--- a/japanese/java/com.aspose.page/imageformat/_index.md
+++ b/japanese/java/com.aspose.page/imageformat/_index.md
@@ -1,0 +1,277 @@
+---
+title: "ImageFormat"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "この列挙は、PS/EPS から画像への変換でサポートされる画像フォーマットの可能な名前を含みます。"
+type: docs
+weight: 23
+url: /ja/java/com.aspose.page/imageformat/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum ImageFormat extends Enum<ImageFormat>
+```
+
+この列挙は、PS/EPS から画像への変換でサポートされる画像フォーマットの可能な名前を含みます。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BMP](#BMP) | BMP 画像形式。 |
+| [GIF](#GIF) | GIF 画像形式。 |
+| [JPEG](#JPEG) | JPEG 画像形式。 |
+| [PNG](#PNG) | PNG 画像形式。 |
+| [TIFF](#TIFF) | TIFF 画像形式。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final ImageFormat BMP
+```
+
+
+BMP 画像形式。
+
+### GIF {#GIF}
+```
+public static final ImageFormat GIF
+```
+
+
+GIF 画像形式。
+
+### JPEG {#JPEG}
+```
+public static final ImageFormat JPEG
+```
+
+
+JPEG 画像形式。
+
+### PNG {#PNG}
+```
+public static final ImageFormat PNG
+```
+
+
+PNG 画像形式。
+
+### TIFF {#TIFF}
+```
+public static final ImageFormat TIFF
+```
+
+
+TIFF 画像形式。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static ImageFormat valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat)
+### values() {#values--}
+```
+public static ImageFormat[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.ImageFormat[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/imultipagesaveoptions/_index.md
+++ b/japanese/java/com.aspose.page/imultipagesaveoptions/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IMultiPageSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "変換用のページ番号設定インターフェイスを定義します。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.page/imultipagesaveoptions/
+---```
+public interface IMultiPageSaveOptions
+```
+
+Defines the interface for setting page numbers for conversion.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getPageNumbers()](#getPageNumbers--) | Gets the array of numbers of pages to convert. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | Sets the array of numbers of pages to convert. |
+### getPageNumbers() {#getPageNumbers--}
+```
+public abstract int[] getPageNumbers()
+```
+
+
+Gets the array of numbers of pages to convert.
+
+**Returns:**
+int[] - The array of page numbers.
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public abstract void setPageNumbers(int[] value)
+```
+
+
+Sets the array of numbers of pages to convert.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | int[] | The array of page numbers. |
+

--- a/japanese/java/com.aspose.page/itrfont/_index.md
+++ b/japanese/java/com.aspose.page/itrfont/_index.md
@@ -1,0 +1,247 @@
+---
+title: "ITrFont"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このインターフェイスは、フォントの主要パラメータへのアクセスを提供します。"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.page/itrfont/
+---```
+public interface ITrFont
+```
+
+This interface give access to main parameters of font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [clone()](#clone--) | Clones the font. |
+| [deriveFont(float size)](#deriveFont-float-) | Creates equivalent of this font with new size. |
+| [deriveFont(float size, int style)](#deriveFont-float-int-) | Creates equivalent of this font with new size and style. |
+| [deriveFont(int style)](#deriveFont-int-) | Creates equivalent of this font with new style. |
+| [deriveFont(AffineTransform transform)](#deriveFont-java.awt.geom.AffineTransform-) | Creates equivalent of this font with new transform. |
+| [getCharStrings()](#getCharStrings--) | Gets a mapping between character name and glyph. |
+| [getCharWidth(char charValue)](#getCharWidth-char-) | Gets a width of character. |
+| [getEncoding()](#getEncoding--) | Gets encoding array. |
+| [getEncodingTable()](#getEncodingTable--) | Gets a name of the encoding. |
+| [getFID()](#getFID--) | Returns font identifier. |
+| [getFont()](#getFont--) | Gets DrFont corresponding to this font. |
+| [getFontName()](#getFontName--) | Gets a name of font. |
+| [getFontType()](#getFontType--) | Gets a type of font in Adobe classification. |
+| [getNativeFont()](#getNativeFont--) | Gets java.awt.Font corresponding to this font. |
+| [getOutline(char charValue, float x, float y)](#getOutline-char-float-float-) | Returns an outline of glyph in specified location. |
+| [getSize()](#getSize--) | Gets font size. |
+| [getStyle()](#getStyle--) | Gets font style. |
+| [getTransform()](#getTransform--) | Gets font transformation. |
+### clone() {#clone--}
+```
+public abstract ITrFont clone()
+```
+
+
+Clones the font.
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(float size) {#deriveFont-float-}
+```
+public abstract ITrFont deriveFont(float size)
+```
+
+
+Creates equivalent of this font with new size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| size | float | Size of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(float size, int style) {#deriveFont-float-int-}
+```
+public abstract ITrFont deriveFont(float size, int style)
+```
+
+
+Creates equivalent of this font with new size and style.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| size | float | Size of new font. |
+| style | int | Style of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(int style) {#deriveFont-int-}
+```
+public abstract ITrFont deriveFont(int style)
+```
+
+
+Creates equivalent of this font with new style.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| style | int | Style of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(AffineTransform transform) {#deriveFont-java.awt.geom.AffineTransform-}
+```
+public abstract ITrFont deriveFont(AffineTransform transform)
+```
+
+
+Creates equivalent of this font with new transform.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| transform | java.awt.geom.AffineTransform | Transformation of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### getCharStrings() {#getCharStrings--}
+```
+public abstract HashMap<String,IGlyph> getCharStrings()
+```
+
+
+Gets a mapping between character name and glyph.
+
+**Returns:**
+java.util.HashMap<java.lang.String,com.aspose.page.IGlyph> - A mapping between character name and glyph.
+### getCharWidth(char charValue) {#getCharWidth-char-}
+```
+public abstract float getCharWidth(char charValue)
+```
+
+
+Gets a width of character.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charValue | char | Character. |
+
+**Returns:**
+float - A width of character.
+### getEncoding() {#getEncoding--}
+```
+public abstract String[] getEncoding()
+```
+
+
+Gets encoding array.
+
+**Returns:**
+java.lang.String[] - An encoding array.
+### getEncodingTable() {#getEncodingTable--}
+```
+public abstract String getEncodingTable()
+```
+
+
+Gets a name of the encoding.
+
+**Returns:**
+java.lang.String - A name of the encoding.
+### getFID() {#getFID--}
+```
+public abstract int getFID()
+```
+
+
+Returns font identifier.
+
+**Returns:**
+int - font identifier
+### getFont() {#getFont--}
+```
+public abstract DrFont getFont()
+```
+
+
+Gets DrFont corresponding to this font.
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Gets a name of font.
+
+**Returns:**
+java.lang.String - Font name.
+### getFontType() {#getFontType--}
+```
+public abstract int getFontType()
+```
+
+
+Gets a type of font in Adobe classification.
+
+**Returns:**
+int - Font type.
+### getNativeFont() {#getNativeFont--}
+```
+public abstract Font getNativeFont()
+```
+
+
+Gets java.awt.Font corresponding to this font.
+
+**Returns:**
+java.awt.Font - Native font.
+### getOutline(char charValue, float x, float y) {#getOutline-char-float-float-}
+```
+public abstract Shape getOutline(char charValue, float x, float y)
+```
+
+
+Returns an outline of glyph in specified location.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charValue | char | Character. |
+| x | float | X coordinate of the character location. |
+| y | float | Y coordinate of the character location. |
+
+**Returns:**
+java.awt.Shape - An outline of glyph.
+### getSize() {#getSize--}
+```
+public abstract float getSize()
+```
+
+
+Gets font size.
+
+**Returns:**
+float - A size of the font.
+### getStyle() {#getStyle--}
+```
+public abstract int getStyle()
+```
+
+
+Gets font style.
+
+**Returns:**
+int - A style of the font.
+### getTransform() {#getTransform--}
+```
+public abstract AffineTransform getTransform()
+```
+
+
+Gets font transformation.
+
+**Returns:**
+java.awt.geom.AffineTransform - A transformation.

--- a/japanese/java/com.aspose.page/license/_index.md
+++ b/japanese/java/com.aspose.page/license/_index.md
@@ -1,0 +1,222 @@
+---
+title: "ライセンス"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "コンポーネントをライセンスするためのメソッドを提供します。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.page/license/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+コンポーネントをライセンスするためのメソッドを提供します。
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリアセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンスファイルを探す試みが行われます。
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [License()](#License--) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInternalFIPSSecurity()](#isInternalFIPSSecurity--) | デフォルトでは、デフォルトの JDK セキュリティを使用しています。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInternalFIPSSecurity(boolean internalFIPSSecurity)](#setInternalFIPSSecurity-boolean-) | デフォルトでは、デフォルトの JRE セキュリティを使用しています。 |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | コンポーネントにライセンスを付与します。 |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | コンポーネントにライセンスを付与します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリアセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンスファイルを探す試みが行われます。
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInternalFIPSSecurity() {#isInternalFIPSSecurity--}
+```
+public static boolean isInternalFIPSSecurity()
+```
+
+
+デフォルトでは、デフォルトの JDK セキュリティを使用しています。デフォルト値は false です。カスタマイズされた Java 環境が必要なアルゴリズムをサポートできない場合があり、その際は内部組み込みの FIPS セキュリティの使用を推奨します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInternalFIPSSecurity(boolean internalFIPSSecurity) {#setInternalFIPSSecurity-boolean-}
+```
+public static void setInternalFIPSSecurity(boolean internalFIPSSecurity)
+```
+
+
+デフォルトでは、デフォルトの JRE セキュリティを使用しています。デフォルト値は false です。カスタマイズされた Java 環境が必要なアルゴリズムをサポートできない場合があり、その際は内部組み込みの FIPS セキュリティの使用を推奨します。
+
+また注意してください：JVM SecureRandom アルゴリズムによると、いくつかのオペレーティングシステムでは /dev/random がホストマシンで \u201cnoise\u201d が一定量生成されるまで結果を返さずに待機します。Oracle\u2019s JVM での乱数生成に使用されるライブラリは、UNIX プラットフォームではデフォルトで /dev/random に依存しています。/dev/random はより安全ですが、デフォルトの JVM 設定で遅延が発生する場合は /dev/urandom の使用が推奨されます。または /dev/random 用にエントロピーを生成するデバイスを追加してください。
+
+以下の Java オプションは遅延を回避し、securerandom.source 設定を上書きするのに役立ちます。 -Djava.security.egd=file:/dev/./urandom
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| internalFIPSSecurity | boolean | boolean 値 |
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+ライセンスを含むストリームです。
+
+このメソッドを使用して、ストリームからライセンスをロードします。
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | license ストリーム |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+コンポーネントにライセンスを付与します。
+
+ライセンスを次の場所で検索します：
+
+1. 明示的なパス。
+
+2. コンポーネント JAR ファイルのフォルダー。
+
+この例では、コンポーネントが含まれるフォルダー、呼び出しアセンブリが含まれるフォルダー、エントリアセンブリのフォルダー、そして呼び出しアセンブリの埋め込みリソース内で、MyLicense.lic という名前のライセンスファイルを探す試みが行われます。
+
+License license = new License();
+license.setLicense("MyLicense.lic");
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| licenseName | java.lang.String | 完全または短いファイル名、または埋め込みリソースの名前を指定できます。空文字列を使用すると評価モードに切り替わります。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/metered/_index.md
+++ b/japanese/java/com.aspose.page/metered/_index.md
@@ -1,0 +1,203 @@
+---
+title: "従量課金"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "メーターキーを設定するためのメソッドを提供します。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.page/metered/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class Metered
+```
+
+メーターキーを設定するためのメソッドを提供します。
+
+--------------------
+
+この例では、従量課金の公開キーと秘密キーを設定しようとします。
+
+```
+The component jar file:
+  
+ 	Metered matered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Metered()](#Metered--) | このクラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clearMeteredLicense()](#clearMeteredLicense--) | 従量課金ライセンスをクリアします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [flush()](#flush--) | サーバー上のカウントデータをフラッシュします。 |
+| [getClass()](#getClass--) |  |
+| [getConsumptionCredit()](#getConsumptionCredit--) | 消費クレジットを取得します。 |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | 消費ファイルサイズを取得します |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | メーター付きの公開キーと秘密キーを設定します |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+このクラスの新しいインスタンスを初期化します。
+
+### clearMeteredLicense() {#clearMeteredLicense--}
+```
+public static void clearMeteredLicense()
+```
+
+
+従量課金ライセンスをクリアします。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### flush() {#flush--}
+```
+public static void flush()
+```
+
+
+サーバー上のカウントデータをフラッシュします。デバッグ目的でのみ使用されます。
+
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static double getConsumptionCredit()
+```
+
+
+消費クレジットを取得します。
+
+**Returns:**
+double - 消費量
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static double getConsumptionQuantity()
+```
+
+
+消費ファイルサイズを取得します
+
+**Returns:**
+double - 消費量
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+メーター付きの公開キーと秘密キーを設定します
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| publicKey | java.lang.String | 公開キー |
+| privateKey | java.lang.String | 秘密キー |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/saveoptions/_index.md
+++ b/japanese/java/com.aspose.page/saveoptions/_index.md
@@ -1,0 +1,341 @@
+---
+title: "SaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、変換プロセスの管理に必要なオプションを含んでいます。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.page/saveoptions/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class SaveOptions
+```
+
+このクラスは、変換プロセスの管理に必要なオプションを含んでいます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [SaveOptions()](#SaveOptions--) | フラグ suppressErrors (true) と debug (false) のデフォルト値で新しい SaveOptions インスタンスを初期化します。 |
+| [SaveOptions(boolean supressErrors)](#SaveOptions-boolean-) | フラグ debug (false) のデフォルト値で新しい SaveOptions インスタンスを初期化します。 |
+| [SaveOptions(Dimension size)](#SaveOptions-java.awt.Dimension-) | 指定されたサイズで SaveOptions の新しいインスタンスを初期化します。 |
+| [SaveOptions(boolean supressErrors, Dimension size)](#SaveOptions-boolean-java.awt.Dimension-) | フラグ debug (false) のデフォルト値と指定されたサイズで新しい SaveOptions インスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SaveOptions() {#SaveOptions--}
+```
+public SaveOptions()
+```
+
+
+フラグ suppressErrors (true) と debug (false) のデフォルト値で新しい SaveOptions インスタンスを初期化します。
+
+### SaveOptions(boolean supressErrors) {#SaveOptions-boolean-}
+```
+public SaveOptions(boolean supressErrors)
+```
+
+
+フラグ debug (false) のデフォルト値で新しい SaveOptions インスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+
+### SaveOptions(Dimension size) {#SaveOptions-java.awt.Dimension-}
+```
+public SaveOptions(Dimension size)
+```
+
+
+指定されたサイズで SaveOptions の新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | サイズです。 |
+
+### SaveOptions(boolean supressErrors, Dimension size) {#SaveOptions-boolean-java.awt.Dimension-}
+```
+public SaveOptions(boolean supressErrors, Dimension size)
+```
+
+
+フラグ debug (false) のデフォルト値と指定されたサイズで新しい SaveOptions インスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | true の場合、致命的でないエラーがあっても変換を続行します。 |
+| size | java.awt.Dimension | サイズです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/textrenderingmode/_index.md
+++ b/japanese/java/com.aspose.page/textrenderingmode/_index.md
@@ -1,0 +1,268 @@
+---
+title: "TextRenderingMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "この列挙は、テキストレンダリングモードの可能な値を含みます。"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.page/textrenderingmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TextRenderingMode extends Enum<TextRenderingMode>
+```
+
+この列挙は、テキストレンダリングモードの可能な値を含みます。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Fill](#Fill) | テキストを塗りつぶします。 |
+| [FillAndStroke](#FillAndStroke) | テキストを塗りつぶし、ストロークします。 |
+| [No](#No) | テキストを塗りつぶさず、ストロークもしません。 |
+| [Stroke](#Stroke) | テキストをストロークします。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fill {#Fill}
+```
+public static final TextRenderingMode Fill
+```
+
+
+テキストを塗りつぶします。
+
+### FillAndStroke {#FillAndStroke}
+```
+public static final TextRenderingMode FillAndStroke
+```
+
+
+テキストを塗りつぶし、ストロークします。
+
+### No {#No}
+```
+public static final TextRenderingMode No
+```
+
+
+テキストを塗りつぶさず、ストロークもしません。
+
+### Stroke {#Stroke}
+```
+public static final TextRenderingMode Stroke
+```
+
+
+テキストをストロークします。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TextRenderingMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[TextRenderingMode](../../com.aspose.page/textrenderingmode)
+### values() {#values--}
+```
+public static TextRenderingMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.TextRenderingMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/transformedstroke/_index.md
+++ b/japanese/java/com.aspose.page/transformedstroke/_index.md
@@ -1,0 +1,184 @@
+---
+title: "TransformedStroke"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "変換を含むストロークです。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.page/transformedstroke/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.awt.Stroke
+```
+public class TransformedStroke implements Stroke
+```
+
+変換を含むストロークです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TransformedStroke(Stroke base, AffineTransform at)](#TransformedStroke-java.awt.Stroke-java.awt.geom.AffineTransform-) | 別の Stroke と AffineTransform に基づいて TransformedStroke を作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createStrokedShape(Shape s)](#createStrokedShape-java.awt.Shape-) | このストロークで指定された Shape を描画し、アウトラインを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBaseStroke()](#getBaseStroke--) | 基本的なストロークを取得します。 |
+| [getClass()](#getClass--) |  |
+| [getTransform()](#getTransform--) | 変換を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TransformedStroke(Stroke base, AffineTransform at) {#TransformedStroke-java.awt.Stroke-java.awt.geom.AffineTransform-}
+```
+public TransformedStroke(Stroke base, AffineTransform at)
+```
+
+
+別の Stroke と AffineTransform に基づいて TransformedStroke を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| base | java.awt.Stroke | ストロークのベースです。 |
+| at | java.awt.geom.AffineTransform | アフィン変換です。 |
+
+### createStrokedShape(Shape s) {#createStrokedShape-java.awt.Shape-}
+```
+public Shape createStrokedShape(Shape s)
+```
+
+
+このストロークで指定された Shape を描画し、アウトラインを作成します。このアウトラインは、ベースストロークによって生成されるアウトラインに対して、当社の AffineTransform によって歪められますが、スケーリング（すなわち線の太さ）のみが適用され、平行移動と回転はストローク後に元に戻されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| s | java.awt.Shape | アウトライン化される Shape として。 |
+
+**Returns:**
+java.awt.Shape - 形状のアウトラインです。
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBaseStroke() {#getBaseStroke--}
+```
+public Stroke getBaseStroke()
+```
+
+
+基本的なストロークを取得します。
+
+**Returns:**
+java.awt.Stroke - 基本的なストロークです。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTransform() {#getTransform--}
+```
+public AffineTransform getTransform()
+```
+
+
+変換を取得します。
+
+**Returns:**
+java.awt.geom.AffineTransform - 変換です。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/units/_index.md
+++ b/japanese/java/com.aspose.page/units/_index.md
@@ -1,0 +1,277 @@
+---
+title: "単位"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "この列挙は、サイズ単位の可能な値を含みます。"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.page/units/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum Units extends Enum<Units>
+```
+
+この列挙は、サイズ単位の可能な値を含みます。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Centimeters](#Centimeters) | センチメートル。 |
+| [Inches](#Inches) | インチ。 |
+| [Millimeters](#Millimeters) | ミリメートル。 |
+| [Percents](#Percents) | 既存サイズのパーセント。 |
+| [Points](#Points) | ポイント（1/72 インチ）。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Centimeters {#Centimeters}
+```
+public static final Units Centimeters
+```
+
+
+センチメートル。
+
+### Inches {#Inches}
+```
+public static final Units Inches
+```
+
+
+インチ。
+
+### Millimeters {#Millimeters}
+```
+public static final Units Millimeters
+```
+
+
+ミリメートル。
+
+### Percents {#Percents}
+```
+public static final Units Percents
+```
+
+
+既存サイズのパーセント。
+
+### Points {#Points}
+```
+public static final Units Points
+```
+
+
+ポイント（1/72 インチ）。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static Units valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[Units](../../com.aspose.page/units)
+### values() {#values--}
+```
+public static Units[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.Units[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.page/userproperties/_index.md
+++ b/japanese/java/com.aspose.page/userproperties/_index.md
@@ -1,0 +1,1691 @@
+---
+title: "UserProperties"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "型付きプロパティの設定と取得を可能にする特別なプロパティクラスです。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.page/userproperties/
+---
+**Inheritance:**
+java.lang.Object, java.util.Dictionary, java.util.Hashtable, java.util.Properties
+```
+public class UserProperties extends Properties
+```
+
+型付きプロパティの設定と取得を可能にする特別なプロパティクラスです。また、このプロパティオブジェクトにプロパティが存在しない場合に検索される2つのデフォルトプロパティオブジェクトをフックアップすることもできます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [UserProperties()](#UserProperties--) | UserProperties クラスの空のインスタンスを初期化します。 |
+| [UserProperties(Properties defaults)](#UserProperties-java.util.Properties-) | UserProperties クラスをデフォルト値で初期化します。 |
+| [UserProperties(Properties defaults, Properties altDefaults)](#UserProperties-java.util.Properties-java.util.Properties-) | UserProperties を、デフォルトテーブルと代替デフォルトテーブル（この順序で検索されます）で構築します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [compute(K arg0, BiFunction<? super K,? super V,? extends V> arg1)](#compute-K-java.util.function.BiFunction---super-K---super-V---extends-V--) |  |
+| [compute(Object arg0, BiFunction<? super Object,? super Object,?> arg1)](#compute-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [computeIfAbsent(K arg0, Function<? super K,? extends V> arg1)](#computeIfAbsent-K-java.util.function.Function---super-K---extends-V--) |  |
+| [computeIfAbsent(Object arg0, Function<? super Object,?> arg1)](#computeIfAbsent-java.lang.Object-java.util.function.Function---super-java.lang.Object----) |  |
+| [computeIfPresent(K arg0, BiFunction<? super K,? super V,? extends V> arg1)](#computeIfPresent-K-java.util.function.BiFunction---super-K---super-V---extends-V--) |  |
+| [computeIfPresent(Object arg0, BiFunction<? super Object,? super Object,?> arg1)](#computeIfPresent-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsKey(Object arg0)](#containsKey-java.lang.Object-) |  |
+| [containsValue(Object arg0)](#containsValue-java.lang.Object-) |  |
+| [elements()](#elements--) |  |
+| [entrySet()](#entrySet--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(BiConsumer<? super K,? super V> arg0)](#forEach-java.util.function.BiConsumer---super-K---super-V--) |  |
+| [forEach(BiConsumer<? super Object,? super Object> arg0)](#forEach-java.util.function.BiConsumer---super-java.lang.Object---super-java.lang.Object--) |  |
+| [get(Object arg0)](#get-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOrDefault(Object arg0, V arg1)](#getOrDefault-java.lang.Object-V-) |  |
+| [getOrDefault(Object arg0, Object arg1)](#getOrDefault-java.lang.Object-java.lang.Object-) |  |
+| [getProperty(String key)](#getProperty-java.lang.String-) | 文字列プロパティの値を取得します。 |
+| [getProperty(String key, String def)](#getProperty-java.lang.String-java.lang.String-) | 文字列プロパティの値を取得します。 |
+| [getPropertyColor(String key)](#getPropertyColor-java.lang.String-) | 色プロパティの値を取得します。 |
+| [getPropertyColor(String key, Color def)](#getPropertyColor-java.lang.String-java.awt.Color-) | 色プロパティの値を取得します。 |
+| [getPropertyDimension(String key)](#getPropertyDimension-java.lang.String-) | 寸法プロパティの値を取得します。 |
+| [getPropertyDimension(String key, Dimension def)](#getPropertyDimension-java.lang.String-java.awt.Dimension-) | 寸法プロパティの値を取得します。 |
+| [getPropertyDouble(String key)](#getPropertyDouble-java.lang.String-) | double プロパティの値を取得します。 |
+| [getPropertyDouble(String key, double def)](#getPropertyDouble-java.lang.String-double-) | double プロパティの値を取得します。 |
+| [getPropertyFloat(String key)](#getPropertyFloat-java.lang.String-) | float プロパティの値を取得します。 |
+| [getPropertyFloat(String key, float def)](#getPropertyFloat-java.lang.String-float-) | float プロパティの値を取得します。 |
+| [getPropertyInsets(String key)](#getPropertyInsets-java.lang.String-) | インセットプロパティの値を取得します。 |
+| [getPropertyInsets(String key, Insets def)](#getPropertyInsets-java.lang.String-java.awt.Insets-) | インセットプロパティの値を取得します。 |
+| [getPropertyInt(String key)](#getPropertyInt-java.lang.String-) | integer プロパティの値を取得します。 |
+| [getPropertyInt(String key, int def)](#getPropertyInt-java.lang.String-int-) | integer プロパティの値を取得します。 |
+| [getPropertyMatrix(String key)](#getPropertyMatrix-java.lang.String-) | float プロパティの値を取得します。 |
+| [getPropertyMatrix(String key, AffineTransform def)](#getPropertyMatrix-java.lang.String-java.awt.geom.AffineTransform-) | float プロパティの値を取得します。 |
+| [getPropertyRectangle(String key)](#getPropertyRectangle-java.lang.String-) | rectangle プロパティの値を取得します。 |
+| [getPropertyRectangle(String key, Rectangle def)](#getPropertyRectangle-java.lang.String-java.awt.Rectangle-) | rectangle プロパティの値を取得します。 |
+| [getPropertyStringArray(String key)](#getPropertyStringArray-java.lang.String-) | string 配列プロパティの値を取得します。 |
+| [getPropertyStringArray(String key, String[] def)](#getPropertyStringArray-java.lang.String-java.lang.String---) | string 配列プロパティの値を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [isProperty(String key)](#isProperty-java.lang.String-) | boolean プロパティの値を取得します。 |
+| [isProperty(String key, boolean def)](#isProperty-java.lang.String-boolean-) | boolean プロパティの値を取得します。 |
+| [keySet()](#keySet--) |  |
+| [keys()](#keys--) |  |
+| [list(PrintStream arg0)](#list-java.io.PrintStream-) |  |
+| [list(PrintWriter arg0)](#list-java.io.PrintWriter-) |  |
+| [load(InputStream arg0)](#load-java.io.InputStream-) |  |
+| [load(Reader arg0)](#load-java.io.Reader-) |  |
+| [loadFromXML(InputStream arg0)](#loadFromXML-java.io.InputStream-) |  |
+| [merge(K arg0, V arg1, BiFunction<? super V,? super V,? extends V> arg2)](#merge-K-V-java.util.function.BiFunction---super-V---super-V---extends-V--) |  |
+| [merge(Object arg0, Object arg1, BiFunction<? super Object,? super Object,?> arg2)](#merge-java.lang.Object-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printProperties()](#printProperties--) | 設定されたすべてのプロパティを出力します。 |
+| [propertyNames()](#propertyNames--) | プロパティ名を返します。 |
+| [put(K arg0, V arg1)](#put-K-V-) |  |
+| [put(Object arg0, Object arg1)](#put-java.lang.Object-java.lang.Object-) |  |
+| [putAll(Map<? extends K,? extends V> arg0)](#putAll-java.util.Map---extends-K---extends-V--) |  |
+| [putAll(Map<?,?> arg0)](#putAll-java.util.Map------) |  |
+| [putIfAbsent(K arg0, V arg1)](#putIfAbsent-K-V-) |  |
+| [putIfAbsent(Object arg0, Object arg1)](#putIfAbsent-java.lang.Object-java.lang.Object-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [remove(Object arg0, Object arg1)](#remove-java.lang.Object-java.lang.Object-) |  |
+| [replace(K arg0, V arg1)](#replace-K-V-) |  |
+| [replace(K arg0, V arg1, V arg2)](#replace-K-V-V-) |  |
+| [replace(Object arg0, Object arg1)](#replace-java.lang.Object-java.lang.Object-) |  |
+| [replace(Object arg0, Object arg1, Object arg2)](#replace-java.lang.Object-java.lang.Object-java.lang.Object-) |  |
+| [replaceAll(BiFunction<? super K,? super V,? extends V> arg0)](#replaceAll-java.util.function.BiFunction---super-K---super-V---extends-V--) |  |
+| [replaceAll(BiFunction<? super Object,? super Object,?> arg0)](#replaceAll-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [save(OutputStream arg0, String arg1)](#save-java.io.OutputStream-java.lang.String-) |  |
+| [setProperties(Properties properties)](#setProperties-java.util.Properties-) | プロパティをコピーし、デフォルトもこの UserProperties に含めます。 |
+| [setProperty(String key, boolean value)](#setProperty-java.lang.String-boolean-) | boolean プロパティの値を設定します。 |
+| [setProperty(String key, double value)](#setProperty-java.lang.String-double-) | double プロパティの値を設定します。 |
+| [setProperty(String key, float value)](#setProperty-java.lang.String-float-) | float プロパティの値を設定します。 |
+| [setProperty(String key, int value)](#setProperty-java.lang.String-int-) | integer プロパティの値を設定します。 |
+| [setProperty(String key, Color value)](#setProperty-java.lang.String-java.awt.Color-) | 色プロパティの値を設定します。 |
+| [setProperty(String key, Dimension value)](#setProperty-java.lang.String-java.awt.Dimension-) | 寸法プロパティの値を設定します。 |
+| [setProperty(String key, Insets value)](#setProperty-java.lang.String-java.awt.Insets-) | インセットプロパティの値を設定します。 |
+| [setProperty(String key, Rectangle value)](#setProperty-java.lang.String-java.awt.Rectangle-) | rectangle プロパティの値を設定します。 |
+| [setProperty(String key, AffineTransform value)](#setProperty-java.lang.String-java.awt.geom.AffineTransform-) | matrix プロパティの値を設定します。 |
+| [setProperty(String key, String value)](#setProperty-java.lang.String-java.lang.String-) | string プロパティの値を設定します。 |
+| [setProperty(String key, String[] value)](#setProperty-java.lang.String-java.lang.String---) | string 配列プロパティの値を設定します。 |
+| [setProperty(Properties properties, String key, boolean value)](#setProperty-java.util.Properties-java.lang.String-boolean-) | 指定されたプロパティテーブルで boolean プロパティの値を設定します。 |
+| [setProperty(Properties properties, String key, double value)](#setProperty-java.util.Properties-java.lang.String-double-) | 指定されたプロパティテーブルで double プロパティの値を設定します。 |
+| [setProperty(Properties properties, String key, float value)](#setProperty-java.util.Properties-java.lang.String-float-) | 指定されたプロパティテーブルの float プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, int value)](#setProperty-java.util.Properties-java.lang.String-int-) | 指定されたプロパティテーブルの integer プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, Color value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Color-) | 指定されたプロパティテーブルの color プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, Dimension value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Dimension-) | 指定されたプロパティテーブルの dimension プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, Insets value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Insets-) | 指定されたプロパティテーブルの insets プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, Rectangle value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Rectangle-) | 指定されたプロパティテーブルの rectangle プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, AffineTransform value)](#setProperty-java.util.Properties-java.lang.String-java.awt.geom.AffineTransform-) | 指定されたプロパティテーブルの matrix プロパティ値を設定します。 |
+| [setProperty(Properties properties, String key, String[] value)](#setProperty-java.util.Properties-java.lang.String-java.lang.String---) | 指定されたプロパティテーブルの string array プロパティ値を設定します。 |
+| [size()](#size--) |  |
+| [store(OutputStream arg0, String arg1)](#store-java.io.OutputStream-java.lang.String-) |  |
+| [store(Writer arg0, String arg1)](#store-java.io.Writer-java.lang.String-) |  |
+| [storeToXML(OutputStream arg0, String arg1)](#storeToXML-java.io.OutputStream-java.lang.String-) |  |
+| [storeToXML(OutputStream arg0, String arg1, String arg2)](#storeToXML-java.io.OutputStream-java.lang.String-java.lang.String-) |  |
+| [storeToXML(OutputStream arg0, String arg1, Charset arg2)](#storeToXML-java.io.OutputStream-java.lang.String-java.nio.charset.Charset-) |  |
+| [stringPropertyNames()](#stringPropertyNames--) |  |
+| [toString()](#toString--) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UserProperties() {#UserProperties--}
+```
+public UserProperties()
+```
+
+
+UserProperties クラスの空のインスタンスを初期化します。
+
+### UserProperties(Properties defaults) {#UserProperties-java.util.Properties-}
+```
+public UserProperties(Properties defaults)
+```
+
+
+UserProperties クラスをデフォルト値で初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| デフォルト | java.util.Properties | デフォルトのプロパティ値です。 |
+
+### UserProperties(Properties defaults, Properties altDefaults) {#UserProperties-java.util.Properties-java.util.Properties-}
+```
+public UserProperties(Properties defaults, Properties altDefaults)
+```
+
+
+UserProperties を、デフォルトテーブルと代替デフォルトテーブル（この順序で検索されます）で構築します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| デフォルト | java.util.Properties | デフォルトのプロパティです。 |
+| altDefaults | java.util.Properties | 代替のデフォルトプロパティです。 |
+
+### clear() {#clear--}
+```
+public synchronized void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public synchronized Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### compute(K arg0, BiFunction<? super K,? super V,? extends V> arg1) {#compute-K-java.util.function.BiFunction---super-K---super-V---extends-V--}
+```
+public synchronized V compute(K arg0, BiFunction<? super K,? super V,? extends V> arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | java.util.function.BiFunction<? super K,? super V,? extends V> |  |
+
+**Returns:**
+V
+### compute(Object arg0, BiFunction<? super Object,? super Object,?> arg1) {#compute-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized Object compute(Object arg0, BiFunction<? super Object,? super Object,?> arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### computeIfAbsent(K arg0, Function<? super K,? extends V> arg1) {#computeIfAbsent-K-java.util.function.Function---super-K---extends-V--}
+```
+public synchronized V computeIfAbsent(K arg0, Function<? super K,? extends V> arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | java.util.function.Function<? super K,? extends V> |  |
+
+**Returns:**
+V
+### computeIfAbsent(Object arg0, Function<? super Object,?> arg1) {#computeIfAbsent-java.lang.Object-java.util.function.Function---super-java.lang.Object----}
+```
+public synchronized Object computeIfAbsent(Object arg0, Function<? super Object,?> arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.util.function.Function<? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### computeIfPresent(K arg0, BiFunction<? super K,? super V,? extends V> arg1) {#computeIfPresent-K-java.util.function.BiFunction---super-K---super-V---extends-V--}
+```
+public synchronized V computeIfPresent(K arg0, BiFunction<? super K,? super V,? extends V> arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | java.util.function.BiFunction<? super K,? super V,? extends V> |  |
+
+**Returns:**
+V
+### computeIfPresent(Object arg0, BiFunction<? super Object,? super Object,?> arg1) {#computeIfPresent-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized Object computeIfPresent(Object arg0, BiFunction<? super Object,? super Object,?> arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsKey(Object arg0) {#containsKey-java.lang.Object-}
+```
+public boolean containsKey(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsValue(Object arg0) {#containsValue-java.lang.Object-}
+```
+public boolean containsValue(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### elements() {#elements--}
+```
+public Enumeration<Object> elements()
+```
+
+
+
+
+**Returns:**
+java.util.Enumeration<java.lang.Object>
+### entrySet() {#entrySet--}
+```
+public Set<Map.Entry<Object,Object>> entrySet()
+```
+
+
+
+
+**Returns:**
+java.util.Set<java.util.Map.Entry<java.lang.Object,java.lang.Object>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public synchronized boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(BiConsumer<? super K,? super V> arg0) {#forEach-java.util.function.BiConsumer---super-K---super-V--}
+```
+public synchronized void forEach(BiConsumer<? super K,? super V> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiConsumer<? super K,? super V> |  |
+
+### forEach(BiConsumer<? super Object,? super Object> arg0) {#forEach-java.util.function.BiConsumer---super-java.lang.Object---super-java.lang.Object--}
+```
+public synchronized void forEach(BiConsumer<? super Object,? super Object> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiConsumer<? super java.lang.Object,? super java.lang.Object> |  |
+
+### get(Object arg0) {#get-java.lang.Object-}
+```
+public Object get(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOrDefault(Object arg0, V arg1) {#getOrDefault-java.lang.Object-V-}
+```
+public synchronized V getOrDefault(Object arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### getOrDefault(Object arg0, Object arg1) {#getOrDefault-java.lang.Object-java.lang.Object-}
+```
+public Object getOrDefault(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### getProperty(String key) {#getProperty-java.lang.String-}
+```
+public String getProperty(String key)
+```
+
+
+文字列プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.lang.String - プロパティ値。
+### getProperty(String key, String def) {#getProperty-java.lang.String-java.lang.String-}
+```
+public String getProperty(String key, String def)
+```
+
+
+文字列プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.lang.String | プロパティのデフォルト値。 |
+
+**Returns:**
+java.lang.String - プロパティ値。
+### getPropertyColor(String key) {#getPropertyColor-java.lang.String-}
+```
+public Color getPropertyColor(String key)
+```
+
+
+色プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Color - プロパティ値。
+### getPropertyColor(String key, Color def) {#getPropertyColor-java.lang.String-java.awt.Color-}
+```
+public Color getPropertyColor(String key, Color def)
+```
+
+
+カラー プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.awt.Color | プロパティのデフォルト値。 |
+
+**Returns:**
+java.awt.Color - プロパティ値。
+### getPropertyDimension(String key) {#getPropertyDimension-java.lang.String-}
+```
+public Dimension getPropertyDimension(String key)
+```
+
+
+寸法プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Dimension - プロパティ値。
+### getPropertyDimension(String key, Dimension def) {#getPropertyDimension-java.lang.String-java.awt.Dimension-}
+```
+public Dimension getPropertyDimension(String key, Dimension def)
+```
+
+
+次元プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.awt.Dimension | プロパティのデフォルト値。 |
+
+**Returns:**
+java.awt.Dimension - プロパティ値。
+### getPropertyDouble(String key) {#getPropertyDouble-java.lang.String-}
+```
+public double getPropertyDouble(String key)
+```
+
+
+double プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+double - プロパティ値。
+### getPropertyDouble(String key, double def) {#getPropertyDouble-java.lang.String-double-}
+```
+public double getPropertyDouble(String key, double def)
+```
+
+
+double プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | double | プロパティのデフォルト値。 |
+
+**Returns:**
+double - プロパティ値。
+### getPropertyFloat(String key) {#getPropertyFloat-java.lang.String-}
+```
+public float getPropertyFloat(String key)
+```
+
+
+float プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+float - プロパティ値。
+### getPropertyFloat(String key, float def) {#getPropertyFloat-java.lang.String-float-}
+```
+public float getPropertyFloat(String key, float def)
+```
+
+
+float プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | float | プロパティのデフォルト値。 |
+
+**Returns:**
+float - プロパティ値。
+### getPropertyInsets(String key) {#getPropertyInsets-java.lang.String-}
+```
+public Insets getPropertyInsets(String key)
+```
+
+
+インセットプロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Insets - プロパティ値。
+### getPropertyInsets(String key, Insets def) {#getPropertyInsets-java.lang.String-java.awt.Insets-}
+```
+public Insets getPropertyInsets(String key, Insets def)
+```
+
+
+インセット プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.awt.Insets | プロパティのデフォルト値。 |
+
+**Returns:**
+java.awt.Insets - プロパティ値。
+### getPropertyInt(String key) {#getPropertyInt-java.lang.String-}
+```
+public int getPropertyInt(String key)
+```
+
+
+integer プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+int - プロパティ値。
+### getPropertyInt(String key, int def) {#getPropertyInt-java.lang.String-int-}
+```
+public int getPropertyInt(String key, int def)
+```
+
+
+整数プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | int | プロパティのデフォルト値。 |
+
+**Returns:**
+int - プロパティ値。
+### getPropertyMatrix(String key) {#getPropertyMatrix-java.lang.String-}
+```
+public AffineTransform getPropertyMatrix(String key)
+```
+
+
+float プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.geom.AffineTransform - プロパティ値。
+### getPropertyMatrix(String key, AffineTransform def) {#getPropertyMatrix-java.lang.String-java.awt.geom.AffineTransform-}
+```
+public AffineTransform getPropertyMatrix(String key, AffineTransform def)
+```
+
+
+float プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.awt.geom.AffineTransform | プロパティのデフォルト値。 |
+
+**Returns:**
+java.awt.geom.AffineTransform - プロパティ値。
+### getPropertyRectangle(String key) {#getPropertyRectangle-java.lang.String-}
+```
+public Rectangle getPropertyRectangle(String key)
+```
+
+
+rectangle プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.awt.Rectangle - プロパティ値。
+### getPropertyRectangle(String key, Rectangle def) {#getPropertyRectangle-java.lang.String-java.awt.Rectangle-}
+```
+public Rectangle getPropertyRectangle(String key, Rectangle def)
+```
+
+
+矩形プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.awt.Rectangle | プロパティのデフォルト値。 |
+
+**Returns:**
+java.awt.Rectangle - プロパティ値。
+### getPropertyStringArray(String key) {#getPropertyStringArray-java.lang.String-}
+```
+public String[] getPropertyStringArray(String key)
+```
+
+
+string 配列プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+java.lang.String[] - プロパティ値。
+### getPropertyStringArray(String key, String[] def) {#getPropertyStringArray-java.lang.String-java.lang.String---}
+```
+public String[] getPropertyStringArray(String key, String[] def)
+```
+
+
+文字列配列プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | java.lang.String[] | プロパティのデフォルト値。 |
+
+**Returns:**
+java.lang.String[] - プロパティ値。
+### hashCode() {#hashCode--}
+```
+public synchronized int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### isProperty(String key) {#isProperty-java.lang.String-}
+```
+public boolean isProperty(String key)
+```
+
+
+boolean プロパティの値を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+
+**Returns:**
+boolean - プロパティ値。
+### isProperty(String key, boolean def) {#isProperty-java.lang.String-boolean-}
+```
+public boolean isProperty(String key, boolean def)
+```
+
+
+ブール型プロパティの値を取得します。要求されたプロパティが存在しない場合、提供されたデフォルト値を返します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| def | boolean | プロパティのデフォルト値。 |
+
+**Returns:**
+boolean - プロパティ値。
+### keySet() {#keySet--}
+```
+public Set<Object> keySet()
+```
+
+
+
+
+**Returns:**
+java.util.Set<java.lang.Object>
+### keys() {#keys--}
+```
+public Enumeration<Object> keys()
+```
+
+
+
+
+**Returns:**
+java.util.Enumeration<java.lang.Object>
+### list(PrintStream arg0) {#list-java.io.PrintStream-}
+```
+public void list(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### list(PrintWriter arg0) {#list-java.io.PrintWriter-}
+```
+public void list(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### load(InputStream arg0) {#load-java.io.InputStream-}
+```
+public synchronized void load(InputStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.InputStream |  |
+
+### load(Reader arg0) {#load-java.io.Reader-}
+```
+public synchronized void load(Reader arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.Reader |  |
+
+### loadFromXML(InputStream arg0) {#loadFromXML-java.io.InputStream-}
+```
+public synchronized void loadFromXML(InputStream arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.InputStream |  |
+
+### merge(K arg0, V arg1, BiFunction<? super V,? super V,? extends V> arg2) {#merge-K-V-java.util.function.BiFunction---super-V---super-V---extends-V--}
+```
+public synchronized V merge(K arg0, V arg1, BiFunction<? super V,? super V,? extends V> arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+| arg2 | java.util.function.BiFunction<? super V,? super V,? extends V> |  |
+
+**Returns:**
+V
+### merge(Object arg0, Object arg1, BiFunction<? super Object,? super Object,?> arg2) {#merge-java.lang.Object-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized Object merge(Object arg0, Object arg1, BiFunction<? super Object,? super Object,?> arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printProperties() {#printProperties--}
+```
+public void printProperties()
+```
+
+
+設定されたすべてのプロパティを出力します。
+
+### propertyNames() {#propertyNames--}
+```
+public Enumeration propertyNames()
+```
+
+
+プロパティ名を返します。
+
+**Returns:**
+java.util.Enumeration - プロパティ名の列挙。
+### put(K arg0, V arg1) {#put-K-V-}
+```
+public synchronized V put(K arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### put(Object arg0, Object arg1) {#put-java.lang.Object-java.lang.Object-}
+```
+public synchronized Object put(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### putAll(Map<? extends K,? extends V> arg0) {#putAll-java.util.Map---extends-K---extends-V--}
+```
+public synchronized void putAll(Map<? extends K,? extends V> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.util.Map<? extends K,? extends V> |  |
+
+### putAll(Map<?,?> arg0) {#putAll-java.util.Map------}
+```
+public synchronized void putAll(Map<?,?> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.util.Map<?,?> |  |
+
+### putIfAbsent(K arg0, V arg1) {#putIfAbsent-K-V-}
+```
+public synchronized V putIfAbsent(K arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### putIfAbsent(Object arg0, Object arg1) {#putIfAbsent-java.lang.Object-java.lang.Object-}
+```
+public synchronized Object putIfAbsent(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public synchronized Object remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### remove(Object arg0, Object arg1) {#remove-java.lang.Object-java.lang.Object-}
+```
+public synchronized boolean remove(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### replace(K arg0, V arg1) {#replace-K-V-}
+```
+public synchronized V replace(K arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### replace(K arg0, V arg1, V arg2) {#replace-K-V-V-}
+```
+public synchronized boolean replace(K arg0, V arg1, V arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+| arg2 | V |  |
+
+**Returns:**
+boolean
+### replace(Object arg0, Object arg1) {#replace-java.lang.Object-java.lang.Object-}
+```
+public synchronized Object replace(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### replace(Object arg0, Object arg1, Object arg2) {#replace-java.lang.Object-java.lang.Object-java.lang.Object-}
+```
+public synchronized boolean replace(Object arg0, Object arg1, Object arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### replaceAll(BiFunction<? super K,? super V,? extends V> arg0) {#replaceAll-java.util.function.BiFunction---super-K---super-V---extends-V--}
+```
+public synchronized void replaceAll(BiFunction<? super K,? super V,? extends V> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiFunction<? super K,? super V,? extends V> |  |
+
+### replaceAll(BiFunction<? super Object,? super Object,?> arg0) {#replaceAll-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized void replaceAll(BiFunction<? super Object,? super Object,?> arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+### save(OutputStream arg0, String arg1) {#save-java.io.OutputStream-java.lang.String-}
+```
+public void save(OutputStream arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+
+### setProperties(Properties properties) {#setProperties-java.util.Properties-}
+```
+public void setProperties(Properties properties)
+```
+
+
+プロパティをコピーし、デフォルトもこの UserProperties に含めます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティ。 |
+
+### setProperty(String key, boolean value) {#setProperty-java.lang.String-boolean-}
+```
+public Object setProperty(String key, boolean value)
+```
+
+
+boolean プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | boolean | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, double value) {#setProperty-java.lang.String-double-}
+```
+public Object setProperty(String key, double value)
+```
+
+
+double プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | double | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, float value) {#setProperty-java.lang.String-float-}
+```
+public Object setProperty(String key, float value)
+```
+
+
+float プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | float | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, int value) {#setProperty-java.lang.String-int-}
+```
+public Object setProperty(String key, int value)
+```
+
+
+integer プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | int | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, Color value) {#setProperty-java.lang.String-java.awt.Color-}
+```
+public Object setProperty(String key, Color value)
+```
+
+
+色プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Color | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, Dimension value) {#setProperty-java.lang.String-java.awt.Dimension-}
+```
+public Object setProperty(String key, Dimension value)
+```
+
+
+寸法プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Dimension | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, Insets value) {#setProperty-java.lang.String-java.awt.Insets-}
+```
+public Object setProperty(String key, Insets value)
+```
+
+
+インセットプロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Insets | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, Rectangle value) {#setProperty-java.lang.String-java.awt.Rectangle-}
+```
+public Object setProperty(String key, Rectangle value)
+```
+
+
+rectangle プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Rectangle | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, AffineTransform value) {#setProperty-java.lang.String-java.awt.geom.AffineTransform-}
+```
+public Object setProperty(String key, AffineTransform value)
+```
+
+
+matrix プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.geom.AffineTransform | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, String value) {#setProperty-java.lang.String-java.lang.String-}
+```
+public Object setProperty(String key, String value)
+```
+
+
+string プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.lang.String | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(String key, String[] value) {#setProperty-java.lang.String-java.lang.String---}
+```
+public Object setProperty(String key, String[] value)
+```
+
+
+string 配列プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.lang.String[] | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, boolean value) {#setProperty-java.util.Properties-java.lang.String-boolean-}
+```
+public static Object setProperty(Properties properties, String key, boolean value)
+```
+
+
+指定されたプロパティテーブルで boolean プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | boolean | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, double value) {#setProperty-java.util.Properties-java.lang.String-double-}
+```
+public static Object setProperty(Properties properties, String key, double value)
+```
+
+
+指定されたプロパティテーブルで double プロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | double | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, float value) {#setProperty-java.util.Properties-java.lang.String-float-}
+```
+public static Object setProperty(Properties properties, String key, float value)
+```
+
+
+指定されたプロパティテーブルの float プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | float | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, int value) {#setProperty-java.util.Properties-java.lang.String-int-}
+```
+public static Object setProperty(Properties properties, String key, int value)
+```
+
+
+指定されたプロパティテーブルの integer プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | int | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, Color value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Color-}
+```
+public static Object setProperty(Properties properties, String key, Color value)
+```
+
+
+指定されたプロパティテーブルの color プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Color | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, Dimension value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Dimension-}
+```
+public static Object setProperty(Properties properties, String key, Dimension value)
+```
+
+
+指定されたプロパティテーブルの dimension プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Dimension | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, Insets value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Insets-}
+```
+public static Object setProperty(Properties properties, String key, Insets value)
+```
+
+
+指定されたプロパティテーブルの insets プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Insets | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, Rectangle value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Rectangle-}
+```
+public static Object setProperty(Properties properties, String key, Rectangle value)
+```
+
+
+指定されたプロパティテーブルの rectangle プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.Rectangle | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, AffineTransform value) {#setProperty-java.util.Properties-java.lang.String-java.awt.geom.AffineTransform-}
+```
+public static Object setProperty(Properties properties, String key, AffineTransform value)
+```
+
+
+指定されたプロパティテーブルの matrix プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.awt.geom.AffineTransform | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### setProperty(Properties properties, String key, String[] value) {#setProperty-java.util.Properties-java.lang.String-java.lang.String---}
+```
+public static Object setProperty(Properties properties, String key, String[] value)
+```
+
+
+指定されたプロパティテーブルの string array プロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| プロパティ | java.util.Properties | プロパティテーブル。 |
+| キー | java.lang.String | プロパティの名前です。 |
+| value | java.lang.String[] | プロパティの値。 |
+
+**Returns:**
+java.lang.Object - プロパティ。
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### store(OutputStream arg0, String arg1) {#store-java.io.OutputStream-java.lang.String-}
+```
+public void store(OutputStream arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+
+### store(Writer arg0, String arg1) {#store-java.io.Writer-java.lang.String-}
+```
+public void store(Writer arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.Writer |  |
+| arg1 | java.lang.String |  |
+
+### storeToXML(OutputStream arg0, String arg1) {#storeToXML-java.io.OutputStream-java.lang.String-}
+```
+public void storeToXML(OutputStream arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+
+### storeToXML(OutputStream arg0, String arg1, String arg2) {#storeToXML-java.io.OutputStream-java.lang.String-java.lang.String-}
+```
+public void storeToXML(OutputStream arg0, String arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.String |  |
+
+### storeToXML(OutputStream arg0, String arg1, Charset arg2) {#storeToXML-java.io.OutputStream-java.lang.String-java.nio.charset.Charset-}
+```
+public void storeToXML(OutputStream arg0, String arg1, Charset arg2)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.nio.charset.Charset |  |
+
+### stringPropertyNames() {#stringPropertyNames--}
+```
+public Set<String> stringPropertyNames()
+```
+
+
+
+
+**Returns:**
+java.util.Set<java.lang.String>
+### toString() {#toString--}
+```
+public synchronized String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### values() {#values--}
+```
+public Collection<Object> values()
+```
+
+
+
+
+**Returns:**
+java.util.Collection<java.lang.Object>
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.features.EventBasedModifications/_index.md
+++ b/japanese/java/com.aspose.xps.features.EventBasedModifications/_index.md
@@ -1,0 +1,26 @@
+---
+title: "com.aspose.xps.features.EventBasedModifications"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.xps.features.EventBasedModifications パッケージは、XPS ドキュメントのイベントベースの変更に関連するクラスを提供します。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.xps.features.eventbasedmodifications/
+---
+
+**com.aspose.xps.features.EventBasedModifications** パッケージは、XPS ドキュメントのイベントベースの変更に関連するクラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [BeforePageSavingEventHandler](../com.aspose.xps.features.eventbasedmodifications/beforepagesavingeventhandler) | ページ保存前イベントハンドラの基底クラスです。 |
+| [BeforeSavingEventArgs<T>](../com.aspose.xps.features.eventbasedmodifications/beforesavingeventargs) | さまざまな保存前イベントの引数用基底クラスを定義します。 |
+| [PageAPI](../com.aspose.xps.features.eventbasedmodifications/pageapi) | **Page** 要素の変更 API。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IBeforeSavingEventHandler<T>](../com.aspose.xps.features.eventbasedmodifications/ibeforesavingeventhandler) | 共通の保存前イベントハンドラインターフェイスを定義します。 |
+| [IModificationAPI](../com.aspose.xps.features.eventbasedmodifications/imodificationapi) | 任意の XPS 要素の変更 API の基本インターフェイスです。 |

--- a/japanese/java/com.aspose.xps.features.EventBasedModifications/beforepagesavingeventhandler/_index.md
+++ b/japanese/java/com.aspose.xps.features.EventBasedModifications/beforepagesavingeventhandler/_index.md
@@ -1,0 +1,154 @@
+---
+title: "BeforePageSavingEventHandler"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページ保存前イベントハンドラの基底クラスです。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.features.eventbasedmodifications/beforepagesavingeventhandler/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.xps.features.EventBasedModifications.IBeforeSavingEventHandler
+```
+public abstract class BeforePageSavingEventHandler implements EventBasedModifications.IBeforeSavingEventHandler<EventBasedModifications.PageAPI>
+```
+
+ページ保存前イベントハンドラの基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BeforePageSavingEventHandler()](#BeforePageSavingEventHandler--) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [handle(EventBasedModifications.BeforeSavingEventArgs<EventBasedModifications.PageAPI> args)](#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-com.aspose.xps.features.EventBasedModifications.PageAPI--) | イベントを処理します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BeforePageSavingEventHandler() {#BeforePageSavingEventHandler--}
+```
+public BeforePageSavingEventHandler()
+```
+
+
+新しいインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### handle(EventBasedModifications.BeforeSavingEventArgs<EventBasedModifications.PageAPI> args) {#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-com.aspose.xps.features.EventBasedModifications.PageAPI--}
+```
+public abstract void handle(EventBasedModifications.BeforeSavingEventArgs<EventBasedModifications.PageAPI> args)
+```
+
+
+イベントを処理します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| args | com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs<com.aspose.xps.features.EventBasedModifications.PageAPI> | イベント引数です。 |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.features.EventBasedModifications/beforesavingeventargs/_index.md
+++ b/japanese/java/com.aspose.xps.features.EventBasedModifications/beforesavingeventargs/_index.md
@@ -1,0 +1,179 @@
+---
+title: "BeforeSavingEventArgs"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "さまざまな保存前イベントの引数用基底クラスを定義します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.features.eventbasedmodifications/beforesavingeventargs/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class BeforeSavingEventArgs<T>
+```
+
+さまざまな保存前イベントの引数用基底クラスを定義します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAbsolutePageNumber()](#getAbsolutePageNumber--) | XPS パッケージ内のすべてのドキュメントにわたる現在の絶対ページ番号を返します。 |
+| [getClass()](#getClass--) |  |
+| [getDocumentNumber()](#getDocumentNumber--) | XPS パッケージ内の現在のドキュメント番号を返します。 |
+| [getElementAPI()](#getElementAPI--) | 保存されようとしている要素の変更 API を返します。 |
+| [getOutputPageNumber()](#getOutputPageNumber--) | 現在の出力番号を返します。 |
+| [getRelativePageNumber()](#getRelativePageNumber--) | XPS パッケージ内の現在のドキュメントに対する現在のページ番号を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAbsolutePageNumber() {#getAbsolutePageNumber--}
+```
+public int getAbsolutePageNumber()
+```
+
+
+XPS パッケージ内のすべてのドキュメントにわたる現在の絶対ページ番号を返します。
+
+**Returns:**
+int - XPS パッケージ内のすべてのドキュメントにわたる現在の絶対ページ番号です。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDocumentNumber() {#getDocumentNumber--}
+```
+public int getDocumentNumber()
+```
+
+
+XPS パッケージ内の現在のドキュメント番号を返します。
+
+**Returns:**
+int - XPS パッケージ内の現在のドキュメント番号です。
+### getElementAPI() {#getElementAPI--}
+```
+public T getElementAPI()
+```
+
+
+保存されようとしている要素の変更 API を返します。
+
+**Returns:**
+T - 保存されようとしている要素の変更 API です。
+### getOutputPageNumber() {#getOutputPageNumber--}
+```
+public int getOutputPageNumber()
+```
+
+
+現在の出力番号を返します。**AbsolutePageNumber** と **PageNumbers** の保存オプションが指定されている場合は異なります。
+
+**Returns:**
+int - 現在の出力番号です。
+### getRelativePageNumber() {#getRelativePageNumber--}
+```
+public int getRelativePageNumber()
+```
+
+
+XPS パッケージ内の現在のドキュメントに対する現在のページ番号を返します。
+
+**Returns:**
+int - XPS パッケージ内の現在のドキュメントに対する現在のページ番号です。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.features.EventBasedModifications/ibeforesavingeventhandler/_index.md
+++ b/japanese/java/com.aspose.xps.features.EventBasedModifications/ibeforesavingeventhandler/_index.md
@@ -1,0 +1,30 @@
+---
+title: "IBeforeSavingEventHandler"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の保存前イベントハンドラインターフェイスを定義します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.features.eventbasedmodifications/ibeforesavingeventhandler/
+---```
+public interface IBeforeSavingEventHandler<T>
+```
+
+Defines the common before-saving event handler interface.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [handle(EventBasedModifications.BeforeSavingEventArgs<T> args)](#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-T--) | Handles the event. |
+### handle(EventBasedModifications.BeforeSavingEventArgs<T> args) {#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-T--}
+```
+public abstract void handle(EventBasedModifications.BeforeSavingEventArgs<T> args)
+```
+
+
+Handles the event.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| args | [BeforeSavingEventArgs](../../com.aspose.xps.features.eventbasedmodifications/beforesavingeventargs) | Event arguments. |
+

--- a/japanese/java/com.aspose.xps.features.EventBasedModifications/imodificationapi/_index.md
+++ b/japanese/java/com.aspose.xps.features.EventBasedModifications/imodificationapi/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IModificationAPI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の XPS 要素変更 API の基本インターフェイスです。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.features.eventbasedmodifications/imodificationapi/
+---```
+public interface IModificationAPI
+```
+
+The basic interface for any XPS element's modification API.

--- a/japanese/java/com.aspose.xps.features.EventBasedModifications/pageapi/_index.md
+++ b/japanese/java/com.aspose.xps.features.EventBasedModifications/pageapi/_index.md
@@ -1,0 +1,1093 @@
+---
+title: "PageAPI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページ要素変更 API。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.features.eventbasedmodifications/pageapi/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.xps.features.EventBasedModifications.IModificationAPI](../../com.aspose.xps.features.eventbasedmodifications/imodificationapi)
+```
+public class PageAPI implements EventBasedModifications.IModificationAPI
+```
+
+**Page** 要素の変更 API。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>add(T element)](#-T-add-T-) | コンテンツ要素（Canvas、Path、または Glyphs）を追加します |
+| [<T>insert(int index, T element)](#-T-insert-int-T-) | ページのインデックス位置に要素（Canvas、Path、または Glyphs）を挿入します。 |
+| [<T>remove(T element)](#-T-remove-T-) | ページから要素を削除します。 |
+| [addCanvas()](#addCanvas--) | ページに新しいキャンバスを追加します。 |
+| [addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | ページに新しいグリフを追加します。 |
+| [addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | ページに新しいグリフを追加します。 |
+| [addOutlineEntry(String description, int outlineLevel, int targetPageNumber)](#addOutlineEntry-java.lang.String-int-int-) | ドキュメントにアウトラインエントリを追加します。 |
+| [addPath(XpsPathGeometry data)](#addPath-com.aspose.xps.XpsPathGeometry-) | ページに新しいパスを追加します。 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-) | 新しいストロークされた楕円弧セグメントを作成します。 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-) | 新しい楕円弧セグメントを作成します。 |
+| [createCanvas()](#createCanvas--) | 新しいキャンバスを作成します。 |
+| [createColor(XpsIccProfile iccProfile, float[] components)](#createColor-com.aspose.xps.XpsIccProfile-float...-) | ICCベースのカラースペースで新しい色を作成します。 |
+| [createColor(float r, float g, float b)](#createColor-float-float-float-) | scRGB カラースペースで新しい色を作成します。 |
+| [createColor(float a, float r, float g, float b)](#createColor-float-float-float-float-) | scRGB カラースペースで新しい色を作成します。 |
+| [createColor(int r, int g, int b)](#createColor-int-int-int-) | sRGB カラースペースで新しい色を作成します。 |
+| [createColor(int a, int r, int g, int b)](#createColor-int-int-int-int-) | sRGB カラースペースで新しい色を作成します。 |
+| [createColor(Color color)](#createColor-java.awt.Color-) | 新しい色を作成します。 |
+| [createColor(String path, float[] components)](#createColor-java.lang.String-float...-) | ICCベースのカラースペースで新しい色を作成します。 |
+| [createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 新しいグリフを作成します。 |
+| [createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 新しいグリフを作成します。 |
+| [createGradientStop(XpsColor color, float offset)](#createGradientStop-com.aspose.xps.XpsColor-float-) | 新しいグラデーションストップを作成します。 |
+| [createGradientStop(Color color, float offset)](#createGradientStop-java.awt.Color-float-) | 新しいグラデーションストップを作成します。 |
+| [createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 新しいイメージブラシを作成します。 |
+| [createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 新しいイメージブラシを作成します。 |
+| [createLinearGradientBrush(Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-) | 新しい線形グラデーションブラシを作成します。 |
+| [createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-) | 新しい線形グラデーションブラシを作成します。 |
+| [createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)](#createMatrix-float-float-float-float-float-float-) | 新しいアフィン変換行列を作成します。 |
+| [createPath(XpsPathGeometry data)](#createPath-com.aspose.xps.XpsPathGeometry-) | 新しいパスを作成します。 |
+| [createPathFigure(Point2D startPoint)](#createPathFigure-java.awt.geom.Point2D-) | 新しいオープンパス図形を作成します。 |
+| [createPathFigure(Point2D startPoint, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-boolean-) | 新しいパス図形を作成します。 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--) | 新しいオープンパス図形を作成します。 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-) | 新しいパス図形を作成します。 |
+| [createPathGeometry()](#createPathGeometry--) | 新しいパスジオメトリを作成します。 |
+| [createPathGeometry(String abbreviatedGeometry)](#createPathGeometry-java.lang.String-) | 省略形で指定された新しいパスジオメトリを作成します。 |
+| [createPathGeometry(List<XpsPathFigure> pathFigures)](#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--) | 指定されたパス図形のリストで新しいパスジオメトリを作成します。 |
+| [createPolyBezierSegment(Point2D[] points)](#createPolyBezierSegment-java.awt.geom.Point2D---) | ストロークされた立方ベジエ曲線の新しいセットを作成します。 |
+| [createPolyBezierSegment(Point2D[] points, boolean isStroked)](#createPolyBezierSegment-java.awt.geom.Point2D---boolean-) | 立方ベジエ曲線の新しいセットを作成します。 |
+| [createPolyLineSegment(Point2D[] points)](#createPolyLineSegment-java.awt.geom.Point2D---) | 任意の数の個々の頂点を含む新しいストロークされた多角形描画を作成します。 |
+| [createPolyLineSegment(Point2D[] points, boolean isStroked)](#createPolyLineSegment-java.awt.geom.Point2D---boolean-) | 任意の数の個々の頂点を含む新しい多角形描画を作成します。 |
+| [createPolyQuadraticBezierSegment(Point2D[] points)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---) | パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、ストロークされた二次ベジエ曲線の新しいセットを作成します。 |
+| [createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-) | パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、二次ベジエ曲線の新しいセットを作成します。 |
+| [createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 新しい放射状グラデーションブラシを作成します。 |
+| [createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 新しい放射状グラデーションブラシを作成します。 |
+| [createSolidColorBrush(XpsColor color)](#createSolidColorBrush-com.aspose.xps.XpsColor-) | 新しい単色ブラシを作成します。 |
+| [createSolidColorBrush(Color color)](#createSolidColorBrush-java.awt.Color-) | 新しい単色ブラシを作成します。 |
+| [createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)](#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 新しいビジュアルブラシを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | ページの高さを、実座標空間の単位で実数として返します。 |
+| [getPageCount()](#getPageCount--) | アクティブなドキュメントのページ数を返します。 |
+| [getTotalPageCount()](#getTotalPageCount--) | XPS ドキュメント内のすべてのドキュメントの総ページ数を返します。 |
+| [getUtils()](#getUtils--) | 正式な XPS 操作 API を超えるユーティリティを提供するオブジェクトを取得します。 |
+| [getWidth()](#getWidth--) | ページの幅を、実座標空間の単位で実数として返します。 |
+| [hashCode()](#hashCode--) |  |
+| [insertCanvas(int index)](#insertCanvas-int-) | ページの index 位置に新しいキャンバスを挿入します。 |
+| [insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)](#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | ページの index 位置に新しいグリフを挿入します。 |
+| [insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | ページの index 位置に新しいグリフを挿入します。 |
+| [insertPath(int index, XpsPathGeometry data)](#insertPath-int-com.aspose.xps.XpsPathGeometry-) | ページの index 位置に新しいパスを挿入します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | ページの index 位置から要素を削除します。 |
+| [setHeight(float value)](#setHeight-float-) | ページの高さを、実座標空間の単位で実数として設定します。 |
+| [setWidth(float value)](#setWidth-float-) | ページの幅を、実座標空間の単位で実数として設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>add(T element) {#-T-add-T-}
+```
+public T <T>add(T element)
+```
+
+
+コンテンツ要素（Canvas、Path、または Glyphs）を追加します
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 要素 | T | 追加する要素です。 |
+
+**Returns:**
+T - 追加された要素。
+### <T>insert(int index, T element) {#-T-insert-int-T-}
+```
+public T <T>insert(int index, T element)
+```
+
+
+ページのインデックス位置に要素（Canvas、Path、または Glyphs）を挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素を挿入すべき位置。 |
+| 要素 | T | 挿入する要素。 |
+
+**Returns:**
+T - 挿入された要素。
+### <T>remove(T element) {#-T-remove-T-}
+```
+public T <T>remove(T element)
+```
+
+
+ページから要素を削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 要素 | T | 削除する要素。 |
+
+**Returns:**
+T - 削除された要素。
+### addCanvas() {#addCanvas--}
+```
+public XpsCanvas addCanvas()
+```
+
+
+ページに新しいキャンバスを追加します。
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Added canvas.
+### addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+ページに新しいグリフを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | フォントリソース。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+ページに新しいグリフを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addOutlineEntry(String description, int outlineLevel, int targetPageNumber) {#addOutlineEntry-java.lang.String-int-int-}
+```
+public void addOutlineEntry(String description, int outlineLevel, int targetPageNumber)
+```
+
+
+ドキュメントにアウトラインエントリを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 説明 | java.lang.String | エントリの説明。 |
+| outlineLevel | int | アウトラインレベル。 |
+| targetPageNumber | int | 対象ページ番号。 |
+
+### addPath(XpsPathGeometry data) {#addPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath addPath(XpsPathGeometry data)
+```
+
+
+ページに新しいパスを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Added path.
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)
+```
+
+
+新しいストロークされた楕円弧セグメントを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | java.awt.geom.Point2D | 楕円弧の終点。 |
+| size | java.awt.geom.Dimension2D | 楕円弧の x と y の半径（x,y のペア）。 |
+| rotationAngle | float | 楕円が現在の座標系に対してどのように回転しているかを示します。 |
+| isLargeArc | boolean | 弧が 180 度以上のスイープで描画されるかどうかを決定します。 |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 弧が描画される方向。 |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)
+```
+
+
+新しい楕円弧セグメントを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | java.awt.geom.Point2D | 楕円弧の終点。 |
+| size | java.awt.geom.Dimension2D | 楕円弧の x と y の半径（x,y のペア）。 |
+| rotationAngle | float | 楕円が現在の座標系に対してどのように回転しているかを示します。 |
+| isLargeArc | boolean | 弧が 180 度以上のスイープで描画されるかどうかを決定します。 |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 弧が描画される方向。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createCanvas() {#createCanvas--}
+```
+public XpsCanvas createCanvas()
+```
+
+
+新しいキャンバスを作成します。
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - New canvas.
+### createColor(XpsIccProfile iccProfile, float[] components) {#createColor-com.aspose.xps.XpsIccProfile-float...-}
+```
+public XpsColor createColor(XpsIccProfile iccProfile, float[] components)
+```
+
+
+ICCベースのカラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| iccProfile | [XpsIccProfile](../../com.aspose.xps/xpsiccprofile) | ICC プロファイルリソース。 |
+| components | float[] | 色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float r, float g, float b) {#createColor-float-float-float-}
+```
+public XpsColor createColor(float r, float g, float b)
+```
+
+
+scRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| r | float | 赤色コンポーネント。 |
+| g | float | 緑色コンポーネント。 |
+| b | float | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float a, float r, float g, float b) {#createColor-float-float-float-float-}
+```
+public XpsColor createColor(float a, float r, float g, float b)
+```
+
+
+scRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | float | アルファ色コンポーネント。 |
+| r | float | 赤色コンポーネント。 |
+| g | float | 緑色コンポーネント。 |
+| b | float | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int r, int g, int b) {#createColor-int-int-int-}
+```
+public XpsColor createColor(int r, int g, int b)
+```
+
+
+sRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| r | int | 赤色コンポーネント。 |
+| g | int | 緑色コンポーネント。 |
+| b | int | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int a, int r, int g, int b) {#createColor-int-int-int-int-}
+```
+public XpsColor createColor(int a, int r, int g, int b)
+```
+
+
+sRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | int | アルファ色コンポーネント。 |
+| r | int | 赤色コンポーネント。 |
+| g | int | 緑色コンポーネント。 |
+| b | int | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(Color color) {#createColor-java.awt.Color-}
+```
+public XpsColor createColor(Color color)
+```
+
+
+新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | java.awt.Color | RGB カラー用のネイティブカラーインスタンスです。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(String path, float[] components) {#createColor-java.lang.String-float...-}
+```
+public XpsColor createColor(String path, float[] components)
+```
+
+
+ICCベースのカラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.lang.String | ICC プロファイルへのパスです。 |
+| components | float[] | 色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+新しいグリフを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | フォントリソース。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+新しいグリフを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGradientStop(XpsColor color, float offset) {#createGradientStop-com.aspose.xps.XpsColor-float-}
+```
+public XpsGradientStop createGradientStop(XpsColor color, float offset)
+```
+
+
+新しいグラデーションストップを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | グラデーションストップカラーです。 |
+| オフセット | float | グラデーションのオフセットです。 |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createGradientStop(Color color, float offset) {#createGradientStop-java.awt.Color-float-}
+```
+public XpsGradientStop createGradientStop(Color color, float offset)
+```
+
+
+新しいグラデーションストップを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | java.awt.Color | グラデーションストップカラーです。 |
+| オフセット | float | グラデーションのオフセットです。 |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+新しいイメージブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | [XpsImage](../../com.aspose.xps/xpsimage) | 画像リソースです。 |
+| ビュー ボックス | java.awt.geom.Rectangle2D | ブラシのソースコンテンツの位置とサイズです。 |
+| ビューポート | java.awt.geom.Rectangle2D | プライムブラシタイルが含まれる座標空間内の領域で、（必要に応じて繰り返し）ブラシが適用される領域を埋めるために適用される領域です。 |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+新しいイメージブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| イメージパス | java.lang.String | ブラシタイルとして使用する画像へのパスです。 |
+| ビュー ボックス | java.awt.geom.Rectangle2D | ブラシのソースコンテンツの位置とサイズです。 |
+| ビューポート | java.awt.geom.Rectangle2D | プライムブラシタイルが含まれる座標空間内の領域で、（必要に応じて繰り返し）ブラシが適用される領域を埋めるために適用される領域です。 |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createLinearGradientBrush(Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(Point2D startPoint, Point2D endPoint)
+```
+
+
+新しい線形グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | 線形グラデーションの開始点です。 |
+| 終了点 | java.awt.geom.Point2D | 線形グラデーションの終了点です。 |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)
+```
+
+
+新しい線形グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| グラデーションストップ | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションストップのリストです。 |
+| 開始点 | java.awt.geom.Point2D | 線形グラデーションの開始点です。 |
+| 終了点 | java.awt.geom.Point2D | 線形グラデーションの終了点です。 |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createMatrix(float m11, float m12, float m21, float m22, float m31, float m32) {#createMatrix-float-float-float-float-float-float-}
+```
+public XpsMatrix createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)
+```
+
+
+新しいアフィン変換行列を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| m11 | float | 要素 11です。 |
+| m12 | float | 要素 12です。 |
+| m21 | float | 要素 21です。 |
+| m22 | float | 要素 22です。 |
+| m31 | float | 要素 31。 |
+| m32 | float | 要素 32。 |
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - New affine transformation matrix.
+### createPath(XpsPathGeometry data) {#createPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath createPath(XpsPathGeometry data)
+```
+
+
+新しいパスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - New path.
+### createPathFigure(Point2D startPoint) {#createPathFigure-java.awt.geom.Point2D-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint)
+```
+
+
+新しいオープンパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, boolean isClosed)
+```
+
+
+新しいパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+| isClosed | boolean | パスが閉じているかどうかを指定します。true に設定すると、ストロークは "closed" と描画され、つまりパス図形の最後のセグメントの最後の点が StartPoint 属性で指定された点と接続されます。false の場合、ストロークは "open" と描画され、最後の点は開始点と接続されません。これは、ストロークを指定する Path 要素でパス図形が使用されている場合にのみ適用されます。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)
+```
+
+
+新しいオープンパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | パスセグメントのリスト。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)
+```
+
+
+新しいパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | パスセグメントのリスト。 |
+| isClosed | boolean | パスが閉じているかどうかを指定します。true に設定すると、ストロークは "closed" と描画され、つまりパス図形の最後のセグメントの最後の点が StartPoint 属性で指定された点と接続されます。false の場合、ストロークは "open" と描画され、最後の点は開始点と接続されません。これは、ストロークを指定する Path 要素でパス図形が使用されている場合にのみ適用されます。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathGeometry() {#createPathGeometry--}
+```
+public XpsPathGeometry createPathGeometry()
+```
+
+
+新しいパスジオメトリを作成します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(String abbreviatedGeometry) {#createPathGeometry-java.lang.String-}
+```
+public XpsPathGeometry createPathGeometry(String abbreviatedGeometry)
+```
+
+
+省略形で指定された新しいパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| abbreviatedGeometry | java.lang.String | パスジオメトリの省略形。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(List<XpsPathFigure> pathFigures) {#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--}
+```
+public XpsPathGeometry createPathGeometry(List<XpsPathFigure> pathFigures)
+```
+
+
+指定されたパス図形のリストで新しいパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pathFigures | java.util.List<com.aspose.xps.XpsPathFigure> | パス図形のリスト。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPolyBezierSegment(Point2D[] points) {#createPolyBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points)
+```
+
+
+ストロークされた立方ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数のベジエセグメントの制御点。 |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyBezierSegment(Point2D[] points, boolean isStroked) {#createPolyBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+立方ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数のベジエセグメントの制御点。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyLineSegment(Point2D[] points) {#createPolyLineSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points)
+```
+
+
+任意の数の個々の頂点を含む新しいストロークされた多角形描画を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | ポリラインセグメントを定義する複数のセグメントの座標セット。 |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyLineSegment(Point2D[] points, boolean isStroked) {#createPolyLineSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points, boolean isStroked)
+```
+
+
+任意の数の個々の頂点を含む新しい多角形描画を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | ポリラインセグメントを定義する複数のセグメントの座標セット。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyQuadraticBezierSegment(Point2D[] points) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points)
+```
+
+
+パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、ストロークされた二次ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数の二次ベジエセグメントの制御点。 |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、二次ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数の二次ベジエセグメントの制御点。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+新しい放射状グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 放射状グラデーションの中心点（すなわち楕円の中心）。 |
+| gradientOrigin | java.awt.geom.Point2D | 放射状グラデーションの起点。 |
+| radiusX | float | 放射状グラデーションを定義する楕円の x 軸方向の半径です。 |
+| radiusY | float | 放射状グラデーションを定義する楕円の y 軸方向の半径です。 |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+新しい放射状グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| グラデーションストップ | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションストップのリストです。 |
+| center | java.awt.geom.Point2D | 放射状グラデーションの中心点（すなわち楕円の中心）。 |
+| gradientOrigin | java.awt.geom.Point2D | 放射状グラデーションの起点。 |
+| radiusX | float | 放射状グラデーションを定義する楕円の x 軸方向の半径です。 |
+| radiusY | float | 放射状グラデーションを定義する楕円の y 軸方向の半径です。 |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createSolidColorBrush(XpsColor color) {#createSolidColorBrush-com.aspose.xps.XpsColor-}
+```
+public XpsSolidColorBrush createSolidColorBrush(XpsColor color)
+```
+
+
+新しい単色ブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | 塗りつぶし要素の色です。 |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createSolidColorBrush(Color color) {#createSolidColorBrush-java.awt.Color-}
+```
+public XpsSolidColorBrush createSolidColorBrush(Color color)
+```
+
+
+新しい単色ブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | java.awt.Color | 塗りつぶし要素の色です。 |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport) {#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsVisualBrush createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+新しいビジュアルブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| element | [XpsContentElement](../../com.aspose.xps/xpscontentelement) | Visual プロパティのビジュアルブラシ用 XPS 要素（Canvas、Path、または Glyphs）。 |
+| ビュー ボックス | java.awt.geom.Rectangle2D | ブラシのソースコンテンツの位置とサイズです。 |
+| ビューポート | java.awt.geom.Rectangle2D | プライムブラシタイルが含まれる座標空間内の領域で、（必要に応じて繰り返し）ブラシが適用される領域を埋めるために適用される領域です。 |
+
+**Returns:**
+[XpsVisualBrush](../../com.aspose.xps/xpsvisualbrush) - New visual brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+ページの高さを、実座標空間の単位で実数として返します。
+
+**Returns:**
+float - ページの高さです。
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+アクティブなドキュメントのページ数を返します。
+
+**Returns:**
+int - アクティブなドキュメントのページ数です。
+### getTotalPageCount() {#getTotalPageCount--}
+```
+public int getTotalPageCount()
+```
+
+
+XPS ドキュメント内のすべてのドキュメントの総ページ数を返します。
+
+**Returns:**
+int - XPS ドキュメント内のすべてのドキュメントの総ページ数です。
+### getUtils() {#getUtils--}
+```
+public DocumentUtils getUtils()
+```
+
+
+正式な XPS 操作 API を超えるユーティリティを提供するオブジェクトを取得します。
+
+**Returns:**
+[DocumentUtils](../../com.aspose.xps/documentutils) - The object that provides utilities beyond the formal XPS manipulation API.
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+ページの幅を、実座標空間の単位で実数として返します。
+
+**Returns:**
+float - ページの幅です。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insertCanvas(int index) {#insertCanvas-int-}
+```
+public XpsCanvas insertCanvas(int index)
+```
+
+
+ページの index 位置に新しいキャンバスを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Canvas を挿入すべき位置です。 |
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Inserted canvas.
+### insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString) {#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)
+```
+
+
+ページの index 位置に新しいグリフを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Glyphs を挿入すべき位置です。 |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | フォントリソース。 |
+| fontSize | float | フォントサイズ。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+ページの index 位置に新しいグリフを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Glyphs を挿入すべき位置です。 |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertPath(int index, XpsPathGeometry data) {#insertPath-int-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath insertPath(int index, XpsPathGeometry data)
+```
+
+
+ページの index 位置に新しいパスを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Path を挿入すべき位置です。 |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Inserted path.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public XpsContentElement removeAt(int index)
+```
+
+
+ページの index 位置から要素を削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素を削除すべき位置です。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Removed element.
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+ページの高さを、実座標空間の単位で実数として設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ページの高さです。 |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+ページの幅を、実座標空間の単位で実数として設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ページの幅です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.features.HyperlinkCollector/_index.md
+++ b/japanese/java/com.aspose.xps.features.HyperlinkCollector/_index.md
@@ -1,0 +1,17 @@
+---
+title: "com.aspose.xps.features.HyperlinkCollector"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.xps.features.HyperlinkCollector パッケージは、ハイパーリンクを含む XPS 要素を収集するクラスを提供します。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.xps.features.hyperlinkcollector/
+---
+
+**com.aspose.xps.features.HyperlinkCollector** パッケージは、ハイパーリンクを含む XPS 要素を収集するクラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [HyperlinkCollector](../com.aspose.xps.features.hyperlinkcollector/hyperlinkcollector) | このクラスは、XPS ドキュメントの現在のページからハイパーリンク付き XPS 要素を収集します。 |

--- a/japanese/java/com.aspose.xps.features.HyperlinkCollector/hyperlinkcollector/_index.md
+++ b/japanese/java/com.aspose.xps.features.HyperlinkCollector/hyperlinkcollector/_index.md
@@ -1,0 +1,157 @@
+---
+title: "HyperlinkCollector"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、XPS ドキュメントの現在のページからハイパーリンク付き XPS 要素を収集します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.features.hyperlinkcollector/hyperlinkcollector/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HyperlinkCollector
+```
+
+このクラスは、XPS ドキュメントの現在のページからハイパーリンク付き XPS 要素を収集します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>collectHyperlinks(XpsDocument document, Class<T> cls)](#-T-collectHyperlinks-com.aspose.xps.XpsDocument-java.lang.Class-T--) | 特定のタイプのハイパーリンクを持つ XPS 要素を収集します。 |
+| [collectHyperlinks(XpsDocument document)](#collectHyperlinks-com.aspose.xps.XpsDocument-) | すべてのタイプのハイパーリンクを持つ XPS 要素を収集します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>collectHyperlinks(XpsDocument document, Class<T> cls) {#-T-collectHyperlinks-com.aspose.xps.XpsDocument-java.lang.Class-T--}
+```
+public static Collection<XpsHyperlinkElement> <T>collectHyperlinks(XpsDocument document, Class<T> cls)
+```
+
+
+特定のタイプのハイパーリンクを持つ XPS 要素を収集します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| document | [XpsDocument](../../com.aspose.xps/xpsdocument) | XPS ドキュメントです。 |
+| cls | java.lang.Class<T> | 除外するハイパーリンク対象タイプに対応するクラスオブジェクトです。 |
+
+**Returns:**
+java.util.Collection<com.aspose.xps.XpsHyperlinkElement> - ハイパーリンクされた XPS 要素を含むコレクションです。
+### collectHyperlinks(XpsDocument document) {#collectHyperlinks-com.aspose.xps.XpsDocument-}
+```
+public static Collection<XpsHyperlinkElement> collectHyperlinks(XpsDocument document)
+```
+
+
+すべてのタイプのハイパーリンクを持つ XPS 要素を収集します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| document | [XpsDocument](../../com.aspose.xps/xpsdocument) | XPS ドキュメントです。 |
+
+**Returns:**
+java.util.Collection<com.aspose.xps.XpsHyperlinkElement> - ハイパーリンクされた XPS 要素を含むコレクションです。
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/_index.md
@@ -1,0 +1,248 @@
+---
+title: "com.aspose.xps.metadata"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.xps.metadata パッケージは、XPS ドキュメントのメタデータを記述するクラスを提供します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.xps.metadata/
+---
+
+**com.aspose.xps.metadata** パッケージは、XPS ドキュメントのメタデータを記述するクラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [Collate](../com.aspose.xps.metadata/collate) | DocumentCollate と JobCollateAllDocuments 機能クラスの基底クラスです。 |
+| [Collate.CollateOption](../com.aspose.xps.metadata/collate.collateoption) | DocumentCollate と JobCollateAllDocuments 機能オプションを説明します。 |
+| [CompositePrintTicketElement](../com.aspose.xps.metadata/compositeprintticketelement) | 他の要素を含む可能性のある複合 Print Schema 要素の基底クラスです。 |
+| [DecimalValue](../com.aspose.xps.metadata/decimalvalue) | PrintTicket ドキュメント内の Decimal 値をカプセル化するクラスです。 |
+| [DocumentBannerSheet](../com.aspose.xps.metadata/documentbannersheet) | 特定のドキュメントに出力されるバナーシートを説明します。 |
+| [DocumentBannerSheet.BannerSheetOption](../com.aspose.xps.metadata/documentbannersheet.bannersheetoption) | DocumentBannerSheet 機能のオプションを表します。 |
+| [DocumentBannerSheetSource](../com.aspose.xps.metadata/documentbannersheetsource) | カスタムバナーシートのソースを指定します。 |
+| [DocumentBinding](../com.aspose.xps.metadata/documentbinding) | 製本方法を説明します。 |
+| [DocumentBinding.BindingGutter](../com.aspose.xps.metadata/documentbinding.bindinggutter) | BindingGutter のスコア付きプロパティ値を整数値で指定するか、DocumentBindingGutter パラメータへの参照で指定するかの方法を説明します。 |
+| [DocumentBinding.BindingOption](../com.aspose.xps.metadata/documentbinding.bindingoption) | DocumentBinding 機能のオプションを表します。 |
+| [DocumentBindingGutter](../com.aspose.xps.metadata/documentbindinggutter) | 製本用のガター幅を指定します。 |
+| [DocumentCollate](../com.aspose.xps.metadata/documentcollate) | 出力の段組特性を説明します。 |
+| [DocumentCopiesAllPages](../com.aspose.xps.metadata/documentcopiesallpages) | ドキュメントの部数を指定します。 |
+| [DocumentCoverBack](../com.aspose.xps.metadata/documentcoverback) | 裏表紙（終了）シートを説明します。 |
+| [DocumentCoverBack.CoverBackOption](../com.aspose.xps.metadata/documentcoverback.coverbackoption) | DocumentCoverBack 機能のオプションを説明します。 |
+| [DocumentCoverBackSource](../com.aspose.xps.metadata/documentcoverbacksource) | カスタム裏表紙シートのソースを指定します。 |
+| [DocumentCoverFront](../com.aspose.xps.metadata/documentcoverfront) | 表紙（開始）シートを説明します。 |
+| [DocumentCoverFront.CoverFrontOption](../com.aspose.xps.metadata/documentcoverfront.coverfrontoption) | DocumentCoverFront 機能のオプションを説明します。 |
+| [DocumentCoverFrontSource](../com.aspose.xps.metadata/documentcoverfrontsource) | カスタム表紙シートのソースを指定します。 |
+| [DocumentDuplex](../com.aspose.xps.metadata/documentduplex) | 出力の両面印刷特性を説明します。 |
+| [DocumentHolePunch](../com.aspose.xps.metadata/documentholepunch) | 出力の穴あけ特性を説明します。 |
+| [DocumentID](../com.aspose.xps.metadata/documentid) | ドキュメントの固有 ID を指定します。 |
+| [DocumentImpositionColor](../com.aspose.xps.metadata/documentimpositioncolor) | 指定された名前色でラベル付けされたアプリケーションコンテンツは、すべてのカラ―分離に必ず表示されなければなりません。 |
+| [DocumentInputBin](../com.aspose.xps.metadata/documentinputbin) | デバイスにインストールされた入力ビン、またはデバイスがサポートするビンの全リストを説明します。 |
+| [DocumentNUp](../com.aspose.xps.metadata/documentnup) | 複数の論理ページを単一の物理シートに出力する際の出力とフォーマットを説明します。 |
+| [DocumentName](../com.aspose.xps.metadata/documentname) | ドキュメントの記述的な名前を指定します。 |
+| [DocumentOutputBin](../com.aspose.xps.metadata/documentoutputbin) | デバイスでサポートされるビンの完全なリストを説明します。 |
+| [DocumentPageRanges](../com.aspose.xps.metadata/documentpageranges) | ドキュメントのページ単位での出力範囲を説明します。 |
+| [DocumentPrintTicket](../com.aspose.xps.metadata/documentprintticket) | ドキュメントレベルの印刷チケットをカプセル化するクラスです。 |
+| [DocumentRollCut](../com.aspose.xps.metadata/documentrollcut) | ロール紙のカット方法を説明します。 |
+| [DocumentSeparatorSheet](../com.aspose.xps.metadata/documentseparatorsheet) | ドキュメントのセパレータシートの使用方法を説明します。 |
+| [DocumentSeparatorSheet.DocumentSeparatorSheetOption](../com.aspose.xps.metadata/documentseparatorsheet.documentseparatorsheetoption) | DocumentSeparatorSheet 機能のオプションを説明します。 |
+| [DocumentStaple](../com.aspose.xps.metadata/documentstaple) | 出力のホチキス特性を説明します。 |
+| [DocumentURI](../com.aspose.xps.metadata/documenturi) | ドキュメントの統一リソース識別子 (URI) を指定します。 |
+| [Duplex](../com.aspose.xps.metadata/duplex) | JobDuplexAllDocumentsContiguously と DocumentDuplex 機能クラスの基底クラスです。 |
+| [Duplex.DuplexMode](../com.aspose.xps.metadata/duplex.duplexmode) | DuplexOption の DuplexMode スコアドプロパティの可能な値を定義します。 |
+| [Duplex.DuplexOption](../com.aspose.xps.metadata/duplex.duplexoption) | JobDuplexAllDocumentsContiguously と DocumentDuplex 機能のオプションを説明します。 |
+| [Feature](../com.aspose.xps.metadata/feature) | 共通の Print Schema 機能をカプセル化するクラスです。 |
+| [HolePunch](../com.aspose.xps.metadata/holepunch) | JobHolePunch と DocumentHolePunch 機能クラスの基底クラスです。 |
+| [HolePunch.HolePunchOption](../com.aspose.xps.metadata/holepunch.holepunchoption) | HolePunch 機能のオプションを説明します。 |
+| [IDProperty](../com.aspose.xps.metadata/idproperty) | JobID と DocumentID プロパティクラスの基底クラスです。 |
+| [InputBin](../com.aspose.xps.metadata/inputbin) | JobInputBin、DocumentInputBin、PageInputBin 機能クラスの基底クラスです。 |
+| [InputBin.BinType](../com.aspose.xps.metadata/inputbin.bintype) | BinType スコアドプロパティ値の定数を定義します。 |
+| [InputBin.FeedDirection](../com.aspose.xps.metadata/inputbin.feeddirection) | FeedDirection スコアドプロパティ値の定数を定義します。 |
+| [InputBin.FeedFace](../com.aspose.xps.metadata/inputbin.feedface) | FeedFace スコアドプロパティ値の定数を定義します。 |
+| [InputBin.FeedType](../com.aspose.xps.metadata/inputbin.feedtype) | FeedType スコアドプロパティ値の定数を定義します。 |
+| [InputBin.InputBinOption](../com.aspose.xps.metadata/inputbin.inputbinoption) | JobInputBin、DocumentInputBin、PageInputBin 機能のオプションを説明します。 |
+| [InputBin.MediaCapacity](../com.aspose.xps.metadata/inputbin.mediacapacity) | MediaCapacity スコアドプロパティ値の定数を定義し、ビンが高容量ビンかどうか（定性的）を指定します。 |
+| [InputBin.MediaPath](../com.aspose.xps.metadata/inputbin.mediapath) | MediaPath スコアドプロパティ値の定数を定義します。 |
+| [InputBin.MediaSheetCapacity](../com.aspose.xps.metadata/inputbin.mediasheetcapacity) | MediaSheetCapacity スコアドプロパティ値を定義し、ビンのページ数（フルレベル）でのメディア容量を指定します。 |
+| [InputBin.MediaSizeAutoSense](../com.aspose.xps.metadata/inputbin.mediasizeautosense) | MediaSizeAutoSense のスコア付きプロパティ値の定数を定義します。 |
+| [InputBin.MediaTypeAutoSense](../com.aspose.xps.metadata/inputbin.mediatypeautosense) | MediaTypeAutoSense のスコア付きプロパティ値の定数を定義します。 |
+| [IntegerParameterInit](../com.aspose.xps.metadata/integerparameterinit) | すべての整数パラメータ初期化子の基底クラスです。 |
+| [IntegerValue](../com.aspose.xps.metadata/integervalue) | PrintTicket ドキュメントで整数値をカプセル化するクラスです。 |
+| [JobAccountingSheet](../com.aspose.xps.metadata/jobaccountingsheet) | ジョブの出力対象となる会計シートを記述します。 |
+| [JobAccountingSheet.JobAccountingSheetOption](../com.aspose.xps.metadata/jobaccountingsheet.jobaccountingsheetoption) | JobAccountingSheet 機能のオプションを記述します。 |
+| [JobBindAllDocuments](../com.aspose.xps.metadata/jobbindalldocuments) | 製本方法を説明します。 |
+| [JobBindAllDocuments.BindingGutter](../com.aspose.xps.metadata/jobbindalldocuments.bindinggutter) | BindingGutter のスコア付きプロパティ値を整数値で指定するか、DocumentBindingGutter パラメータへの参照で指定するかの方法を説明します。 |
+| [JobBindAllDocuments.BindingOption](../com.aspose.xps.metadata/jobbindalldocuments.bindingoption) | JobBindAllDocuments 機能のオプションを記述します。 |
+| [JobBindAllDocumentsGutter](../com.aspose.xps.metadata/jobbindalldocumentsgutter) | 製本用のガター幅を指定します。 |
+| [JobCollateAllDocuments](../com.aspose.xps.metadata/jobcollatealldocuments) | 出力の段組特性を説明します。 |
+| [JobComment](../com.aspose.xps.metadata/jobcomment) | ジョブに関連付けられたコメントを指定します。 |
+| [JobCopiesAllDocuments](../com.aspose.xps.metadata/jobcopiesalldocuments) | ジョブのコピー数を指定します。 |
+| [JobDeviceLanguage](../com.aspose.xps.metadata/jobdevicelanguage) | ドライバーから物理デバイスへデータを送信する際にサポートされるデバイス言語を記述します。 |
+| [JobDeviceLanguage.JobDeviceLanguageOption](../com.aspose.xps.metadata/jobdevicelanguage.jobdevicelanguageoption) | JobDeviceLanguage 機能のオプションを記述します。 |
+| [JobDigitalSignatureProcessing](../com.aspose.xps.metadata/jobdigitalsignatureprocessing) | ジョブ全体のデジタル署名処理の構成方法を記述します。 |
+| [JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption](../com.aspose.xps.metadata/jobdigitalsignatureprocessing.jobdigitalsignatureprocessingoption) | JobDigitalSignatureProcessing 機能のオプションを記述します。 |
+| [JobDuplexAllDocumentsContiguously](../com.aspose.xps.metadata/jobduplexalldocumentscontiguously) | 出力の両面印刷特性を説明します。 |
+| [JobErrorSheet](../com.aspose.xps.metadata/joberrorsheet) | エラー�シートの出力を記述します。 |
+| [JobErrorSheet.ErrorSheetOption](../com.aspose.xps.metadata/joberrorsheet.errorsheetoption) | JobErrorSheet 機能のオプションを記述します。 |
+| [JobErrorSheet.ErrorSheetWhen](../com.aspose.xps.metadata/joberrorsheet.errorsheetwhen) | ErrorSheetWhen の内部機能を記述します。 |
+| [JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption](../com.aspose.xps.metadata/joberrorsheet.errorsheetwhen.errorsheetwhenoption) | ErrorSheetWhen 機能のオプションを記述します。 |
+| [JobErrorSheetSource](../com.aspose.xps.metadata/joberrorsheetsource) | カスタムエラー�シートのソースを指定します。 |
+| [JobHolePunch](../com.aspose.xps.metadata/jobholepunch) | 出力の穴あけ特性を説明します。 |
+| [JobID](../com.aspose.xps.metadata/jobid) | ジョブの一意の ID を指定します。 |
+| [JobInputBin](../com.aspose.xps.metadata/jobinputbin) | デバイスにインストールされた入力ビン、またはデバイスがサポートするビンの全リストを説明します。 |
+| [JobNUpAllDocumentsContiguously](../com.aspose.xps.metadata/jobnupalldocumentscontiguously) | 複数の論理ページを 1 枚の物理シートに出力する方法を記述します。 |
+| [JobName](../com.aspose.xps.metadata/jobname) | ジョブの説明名を指定します。 |
+| [JobOptimalDestinationColorProfile](../com.aspose.xps.metadata/joboptimaldestinationcolorprofile) | 現在のデバイス構成に基づく最適なカラープロファイルを指定します。 |
+| [JobOptimalDestinationColorProfile.Profile](../com.aspose.xps.metadata/joboptimaldestinationcolorprofile.profile) | 利用可能なカラープロファイルを記述します。 |
+| [JobOutputBin](../com.aspose.xps.metadata/joboutputbin) | デバイスにインストールされた出力ビン、またはデバイスがサポートするビンの全リストを記述します。 |
+| [JobOutputOptimization](../com.aspose.xps.metadata/joboutputoptimization) | 指定されたオプションで示される特定の使用シナリオに合わせて出力を最適化することを目的としたジョブ処理を記述します。 |
+| [JobOutputOptimization.JobOutputOptimizationOption](../com.aspose.xps.metadata/joboutputoptimization.joboutputoptimizationoption) | JobOutputOptimization機能のオプションを説明します。 |
+| [JobPageOrder](../com.aspose.xps.metadata/jobpageorder) | 出力の物理ページの順序を定義します。 |
+| [JobPageOrder.JobPageOrderOption](../com.aspose.xps.metadata/jobpageorder.jobpageorderoption) | JobPageOrder機能のオプションを説明します。 |
+| [JobPrimaryBannerSheet](../com.aspose.xps.metadata/jobprimarybannersheet) | ジョブの出力バナーシートを説明します。 |
+| [JobPrimaryBannerSheet.BannerSheetOption](../com.aspose.xps.metadata/jobprimarybannersheet.bannersheetoption) | JobPrimaryBannerSheet機能のオプションを表します。 |
+| [JobPrimaryBannerSheetSource](../com.aspose.xps.metadata/jobprimarybannersheetsource) | ジョブのプライマリカスタムバナーシートのソースを指定します。 |
+| [JobPrimaryCoverBack](../com.aspose.xps.metadata/jobprimarycoverback) | 裏表紙（終了）シートを説明します。 |
+| [JobPrimaryCoverBack.CoverBackOption](../com.aspose.xps.metadata/jobprimarycoverback.coverbackoption) | JobPrimaryCoverBack機能のオプションを説明します。 |
+| [JobPrimaryCoverBackSource](../com.aspose.xps.metadata/jobprimarycoverbacksource) | ジョブのカスタム裏表紙プライマリシートのソースを指定します。 |
+| [JobPrimaryCoverFront](../com.aspose.xps.metadata/jobprimarycoverfront) | 表紙（開始）シートを説明します。 |
+| [JobPrimaryCoverFront.CoverFrontOption](../com.aspose.xps.metadata/jobprimarycoverfront.coverfrontoption) | JobPrimaryCoverFront機能のオプションを説明します。 |
+| [JobPrimaryCoverFrontSource](../com.aspose.xps.metadata/jobprimarycoverfrontsource) | ジョブのカスタム表紙プライマリシートのソースを指定します。 |
+| [JobPrintTicket](../com.aspose.xps.metadata/jobprintticket) | ジョブレベルの印刷チケットをカプセル化するクラスです。 |
+| [JobRollCutAtEndOfJob](../com.aspose.xps.metadata/jobrollcutatendofjob) | ロール紙のカット方法を説明します。 |
+| [JobStapleAllDocuments](../com.aspose.xps.metadata/jobstaplealldocuments) | 出力のホチキス特性を説明します。 |
+| [JobURI](../com.aspose.xps.metadata/joburi) | ドキュメントの統一リソース識別子 (URI) を指定します。 |
+| [NUp](../com.aspose.xps.metadata/nup) | JobNUpAllDocumentsContiguously と DocumentNUp 機能クラスの基底クラスです。 |
+| [NUp.PresentationDirection](../com.aspose.xps.metadata/nup.presentationdirection) | 内部 PresentationDirection 機能を説明します。 |
+| [NUp.PresentationDirection.PresentationDirectionOption](../com.aspose.xps.metadata/nup.presentationdirection.presentationdirectionoption) | PresentationDirection 機能のオプションを説明します。 |
+| [NameProperty](../com.aspose.xps.metadata/nameproperty) | JobName と DocumentName プロパティクラスの基底クラスです。 |
+| [Option](../com.aspose.xps.metadata/option) | 共通 PrintTicket オプションを実装するクラスです。 |
+| [OutputBin](../com.aspose.xps.metadata/outputbin) | JobOutputBin、DocumentOutputBin、PageOutputBin 機能クラスの基底クラスです。 |
+| [OutputBin.BinType](../com.aspose.xps.metadata/outputbin.bintype) | BinType スコアドプロパティ値の定数を定義します。 |
+| [OutputBin.MediaSheetCapacity](../com.aspose.xps.metadata/outputbin.mediasheetcapacity) | MediaSheetCapacity スコアドプロパティ値を定義し、ビンのページ数（フルレベル）でのメディア容量を指定します。 |
+| [OutputBin.OutputBinOption](../com.aspose.xps.metadata/outputbin.outputbinoption) | JobOutputBin、DocumentOutputBin、PageOutputBin 機能のオプションを説明します。 |
+| [PageBlackGenerationProcessing](../com.aspose.xps.metadata/pageblackgenerationprocessing) | CMYK 分離の黒生成動作を指定します。 |
+| [PageBlackGenerationProcessing.PageBlackGenerationProcessingOption](../com.aspose.xps.metadata/pageblackgenerationprocessing.pageblackgenerationprocessingoption) | PageBlackGenerationProcessing 機能のオプションを説明します。 |
+| [PageBlackGenerationProcessingBlackInkLimit](../com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit) | 指定された名前色でラベル付けされたアプリケーションコンテンツは、すべてのカラ―分離に必ず表示されなければなりません。 |
+| [PageBlackGenerationProcessingGrayComponentReplacementExtent](../com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent) | GCR が適用する中立色を超える（彩色領域への）範囲を説明します。0% = 均一成分置換、100% = グレイコンポーネント置換。 |
+| [PageBlackGenerationProcessingGrayComponentReplacementLevel](../com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel) | 実行するグレイコンポーネント置換の割合を指定します。 |
+| [PageBlackGenerationProcessingGrayComponentReplacementStart](../com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart) | GCR が開始すべき\"highlight to shadow\"範囲の点を説明します（100% が最も暗いシャドウ）。 |
+| [PageBlackGenerationProcessingTotalInkCoverageLimit](../com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit) | 画像内の任意の場所で許容されるインクカバレッジ4色の合計最大値を指定します。 |
+| [PageBlackGenerationProcessingUnderColorAdditionLevel](../com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel) | 暗い中立色およびほぼ中立色領域で GCR/UCR が\"BlackInkLimit\"（または指定されている場合は\"UCAStart\"）を生成した領域に追加する彩色インク（グレイコンポーネント比）の量を説明します。 |
+| [PageBlackGenerationProcessingUnderColorAdditionStart](../com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart) | UCA が適用される影レベル以下を説明します。 |
+| [PageBlendColorSpace](../com.aspose.xps.metadata/pageblendcolorspace) | ブレンド操作に使用すべきカラースペースを説明します。 |
+| [PageBlendColorSpace.PageBlendColorSpaceOption](../com.aspose.xps.metadata/pageblendcolorspace.pageblendcolorspaceoption) | PageBlendColorSpace 機能オプションを説明します。 |
+| [PageBlendColorSpaceICCProfileURI](../com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri) | ブレンドに使用すべきカラースペースを定義する ICC プロファイルへの相対 URI 参照を指定します。 |
+| [PageBorderless](../com.aspose.xps.metadata/pageborderless) | 画像コンテンツを媒体の物理的な端まで印刷すべきタイミングを説明します。 |
+| [PageBorderless.PageBorderlessOption](../com.aspose.xps.metadata/pageborderless.pageborderlessoption) | PageBorderless 機能オプションを説明します。 |
+| [PageColorManagement](../com.aspose.xps.metadata/pagecolormanagement) | 現在のページのカラーマネジメントを構成します。 |
+| [PageColorManagement.PageColorManagementOption](../com.aspose.xps.metadata/pagecolormanagement.pagecolormanagementoption) | PageColorManagement 機能オプションを説明します。 |
+| [PageCopies](../com.aspose.xps.metadata/pagecopies) | ページのコピー数を指定します。 |
+| [PageDestinationColorProfile](../com.aspose.xps.metadata/pagedestinationcolorprofile) | 宛先カラープロファイルの特性を定義します。 |
+| [PageDestinationColorProfile.PageDestinationColorProfileOption](../com.aspose.xps.metadata/pagedestinationcolorprofile.pagedestinationcolorprofileoption) | PageDestinationColorProfile 機能オプションを説明します。 |
+| [PageDestinationColorProfileEmbedded](../com.aspose.xps.metadata/pagedestinationcolorprofileembedded) | 埋め込まれた宛先カラープロファイルを指定します。 |
+| [PageDestinationColorProfileURI](../com.aspose.xps.metadata/pagedestinationcolorprofileuri) | XPS ドキュメントに含まれる ICC プロファイルへの相対 URI 参照を指定します。 |
+| [PageDeviceColorSpaceProfileURI](../com.aspose.xps.metadata/pagedevicecolorspaceprofileuri) | XPS ドキュメントに含まれる ICC プロファイルへのパッケージルートからの相対 URI を指定します。 |
+| [PageDeviceColorSpaceUsage](../com.aspose.xps.metadata/pagedevicecolorspaceusage) | PageDeviceColorSpaceProfileURI パラメータと組み合わせて、このパラメータはデバイスカラースペースで提示される要素のレンダリング動作を定義します。 |
+| [PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption](../com.aspose.xps.metadata/pagedevicecolorspaceusage.pagedevicecolorspaceusageoption) | PageDeviceColorSpaceUsage 機能オプションを説明します。 |
+| [PageDeviceFontSubstitution](../com.aspose.xps.metadata/pagedevicefontsubstitution) | デバイスフォント置換の有効/無効状態を説明します。 |
+| [PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption](../com.aspose.xps.metadata/pagedevicefontsubstitution.pagedevicefontsubstitutionoption) | PageDeviceFontSubstitution 機能オプションを説明します。 |
+| [PageForceFrontSide](../com.aspose.xps.metadata/pageforcefrontside) | 出力が媒体シートの表面に表示されるよう強制します。 |
+| [PageForceFrontSide.PageForceFrontSideOption](../com.aspose.xps.metadata/pageforcefrontside.pageforcefrontsideoption) | PageForceFrontSide 機能オプションを説明します。 |
+| [PageICMRenderingIntent](../com.aspose.xps.metadata/pageicmrenderingintent) | ICC v2 仕様で定義されたレンダリングインテントを説明します。 |
+| [PageICMRenderingIntent.PageICMRenderingIntentOption](../com.aspose.xps.metadata/pageicmrenderingintent.pageicmrenderingintentoption) | PageICMRenderingIntent 機能オプションを説明します。 |
+| [PageImageableSize](../com.aspose.xps.metadata/pageimageablesize) | レイアウトとレンダリングのためのイメージ化されたキャンバスを説明します。 |
+| [PageInputBin](../com.aspose.xps.metadata/pageinputbin) | デバイスにインストールされた入力ビン、またはデバイスがサポートするビンの全リストを説明します。 |
+| [PageMediaColor](../com.aspose.xps.metadata/pagemediacolor) | メディアカラーオプションと各オプションの特性を説明します。 |
+| [PageMediaColor.PageMediaColorOption](../com.aspose.xps.metadata/pagemediacolor.pagemediacoloroption) | PageMediaColor 機能オプションを説明します。 |
+| [PageMediaSize](../com.aspose.xps.metadata/pagemediasize) | 出力に使用される物理メディアの寸法を説明します。 |
+| [PageMediaSize.PageMediaSizeOption](../com.aspose.xps.metadata/pagemediasize.pagemediasizeoption) | PageMediaSize 機能のオプションを説明します。 |
+| [PageMediaSizeMediaSizeHeight](../com.aspose.xps.metadata/pagemediasizemediasizeheight) | Custom MediaSize オプションの MediaSizeWidth 方向の寸法を指定します。 |
+| [PageMediaSizeMediaSizeWidth](../com.aspose.xps.metadata/pagemediasizemediasizewidth) | Custom MediaSize オプションの MediaSizeHeight 方向の寸法を指定します。 |
+| [PageMediaSizePSHeight](../com.aspose.xps.metadata/pagemediasizepsheight) | ページの高さを、給紙方向に平行に指定します。 |
+| [PageMediaSizePSHeightOffset](../com.aspose.xps.metadata/pagemediasizepsheightoffset) | 給紙方向に平行なオフセットを指定します。 |
+| [PageMediaSizePSOrientation](../com.aspose.xps.metadata/pagemediasizepsorientation) | 給紙方向に対する向きを指定します https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsorientation |
+| [PageMediaSizePSWidth](../com.aspose.xps.metadata/pagemediasizepswidth) | ページの幅を、給紙方向に垂直に指定します。 |
+| [PageMediaSizePSWidthOffset](../com.aspose.xps.metadata/pagemediasizepswidthoffset) | 給紙方向に垂直なオフセットを指定します。 |
+| [PageMediaType](../com.aspose.xps.metadata/pagemediatype) | MediaType オプションと各オプションの特性を説明します。 |
+| [PageMediaType.BackCoating](../com.aspose.xps.metadata/pagemediatype.backcoating) | BackCoating スコア付きプロパティ値の定数を定義します。 |
+| [PageMediaType.FrontCoating](../com.aspose.xps.metadata/pagemediatype.frontcoating) | FrontCoating スコア付きプロパティ値の定数を定義します。 |
+| [PageMediaType.Material](../com.aspose.xps.metadata/pagemediatype.material) | Material スコア付きプロパティ値の定数を定義します。 |
+| [PageMediaType.PageMediaTypeOption](../com.aspose.xps.metadata/pagemediatype.pagemediatypeoption) | PageMediaType 機能のオプションを説明します。 |
+| [PageMediaType.PrePrinted](../com.aspose.xps.metadata/pagemediatype.preprinted) | PrePrinted スコア付きプロパティ値の定数を定義します。 |
+| [PageMediaType.PrePunched](../com.aspose.xps.metadata/pagemediatype.prepunched) | PrePunched スコア付きプロパティ値の定数を定義します。 |
+| [PageMediaType.Recycled](../com.aspose.xps.metadata/pagemediatype.recycled) | Recycled スコア付きプロパティ値の定数を定義します。 |
+| [PageMirrorImage](../com.aspose.xps.metadata/pagemirrorimage) | 出力のミラーリング設定を説明します。 |
+| [PageMirrorImage.PageMirrorImageOption](../com.aspose.xps.metadata/pagemirrorimage.pagemirrorimageoption) | PageMirrorImage 機能のオプションを定義します。 |
+| [PageNegativeImage](../com.aspose.xps.metadata/pagenegativeimage) | 出力のネガティブ設定を説明します。 |
+| [PageNegativeImage.PageNegativeImageOption](../com.aspose.xps.metadata/pagenegativeimage.pagenegativeimageoption) | PageNegativeImage 機能のオプションを定義します。 |
+| [PageOrientation](../com.aspose.xps.metadata/pageorientation) | 物理メディアシートの向きを説明します。 |
+| [PageOrientation.PageOrientationOption](../com.aspose.xps.metadata/pageorientation.pageorientationoption) | PageOrientation 機能のオプションを説明します。 |
+| [PageOutputBin](../com.aspose.xps.metadata/pageoutputbin) | デバイスでサポートされるビンの完全なリストを説明します。 |
+| [PageOutputColor](../com.aspose.xps.metadata/pageoutputcolor) | 出力のカラ設定の特性を説明します。 |
+| [PageOutputColor.PageOutputColorOption](../com.aspose.xps.metadata/pageoutputcolor.pageoutputcoloroption) | PageOutputColor 機能のオプションを説明します。 |
+| [PageOutputQuality](../com.aspose.xps.metadata/pageoutputquality) | 出力のネガティブ設定を説明します。 |
+| [PageOutputQuality.PageOutputQualityOption](../com.aspose.xps.metadata/pageoutputquality.pageoutputqualityoption) | PageOutputQuality の機能オプションを定義します。 |
+| [PagePhotoPrintingIntent](../com.aspose.xps.metadata/pagephotoprintingintent) | 写真印刷設定の設定を行うための高レベルの意図をドライバーに示します。 |
+| [PagePhotoPrintingIntent.PagePhotoPrintingIntentOption](../com.aspose.xps.metadata/pagephotoprintingintent.pagephotoprintingintentoption) | PagePhotoPrintingIntent の機能オプションを定義します。 |
+| [PagePoster](../com.aspose.xps.metadata/pageposter) | 単一ページの出力を複数の物理メディアシートに記述します。 |
+| [PagePrintTicket](../com.aspose.xps.metadata/pageprintticket) | ページレベルの印刷チケットをカプセル化するクラスです。 |
+| [PageResolution](../com.aspose.xps.metadata/pageresolution) | 印刷出力のページ解像度を定性的な値、または DPI（ドット毎インチ）として、またはその両方として定義します。 |
+| [PageResolution.PageResolutionOption](../com.aspose.xps.metadata/pageresolution.pageresolutionoption) | PageResolution の機能オプションを記述します。 |
+| [PageResolution.QualitativeResolution](../com.aspose.xps.metadata/pageresolution.qualitativeresolution) | QualitativeResolution のスコア付きプロパティ値の定数を定義します。 |
+| [PageScaling](../com.aspose.xps.metadata/pagescaling) | 出力のスケーリング特性を記述します。 |
+| [PageScaling.PageScalingOption](../com.aspose.xps.metadata/pagescaling.pagescalingoption) | PageScaling の機能オプションを記述します。 |
+| [PageScaling.ScaleOffsetAlignment](../com.aspose.xps.metadata/pagescaling.scaleoffsetalignment) | 内部の ScaleOffsetAlignment 機能を記述します。 |
+| [PageScaling.ScaleOffsetAlignmentOption](../com.aspose.xps.metadata/pagescaling.scaleoffsetalignmentoption) | ScaleOffsetAlignment の機能オプションを記述します。 |
+| [PageScalingOffsetHeight](../com.aspose.xps.metadata/pagescalingoffsetheight) | カスタムスケーリングのために ImageableSizeWidth 方向のスケーリングオフセットを指定します。 |
+| [PageScalingOffsetWidth](../com.aspose.xps.metadata/pagescalingoffsetwidth) | カスタムスケーリングのために ImageableSizeWidth 方向のスケーリングオフセットを指定します。 |
+| [PageScalingScale](../com.aspose.xps.metadata/pagescalingscale) | カスタム正方形スケーリングのスケーリング係数を指定します。 |
+| [PageScalingScaleHeight](../com.aspose.xps.metadata/pagescalingscaleheight) | カスタムスケーリングのために ImageableSizeHeight 方向のスケーリング係数を指定します。 |
+| [PageScalingScaleWidth](../com.aspose.xps.metadata/pagescalingscalewidth) | カスタムスケーリングのために ImageableSizeWidth 方向のスケーリング係数を指定します。 |
+| [PageSourceColorProfile](../com.aspose.xps.metadata/pagesourcecolorprofile) | ソースカラープロファイルの特性を定義します。 |
+| [PageSourceColorProfile.PageSourceColorProfileOption](../com.aspose.xps.metadata/pagesourcecolorprofile.pagesourcecolorprofileoption) | PageSourceColorProfile の機能オプションを記述します。 |
+| [PageSourceColorProfileEmbedded](../com.aspose.xps.metadata/pagesourcecolorprofileembedded) | 埋め込みソースカラープロファイルを指定します。 |
+| [PageSourceColorProfileURI](../com.aspose.xps.metadata/pagesourcecolorprofileuri) | カラープロファイルのソースを指定します。 |
+| [PageTrueTypeFontMode](../com.aspose.xps.metadata/pagetruetypefontmode) | 使用する TrueType フォント処理の方法を記述します。 |
+| [PageTrueTypeFontMode.PageTrueTypeFontModeOption](../com.aspose.xps.metadata/pagetruetypefontmode.pagetruetypefontmodeoption) | PageTrueTypeFontMode の機能オプションを記述します。 |
+| [PageWatermark](../com.aspose.xps.metadata/pagewatermark) | 出力の透かし設定と透かしの特性を記述します。 |
+| [PageWatermark.Layering](../com.aspose.xps.metadata/pagewatermark.layering) | 内部の Layering 機能を記述します。 |
+| [PageWatermark.LayeringOption](../com.aspose.xps.metadata/pagewatermark.layeringoption) | Layering の機能オプションを記述します。 |
+| [PageWatermark.PageWatermarkOption](../com.aspose.xps.metadata/pagewatermark.pagewatermarkoption) | PageWatermark の機能オプションについて説明します。 |
+| [PageWatermarkOriginHeight](../com.aspose.xps.metadata/pagewatermarkoriginheight) | 透かしの原点を PageImageableSize の原点に対して指定します。 |
+| [PageWatermarkOriginWidth](../com.aspose.xps.metadata/pagewatermarkoriginwidth) | 透かしの原点を PageImageableSize の原点に対して指定します。 |
+| [PageWatermarkTextAngle](../com.aspose.xps.metadata/pagewatermarktextangle) | 透かしテキストの角度を PageImageableSizeWidth の方向に対して指定します。 |
+| [PageWatermarkTextColor](../com.aspose.xps.metadata/pagewatermarktextcolor) | 透かしテキストの sRGB カラーを定義します。 |
+| [PageWatermarkTextFontSize](../com.aspose.xps.metadata/pagewatermarktextfontsize) | 透かしテキストに利用可能なフォントサイズを定義します。 |
+| [PageWatermarkTextText](../com.aspose.xps.metadata/pagewatermarktexttext) | 透かしのテキストを指定します。 |
+| [PageWatermarkTransparency](../com.aspose.xps.metadata/pagewatermarktransparency) | 透かしの透明度を指定します。 |
+| [ParameterInit](../com.aspose.xps.metadata/parameterinit) | 印刷チケットパラメータ初期化子を実装するクラスです。 |
+| [ParameterRef](../com.aspose.xps.metadata/parameterref) | 共通の PrintTicket パラメータ参照を実装するクラスです。 |
+| [PrintTicket](../com.aspose.xps.metadata/printticket) | 任意のスコープの共通 PrintTicket を実装するクラスです。 |
+| [PrintTicketElement](../com.aspose.xps.metadata/printticketelement) | Print Schema 要素になる可能性のあるクラスの基底クラスです。 |
+| [Property](../com.aspose.xps.metadata/property) | 印刷チケットプロパティを実装するクラスです。 |
+| [QNameValue](../com.aspose.xps.metadata/qnamevalue) | PrintTicket ドキュメント内の QName 値をカプセル化するクラスです。 |
+| [RollCut](../com.aspose.xps.metadata/rollcut) | JobRollCutAtEndOfJob と DocumentRollCut 機能クラスの基底クラスです。 |
+| [RollCut.RollCutOption](../com.aspose.xps.metadata/rollcut.rollcutoption) | JobRollCutAtEndOfJob と DocumentRollCut の機能オプションについて説明します。 |
+| [ScoredProperty](../com.aspose.xps.metadata/scoredproperty) | 共通 PrintTicket ScoredProperty を実装するクラスです。 |
+| [SelectionType](../com.aspose.xps.metadata/selectiontype) | SelectionType PrintTicket プロパティ用の便利クラスです。 |
+| [Staple](../com.aspose.xps.metadata/staple) | JobStapleAllDocuments と DocumentStaple 機能クラスの基底クラスです。 |
+| [Staple.StapleOption](../com.aspose.xps.metadata/staple.stapleoption) | JobStapleAllDocuments と DocumentStaple の機能オプションについて説明します。 |
+| [StringParameterInit](../com.aspose.xps.metadata/stringparameterinit) | すべての文字列パラメータ初期化子の基底クラスです。 |
+| [StringValue](../com.aspose.xps.metadata/stringvalue) | PrintTicket ドキュメント内の文字列値をカプセル化するクラスです。 |
+| [URIProperty](../com.aspose.xps.metadata/uriproperty) | JobURI と DocumentURI プロパティクラスの基底クラスです。 |
+| [Value](../com.aspose.xps.metadata/value) | PrintTicket ドキュメント内の Property または ScoredProperty の値をカプセル化する基底クラスです。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IDocumentPrintTicketItem](../com.aspose.xps.metadata/idocumentprintticketitem) | ドキュメント接頭辞付き印刷チケット項目のインターフェイスです。 |
+| [IFeatureItem](../com.aspose.xps.metadata/ifeatureitem) | Print Schema Feature 項目になる可能性のあるクラスの基底インターフェイスです。 |
+| [IJobPrintTicketItem](../com.aspose.xps.metadata/ijobprintticketitem) | ジョブ接頭辞付き印刷チケット項目のインターフェイスです。 |
+| [IOptionItem](../com.aspose.xps.metadata/ioptionitem) | Print Schema  Option  項目になる可能性のあるクラスのインターフェイスです。 |
+| [IPagePrintTicketItem](../com.aspose.xps.metadata/ipageprintticketitem) | ページ接頭辞付き印刷チケット項目のインターフェイスです。 |
+| [IPrintTicketElementChild](../com.aspose.xps.metadata/iprintticketelementchild) | 任意の Print Schema 要素の子要素の基本インターフェイスです。 |
+| [IPrintTicketItem](../com.aspose.xps.metadata/iprintticketitem) | PrintTicket  ルート要素項目になる可能性のあるクラスの基本インターフェイスです。 |
+| [IPropertyItem](../com.aspose.xps.metadata/ipropertyitem) | PrintTicket  Property  項目になる可能性のあるクラスの基本インターフェイスです。 |
+| [IScoredPropertyItem](../com.aspose.xps.metadata/iscoredpropertyitem) | PrintTicket  ScoredProperty  項目になる可能性のあるクラスの基本インターフェイスです。 |

--- a/japanese/java/com.aspose.xps.metadata/backcoating/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/backcoating/_index.md
@@ -1,0 +1,196 @@
+---
+title: "PageMediaType.BackCoating"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "BackCoating のスコア付プロパティ値の定数を定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.backcoating/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.BackCoating extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+BackCoating スコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Glossy](#Glossy) | 光沢のある値。 |
+| [HighGloss](#HighGloss) | ハイグロスの値。 |
+| [Matte](#Matte) | マットの値。 |
+| [None](#None) | None 値。 |
+| [Satin](#Satin) | サテンの値。 |
+| [SemiGloss](#SemiGloss) | セミグロスの値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Glossy {#Glossy}
+```
+public static PageMediaType.BackCoating Glossy
+```
+
+
+光沢のある値。
+
+### HighGloss {#HighGloss}
+```
+public static PageMediaType.BackCoating HighGloss
+```
+
+
+ハイグロスの値。
+
+### Matte {#Matte}
+```
+public static PageMediaType.BackCoating Matte
+```
+
+
+マットの値。
+
+### None {#None}
+```
+public static PageMediaType.BackCoating None
+```
+
+
+None 値。
+
+### Satin {#Satin}
+```
+public static PageMediaType.BackCoating Satin
+```
+
+
+サテンの値。
+
+### SemiGloss {#SemiGloss}
+```
+public static PageMediaType.BackCoating SemiGloss
+```
+
+
+セミグロスの値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/bannersheetoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/bannersheetoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "JobPrimaryBannerSheet.BannerSheetOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobPrimaryBannerSheet 機能のオプションを表します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobprimarybannersheet.bannersheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPrimaryBannerSheet.BannerSheetOption extends Option
+```
+
+JobPrimaryBannerSheet機能のオプションを表します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Custom](#Custom) | カスタムバナ―シートを出力するように指定します。 |
+| [None](#None) | バナ―シートを出力しないように指定します。 |
+| [Standard](#Standard) | 標準（デバイス定義）バナ―シートを出力するように指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Custom {#Custom}
+```
+public static final JobPrimaryBannerSheet.BannerSheetOption Custom
+```
+
+
+カスタムバナ―シートを出力するように指定します。JobPrimaryBannerSheetSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### None {#None}
+```
+public static final JobPrimaryBannerSheet.BannerSheetOption None
+```
+
+
+バナ―シートを出力しないように指定します。
+
+### Standard {#Standard}
+```
+public static final JobPrimaryBannerSheet.BannerSheetOption Standard
+```
+
+
+標準（デバイス定義）バナ―シートを出力するように指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/bindinggutter/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/bindinggutter/_index.md
@@ -1,0 +1,169 @@
+---
+title: "JobBindAllDocuments.BindingGutter"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "BindingGutter のスコア付きプロパティ値を整数値で指定するか、DocumentBindingGutter パラメータへの参照で指定するかの方法を記述します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobbindalldocuments.bindinggutter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.JobBindAllDocuments.IBindingOptionItem](../../com.aspose.xps.metadata/ibindingoptionitem)
+```
+public static final class JobBindAllDocuments.BindingGutter extends ScoredProperty implements JobBindAllDocuments.IBindingOptionItem
+```
+
+BindingGutter のスコア付きプロパティ値を整数値で指定するか、DocumentBindingGutter パラメータへの参照で指定するかの方法を説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BindingGutter(int value)](#BindingGutter-int-) | 新しいインスタンスを作成します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [JobBindAllDocumentsGutter](#JobBindAllDocumentsGutter) | BindingGutter のスコア付きプロパティ値を DocumentBindingGutter パラメータへの参照で指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BindingGutter(int value) {#BindingGutter-int-}
+```
+public BindingGutter(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | スコア付きプロパティ値。 |
+
+### JobBindAllDocumentsGutter {#JobBindAllDocumentsGutter}
+```
+public static final JobBindAllDocuments.BindingGutter JobBindAllDocumentsGutter
+```
+
+
+BindingGutter のスコア付きプロパティ値を DocumentBindingGutter パラメータへの参照で指定します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/bindingoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/bindingoption/_index.md
@@ -1,0 +1,298 @@
+---
+title: "JobBindAllDocuments.BindingOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobBindAllDocuments 機能のオプションについて説明します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/jobbindalldocuments.bindingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobBindAllDocuments.BindingOption extends Option
+```
+
+JobBindAllDocuments 機能のオプションを記述します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BindingOption(String name, JobBindAllDocuments.IBindingOptionItem[] items)](#BindingOption-java.lang.String-com.aspose.xps.metadata.JobBindAllDocuments.IBindingOptionItem...-) | 新しいインスタンスを作成します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Bale](#Bale) | ベイル結合を指定します。 |
+| [BindBottom](#BindBottom) | 下端に沿った結合を指定します。 |
+| [BindLeft](#BindLeft) | 左端に沿った結合を指定します。 |
+| [BindRight](#BindRight) | 右端に沿った結合を指定します。 |
+| [BindTop](#BindTop) | 上端に沿った結合を指定します。 |
+| [Booklet](#Booklet) | ブックレット結合を指定します。 |
+| [EdgeStitchBottom](#EdgeStitchBottom) | 下端に沿ったエッジステッチングを指定します。 |
+| [EdgeStitchLeft](#EdgeStitchLeft) | 左端に沿ったエッジステッチングを指定します。 |
+| [EdgeStitchRight](#EdgeStitchRight) | 右端に沿ったエッジステッチングを指定します。 |
+| [EdgeStitchTop](#EdgeStitchTop) | 上端に沿ったエッジステッチングを指定します。 |
+| [Fold](#Fold) | 折りたたみ結合を指定します。 |
+| [JogOffset](#JogOffset) | ジョグオフセット結合を指定します。 |
+| [None](#None) | 結合なしを指定します。 |
+| [Trim](#Trim) | トリミング結合を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BindingOption(String name, JobBindAllDocuments.IBindingOptionItem[] items) {#BindingOption-java.lang.String-com.aspose.xps.metadata.JobBindAllDocuments.IBindingOptionItem...-}
+```
+public BindingOption(String name, JobBindAllDocuments.IBindingOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | オプション名。 |
+| items | [IBindingOptionItem\[\]](../../com.aspose.xps.metadata/ibindingoptionitem) | 有効な子項目の配列です。 |
+
+### Bale {#Bale}
+```
+public static final JobBindAllDocuments.BindingOption Bale
+```
+
+
+ベイル結合を指定します。
+
+### BindBottom {#BindBottom}
+```
+public static final JobBindAllDocuments.BindingOption BindBottom
+```
+
+
+下端に沿った結合を指定します。
+
+### BindLeft {#BindLeft}
+```
+public static final JobBindAllDocuments.BindingOption BindLeft
+```
+
+
+左端に沿った結合を指定します。
+
+### BindRight {#BindRight}
+```
+public static final JobBindAllDocuments.BindingOption BindRight
+```
+
+
+右端に沿った結合を指定します。
+
+### BindTop {#BindTop}
+```
+public static final JobBindAllDocuments.BindingOption BindTop
+```
+
+
+上端に沿った結合を指定します。
+
+### Booklet {#Booklet}
+```
+public static final JobBindAllDocuments.BindingOption Booklet
+```
+
+
+ブックレット結合を指定します。
+
+### EdgeStitchBottom {#EdgeStitchBottom}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchBottom
+```
+
+
+下端に沿ったエッジステッチングを指定します。
+
+### EdgeStitchLeft {#EdgeStitchLeft}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchLeft
+```
+
+
+左端に沿ったエッジステッチングを指定します。
+
+### EdgeStitchRight {#EdgeStitchRight}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchRight
+```
+
+
+右端に沿ったエッジステッチングを指定します。
+
+### EdgeStitchTop {#EdgeStitchTop}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchTop
+```
+
+
+上端に沿ったエッジステッチングを指定します。
+
+### Fold {#Fold}
+```
+public static final JobBindAllDocuments.BindingOption Fold
+```
+
+
+折りたたみ結合を指定します。
+
+### JogOffset {#JogOffset}
+```
+public static final JobBindAllDocuments.BindingOption JogOffset
+```
+
+
+ジョグオフセット結合を指定します。
+
+### None {#None}
+```
+public static final JobBindAllDocuments.BindingOption None
+```
+
+
+結合なしを指定します。
+
+### Trim {#Trim}
+```
+public static final JobBindAllDocuments.BindingOption Trim
+```
+
+
+トリミング結合を指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/bintype/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/bintype/_index.md
@@ -1,0 +1,187 @@
+---
+title: "OutputBin.BinType"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "BinType のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/outputbin.bintype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem](../../com.aspose.xps.metadata/ioutputbinoptionitem)
+```
+public static final class OutputBin.BinType extends ScoredProperty implements OutputBin.IOutputBinOptionItem
+```
+
+BinType スコアドプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Finisher](#Finisher) | 仕上げ用ビンです。 |
+| [MailBox](#MailBox) | メールボックスビンです。 |
+| [None](#None) | 上記のいずれでもありません。 |
+| [Sorter](#Sorter) | 仕分けビンです。 |
+| [Stacker](#Stacker) | スタッカービンです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Finisher {#Finisher}
+```
+public static final OutputBin.BinType Finisher
+```
+
+
+仕上げ用ビンです。
+
+### MailBox {#MailBox}
+```
+public static final OutputBin.BinType MailBox
+```
+
+
+メールボックスビンです。
+
+### None {#None}
+```
+public static final OutputBin.BinType None
+```
+
+
+上記のいずれでもありません。
+
+### Sorter {#Sorter}
+```
+public static final OutputBin.BinType Sorter
+```
+
+
+仕分けビンです。
+
+### Stacker {#Stacker}
+```
+public static final OutputBin.BinType Stacker
+```
+
+
+スタッカービンです。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/collate/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/collate/_index.md
@@ -1,0 +1,149 @@
+---
+title: "結合"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "DocumentCollate と JobCollateAllDocuments 機能クラスの基底クラスです。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/collate/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class Collate extends Feature
+```
+
+DocumentCollate と JobCollateAllDocuments 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/collateoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/collateoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "Collate.CollateOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "DocumentCollate と JobCollateAllDocuments 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/collate.collateoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class Collate.CollateOption extends Option
+```
+
+DocumentCollate と JobCollateAllDocuments 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Collated](#Collated) | 段組みを指定します。 |
+| [Uncollated](#Uncollated) | 段組みしないことを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collated {#Collated}
+```
+public static Collate.CollateOption Collated
+```
+
+
+段組みを指定します。
+
+### Uncollated {#Uncollated}
+```
+public static Collate.CollateOption Uncollated
+```
+
+
+段組みしないことを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/compositeprintticketelement/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/compositeprintticketelement/_index.md
@@ -1,0 +1,168 @@
+---
+title: "CompositePrintTicketElement"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "他の要素を含む複合 Print Schema 要素になる可能性があるクラスの基底クラスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/compositeprintticketelement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+```
+public abstract class CompositePrintTicketElement extends PrintTicketElement
+```
+
+他の要素を含む可能性のある複合 Print Schema 要素の基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [CompositePrintTicketElement(String name, IPrintTicketElementChild[] items)](#CompositePrintTicketElement-java.lang.String-com.aspose.xps.metadata.IPrintTicketElementChild...-) | 新しいインスタンスを作成します。 |
+| [CompositePrintTicketElement(CompositePrintTicketElement element)](#CompositePrintTicketElement-com.aspose.xps.metadata.CompositePrintTicketElement-) | この要素インスタンスをクローンします。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompositePrintTicketElement(String name, IPrintTicketElementChild[] items) {#CompositePrintTicketElement-java.lang.String-com.aspose.xps.metadata.IPrintTicketElementChild...-}
+```
+public CompositePrintTicketElement(String name, IPrintTicketElementChild[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | 要素の名前を、いくつかの XML スキーマ（Microsoft Print Schema Framework など）に従って指定します。 |
+| items | [IPrintTicketElementChild\[\]](../../com.aspose.xps.metadata/iprintticketelementchild) | 子アイテムの任意の配列です。 |
+
+### CompositePrintTicketElement(CompositePrintTicketElement element) {#CompositePrintTicketElement-com.aspose.xps.metadata.CompositePrintTicketElement-}
+```
+public CompositePrintTicketElement(CompositePrintTicketElement element)
+```
+
+
+この要素インスタンスをクローンします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| element | [CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement) | クローンする要素インスタンスです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/coverbackoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/coverbackoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "JobPrimaryCoverBack.CoverBackOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobPrimaryCoverBack 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobprimarycoverback.coverbackoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPrimaryCoverBack.CoverBackOption extends Option
+```
+
+JobPrimaryCoverBack機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BlankCover](#BlankCover) | 空白のカバーシートを印刷することを指定します。 |
+| [NoCover](#NoCover) | カバーが出力されないことを指定します。 |
+| [PrintBack](#PrintBack) | \"CoverBackSource\" で示されたカバーがカバーシートの裏面に印刷されることを指定します。 |
+| [PrintBoth](#PrintBoth) | \"CoverBackSource\" で示されたカバーがカバーシートの両面に印刷される可能性があることを指定します。 |
+| [PrintFront](#PrintFront) | \"CoverBackSource\" で示されたカバーがカバーシートの表面に印刷されることを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BlankCover {#BlankCover}
+```
+public static final JobPrimaryCoverBack.CoverBackOption BlankCover
+```
+
+
+空白のカバーシートを印刷することを指定します。
+
+### NoCover {#NoCover}
+```
+public static final JobPrimaryCoverBack.CoverBackOption NoCover
+```
+
+
+カバーが出力されないことを指定します。
+
+### PrintBack {#PrintBack}
+```
+public static final JobPrimaryCoverBack.CoverBackOption PrintBack
+```
+
+
+\"CoverBackSource\" で示されたカバーがカバーシートの裏面に印刷されることを指定します。JobPrimaryCoverBackSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### PrintBoth {#PrintBoth}
+```
+public static final JobPrimaryCoverBack.CoverBackOption PrintBoth
+```
+
+
+\"CoverBackSource\" で示されたカバーがカバーシートの両面に印刷される可能性があることを指定します。JobPrimaryCoverBackSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### PrintFront {#PrintFront}
+```
+public static final JobPrimaryCoverBack.CoverBackOption PrintFront
+```
+
+
+\"CoverBackSource\" で示されたカバーがカバーシートの表面に印刷されることを指定します。JobPrimaryCoverBackSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/coverfrontoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/coverfrontoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "JobPrimaryCoverFront.CoverFrontOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobPrimaryCoverFront 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobprimarycoverfront.coverfrontoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPrimaryCoverFront.CoverFrontOption extends Option
+```
+
+JobPrimaryCoverFront機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BlankCover](#BlankCover) | 空白のカバーシートを印刷することを指定します。 |
+| [NoCover](#NoCover) | カバーが出力されないことを指定します。 |
+| [PrintBack](#PrintBack) | 「CoverFrontSource」で指定されたカバーをカバーシートの裏面に印刷することを指定します。 |
+| [PrintBoth](#PrintBoth) | 「CoverFrontSource」で指定されたカバーをカバーシートの表裏いずれかに印刷できることを指定します。 |
+| [PrintFront](#PrintFront) | 「CoverFrontSource」で指定されたカバーをカバーシートの表面に印刷することを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BlankCover {#BlankCover}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption BlankCover
+```
+
+
+空白のカバーシートを印刷することを指定します。
+
+### NoCover {#NoCover}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption NoCover
+```
+
+
+カバーが出力されないことを指定します。
+
+### PrintBack {#PrintBack}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption PrintBack
+```
+
+
+「CoverFrontSource」で指定されたカバーをカバーシートの裏面に印刷することを指定します。JobPrimaryCoverFrontSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### PrintBoth {#PrintBoth}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption PrintBoth
+```
+
+
+「CoverFrontSource」で指定されたカバーをカバーシートの表裏いずれかに印刷できることを指定します。JobPrimaryCoverFrontSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### PrintFront {#PrintFront}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption PrintFront
+```
+
+
+「CoverFrontSource」で指定されたカバーをカバーシートの表面に印刷することを指定します。JobPrimaryCoverFrontSource ParameterInit 要素が指定されていない場合、このオプションは無視されるべきです。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/decimalvalue/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/decimalvalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "DecimalValue"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ドキュメント内の Decimal 値をカプセル化するクラスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/decimalvalue/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)、[com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class DecimalValue extends Value
+```
+
+PrintTicket ドキュメント内の Decimal 値をカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DecimalValue(float value)](#DecimalValue-float-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [getValueString()](#getValueString--) | 値を文字列として取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DecimalValue(float value) {#DecimalValue-float-}
+```
+public DecimalValue(float value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 小数値です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+値を文字列として取得します。
+
+**Returns:**
+java.lang.String - 値を文字列として取得します。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentbannersheet/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentbannersheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentBannerSheet"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "特定のドキュメントに出力されるバナーシートを説明します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/documentbannersheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBannerSheet extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+特定のドキュメントのバナーシートの出力方法を説明します。バナーシートはデフォルトの PageMediaSize で、デフォルトの PageMediaType を使用して出力する必要があります。バナーシートはジョブの残りの部分からも分離されるべきです。これは、DocumentDuplex、DocumentStaple、または DocumentBinding などの仕上げや処理オプションにバナーシートが含まれないことを意味します。バナーシートはジョブの残りと分離される場合とされない場合があります。これは、ジョブの仕上げや処理オプションにドキュメントバナーシートが含まれる可能性があることを意味します。バナーシートはドキュメントの最初のシートとして配置されるべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbannersheet
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentBannerSheet(DocumentBannerSheet.BannerSheetOption[] options)](#DocumentBannerSheet-com.aspose.xps.metadata.DocumentBannerSheet.BannerSheetOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBannerSheet(DocumentBannerSheet.BannerSheetOption[] options) {#DocumentBannerSheet-com.aspose.xps.metadata.DocumentBannerSheet.BannerSheetOption...-}
+```
+public DocumentBannerSheet(DocumentBannerSheet.BannerSheetOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [BannerSheetOption\[\]](../../com.aspose.xps.metadata/bannersheetoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentbannersheetsource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentbannersheetsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentBannerSheetSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタムバナーシートのソースを指定します。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.metadata/documentbannersheetsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBannerSheetSource extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+カスタムバナーシートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbannersheetsource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentBannerSheetSource(String value)](#DocumentBannerSheetSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBannerSheetSource(String value) {#DocumentBannerSheetSource-java.lang.String-}
+```
+public DocumentBannerSheetSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentbinding/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentbinding/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentBinding"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "製本方法を説明します。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.xps.metadata/documentbinding/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBinding extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+バインディング方法を説明します。各ドキュメントは個別にバインドされます。DocumentBinding と JobBindAllDocuments は相互に排他的です。キーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbinding
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentBinding(DocumentBinding.BindingOption[] options)](#DocumentBinding-com.aspose.xps.metadata.DocumentBinding.BindingOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBinding(DocumentBinding.BindingOption[] options) {#DocumentBinding-com.aspose.xps.metadata.DocumentBinding.BindingOption...-}
+```
+public DocumentBinding(DocumentBinding.BindingOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [BindingOption\[\]](../../com.aspose.xps.metadata/bindingoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentbindinggutter/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentbindinggutter/_index.md
@@ -1,0 +1,189 @@
+---
+title: "DocumentBindingGutter"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "製本用のガター幅を指定します。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.xps.metadata/documentbindinggutter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBindingGutter extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+綴じ込みの溝の幅を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbindinggutter
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentBindingGutter(int value)](#DocumentBindingGutter-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBindingGutter(int value) {#DocumentBindingGutter-int-}
+```
+public DocumentBindingGutter(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentcollate/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentcollate/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentCollate"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の段組特性を説明します。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.xps.metadata/documentcollate/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Collate](../../com.aspose.xps.metadata/collate)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCollate extends Collate implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+出力の段組み特性を説明します。各個別ドキュメントのすべてのページが段組みされます。DocumentCollate と JobCollateAlldocuments は相互に排他的です。これらのキーワードが両方実装されるか、どちらか一方のみ実装されるかの動作と実装はドライバーに委ねられます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcollate
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentCollate(Collate.CollateOption[] options)](#DocumentCollate-com.aspose.xps.metadata.Collate.CollateOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCollate(Collate.CollateOption[] options) {#DocumentCollate-com.aspose.xps.metadata.Collate.CollateOption...-}
+```
+public DocumentCollate(Collate.CollateOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [CollateOption\[\]](../../com.aspose.xps.metadata/collateoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentcopiesallpages/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentcopiesallpages/_index.md
@@ -1,0 +1,189 @@
+---
+title: "DocumentCopiesAllPages"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントの部数を指定します。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.xps.metadata/documentcopiesallpages/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCopiesAllPages extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+ドキュメントのコピー数を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcopiesallpages
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentCopiesAllPages(int value)](#DocumentCopiesAllPages-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCopiesAllPages(int value) {#DocumentCopiesAllPages-int-}
+```
+public DocumentCopiesAllPages(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentcoverback/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentcoverback/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentCoverBack"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "裏面のカバーシートを説明します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.xps.metadata/documentcoverback/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverBack extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+裏表紙（終了）カバーシートを記述します。各ドキュメントは個別のシートを持ちます。カバーシートは、ドキュメントの最終ページに使用される PageMediaSize と PageMediaType 上に印刷する必要があります。カバーシートは、指定されたオプションで示されるように、DocumentDuplex や DocumentNUp などの処理オプションに統合すべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverback
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentCoverBack(DocumentCoverBack.CoverBackOption[] options)](#DocumentCoverBack-com.aspose.xps.metadata.DocumentCoverBack.CoverBackOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverBack(DocumentCoverBack.CoverBackOption[] options) {#DocumentCoverBack-com.aspose.xps.metadata.DocumentCoverBack.CoverBackOption...-}
+```
+public DocumentCoverBack(DocumentCoverBack.CoverBackOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [CoverBackOption\[\]](../../com.aspose.xps.metadata/coverbackoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentcoverbacksource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentcoverbacksource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentCoverBackSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタム裏表紙シートのソースを指定します。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.xps.metadata/documentcoverbacksource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverBackSource extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+カスタム裏表紙シートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverbacksource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentCoverBackSource(String value)](#DocumentCoverBackSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverBackSource(String value) {#DocumentCoverBackSource-java.lang.String-}
+```
+public DocumentCoverBackSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentcoverfront/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentcoverfront/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentCoverFront"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "前面の開始カバーシートを説明します。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.xps.metadata/documentcoverfront/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverFront extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+表紙（最初）のカバーシートを説明します。各ドキュメントは別々のシートを持ちます。カバーシートはドキュメントの最初のページに使用される PageMediaSize と PageMediaType に印刷する必要があります。カバーシートは処理オプション（例: DocumentDuplex、DocumentNUp）に統合すべきで、指定された Option によって示されます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverfront
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentCoverFront(DocumentCoverFront.CoverFrontOption[] options)](#DocumentCoverFront-com.aspose.xps.metadata.DocumentCoverFront.CoverFrontOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverFront(DocumentCoverFront.CoverFrontOption[] options) {#DocumentCoverFront-com.aspose.xps.metadata.DocumentCoverFront.CoverFrontOption...-}
+```
+public DocumentCoverFront(DocumentCoverFront.CoverFrontOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [CoverFrontOption\[\]](../../com.aspose.xps.metadata/coverfrontoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentcoverfrontsource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentcoverfrontsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentCoverFrontSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタム表紙シートのソースを指定します。"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.xps.metadata/documentcoverfrontsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverFrontSource extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+カスタム表紙シートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverfrontsource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentCoverFrontSource(String value)](#DocumentCoverFrontSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverFrontSource(String value) {#DocumentCoverFrontSource-java.lang.String-}
+```
+public DocumentCoverFrontSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentduplex/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentduplex/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentDuplex"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の両面印刷特性を説明します。"
+type: docs
+weight: 23
+url: /ja/java/com.aspose.xps.metadata/documentduplex/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Duplex](../../com.aspose.xps.metadata/duplex)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentDuplex extends Duplex implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+出力の両面印刷特性を説明します。両面機能により、メディアの両面に印刷できます。各ドキュメントは個別に両面処理されます。DocumentDuplex と JobDuplexAllDocumentsContiguously は相互に排他的です。これらのキーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentduplex
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentDuplex(Duplex.DuplexOption[] options)](#DocumentDuplex-com.aspose.xps.metadata.Duplex.DuplexOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentDuplex(Duplex.DuplexOption[] options) {#DocumentDuplex-com.aspose.xps.metadata.Duplex.DuplexOption...-}
+```
+public DocumentDuplex(Duplex.DuplexOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [DuplexOption\[\]](../../com.aspose.xps.metadata/duplexoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentholepunch/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentholepunch/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentHolePunch"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の穴あけ特性を説明します。"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.xps.metadata/documentholepunch/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.HolePunch](../../com.aspose.xps.metadata/holepunch)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentHolePunch extends HolePunch implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+出力の穴あけ特性を説明します。各ドキュメントは個別に穴あけされます。  JobHolePunch  と  DocumentHolePunch  キーワードは相互に排他的です。PrintTicket または Print Capabilities ドキュメントで同時に指定してはいけません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentholepunch
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentHolePunch(HolePunch.HolePunchOption[] options)](#DocumentHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentHolePunch(HolePunch.HolePunchOption[] options) {#DocumentHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-}
+```
+public DocumentHolePunch(HolePunch.HolePunchOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [HolePunchOption\[\]](../../com.aspose.xps.metadata/holepunchoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentid/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentid/_index.md
@@ -1,0 +1,153 @@
+---
+title: "DocumentID"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントの固有 ID を指定します。"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.xps.metadata/documentid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.IDProperty](../../com.aspose.xps.metadata/idproperty)
+```
+public final class DocumentID extends IDProperty
+```
+
+ドキュメントの一意の ID を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentid
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentID(String documentID)](#DocumentID-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentID(String documentID) {#DocumentID-java.lang.String-}
+```
+public DocumentID(String documentID)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentID | java.lang.String | ドキュメント ID です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentimpositioncolor/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentimpositioncolor/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentImpositionColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "指定された名前色でラベル付けされたアプリケーションコンテンツは、すべてのカラ―分離に必ず表示されなければなりません。"
+type: docs
+weight: 26
+url: /ja/java/com.aspose.xps.metadata/documentimpositioncolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentImpositionColor extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+指定された名前付きカラーでラベル付けされたアプリケーションコンテンツは、すべてのカラ―分離に必ず表示されます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentimpositioncolor
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentImpositionColor(String value)](#DocumentImpositionColor-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentImpositionColor(String value) {#DocumentImpositionColor-java.lang.String-}
+```
+public DocumentImpositionColor(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentinputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentinputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentInputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスにインストールされた入力ビン、またはデバイスがサポートするビンの全リストを説明します。"
+type: docs
+weight: 27
+url: /ja/java/com.aspose.xps.metadata/documentinputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.InputBin](../../com.aspose.xps.metadata/inputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentInputBin extends InputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+デバイスにインストールされた入力ビン、またはデバイスでサポートされているビンの完全なリストを説明します。JobInputBin、DocumentInputBin、PageInputBin キーワードは相互に排他的です。PrintTicket または Print Capabilities ドキュメントで同時に指定すべきではありません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentinputbin
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentInputBin(InputBin.IInputBinItem[] items)](#DocumentInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentInputBin(InputBin.IInputBinItem[] items) {#DocumentInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-}
+```
+public DocumentInputBin(InputBin.IInputBinItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IInputBinItem\[\]](../../com.aspose.xps.metadata/iinputbinitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentname/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentname/_index.md
@@ -1,0 +1,153 @@
+---
+title: "DocumentName"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントの記述的な名前を指定します。"
+type: docs
+weight: 29
+url: /ja/java/com.aspose.xps.metadata/documentname/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.NameProperty](../../com.aspose.xps.metadata/nameproperty)
+```
+public final class DocumentName extends NameProperty
+```
+
+ドキュメントの記述的な名前を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentname
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentName(String documentName)](#DocumentName-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentName(String documentName) {#DocumentName-java.lang.String-}
+```
+public DocumentName(String documentName)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentName | java.lang.String | ドキュメント名です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentnup/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentnup/_index.md
@@ -1,0 +1,192 @@
+---
+title: "DocumentNUp"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "複数の論理ページを単一の物理シートに出力する際の出力とフォーマットを説明します。"
+type: docs
+weight: 28
+url: /ja/java/com.aspose.xps.metadata/documentnup/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.NUp](../../com.aspose.xps.metadata/nup)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentNUp extends NUp implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+複数の論理ページを単一の物理シートに出力する形式とフォーマットを説明します。各ドキュメントは個別にコンパイルされます。DocumentNUp と JobNUpAllDocumentsContiguously は相互に排他的です。これらのキーワード間の制約処理を決定するのはドライバー次第です。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentnup
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentNUp(NUp.INUpItem[] items)](#DocumentNUp-com.aspose.xps.metadata.NUp.INUpItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [addPagesPerSheetOption(int value)](#addPagesPerSheetOption-int-) | PagesPerSheet スコアドプロパティ値を持つオプションを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentNUp(NUp.INUpItem[] items) {#DocumentNUp-com.aspose.xps.metadata.NUp.INUpItem...-}
+```
+public DocumentNUp(NUp.INUpItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [INUpItem\[\]](../../com.aspose.xps.metadata/inupitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### addPagesPerSheetOption(int value) {#addPagesPerSheetOption-int-}
+```
+public DocumentNUp addPagesPerSheetOption(int value)
+```
+
+
+PagesPerSheet スコアドプロパティ値を持つオプションを追加します。物理シートあたりの論理ページ数を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+|  | value | int | A |
+
+```
+PagesPerSheet
+```
+
+スコア付きプロパティ値。サポートされるセットは任意の整数集合で構いません。例: \\{1,2,4,6,8,9,16\\}. |
+
+**Returns:**
+[DocumentNUp](../../com.aspose.xps.metadata/documentnup) - This feature instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentoutputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentoutputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentOutputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスでサポートされるビンの完全なリストを説明します。"
+type: docs
+weight: 30
+url: /ja/java/com.aspose.xps.metadata/documentoutputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.OutputBin](../../com.aspose.xps.metadata/outputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentOutputBin extends OutputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+デバイスでサポートされているビンの完全なリストを説明します。文書ごとに出力ビンを指定できます。JobOutputBin、DocumentOutputBin、PageOutputBin キーワードは相互に排他的であり、PrintTicket または Print Capabilities 文書で指定できるのは 1 つだけです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentoutputbin
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentOutputBin(OutputBin.IOutputBinItem[] items)](#DocumentOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentOutputBin(OutputBin.IOutputBinItem[] items) {#DocumentOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-}
+```
+public DocumentOutputBin(OutputBin.IOutputBinItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOutputBinItem\[\]](../../com.aspose.xps.metadata/ioutputbinitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentpageranges/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentpageranges/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentPageRanges"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントのページ単位での出力範囲を説明します。"
+type: docs
+weight: 31
+url: /ja/java/com.aspose.xps.metadata/documentpageranges/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentPageRanges extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+ドキュメントのページ単位での出力範囲を説明します。パラメーター値は以下の構造に従う必要があります: - PageRangeText: "PageRange" または "PageRange,PageRange" - PageRange: "PageNumber" または "PageNumber-PageNumber" - PageNumber: 1 から N まで、ここで N はドキュメントのページ数です。PageNumber が N を超える場合、PageNumber は N になります。文字列内の空白は無視されるべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentpageranges
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentPageRanges(String value)](#DocumentPageRanges-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentPageRanges(String value) {#DocumentPageRanges-java.lang.String-}
+```
+public DocumentPageRanges(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentprintticket/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentprintticket/_index.md
@@ -1,0 +1,181 @@
+---
+title: "DocumentPrintTicket"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントレベルの印刷チケットをカプセル化するクラスです。"
+type: docs
+weight: 32
+url: /ja/java/com.aspose.xps.metadata/documentprintticket/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicket](../../com.aspose.xps.metadata/printticket)
+```
+public final class DocumentPrintTicket extends PrintTicket
+```
+
+ドキュメントレベルの印刷チケットをカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentPrintTicket(IDocumentPrintTicketItem[] items)](#DocumentPrintTicket-com.aspose.xps.metadata.IDocumentPrintTicketItem...-) | ドキュメントレベルの印刷チケット インスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IDocumentPrintTicketItem[] items)](#add-com.aspose.xps.metadata.IDocumentPrintTicketItem...-) | この PrintTicket アイテムリストの末尾にアイテムの配列を追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 印刷チケット アイテム名のイテレータを返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | この PrintTicket アイテムリストからアイテムを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentPrintTicket(IDocumentPrintTicketItem[] items) {#DocumentPrintTicket-com.aspose.xps.metadata.IDocumentPrintTicketItem...-}
+```
+public DocumentPrintTicket(IDocumentPrintTicketItem[] items)
+```
+
+
+ドキュメントレベルの印刷チケット インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IDocumentPrintTicketItem\[\]](../../com.aspose.xps.metadata/idocumentprintticketitem) | 任意の IDocumentPrintTicketItem インスタンスの配列です。各インスタンスは Feature、ParameterInit、または Property のいずれかでなければなりません。 |
+
+### add(IDocumentPrintTicketItem[] items) {#add-com.aspose.xps.metadata.IDocumentPrintTicketItem...-}
+```
+public void add(IDocumentPrintTicketItem[] items)
+```
+
+
+この PrintTicket アイテムリストの末尾にアイテムの配列を追加します。各アイテムは Feature、Option、または Property のインスタンスである可能性があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IDocumentPrintTicketItem\[\]](../../com.aspose.xps.metadata/idocumentprintticketitem) | 追加するアイテムの配列です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+印刷チケット アイテム名のイテレータを返します。
+
+**Returns:**
+java.util.Iterator<java.lang.String> - リストのイテレータを返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+この PrintTicket アイテムリストからアイテムを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String[] | アイテム名の配列です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentrollcut/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentrollcut/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentRollCut"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ロール紙のカット方法を説明します。"
+type: docs
+weight: 33
+url: /ja/java/com.aspose.xps.metadata/documentrollcut/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.RollCut](../../com.aspose.xps.metadata/rollcut)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentRollCut extends RollCut implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+ロール紙のカット方法を記述します。各ドキュメントは個別に処理されます。指定されたオプションはロールカットのさまざまな方法を示します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentrollcut
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentRollCut(RollCut.RollCutOption[] options)](#DocumentRollCut-com.aspose.xps.metadata.RollCut.RollCutOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentRollCut(RollCut.RollCutOption[] options) {#DocumentRollCut-com.aspose.xps.metadata.RollCut.RollCutOption...-}
+```
+public DocumentRollCut(RollCut.RollCutOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [RollCutOption\[\]](../../com.aspose.xps.metadata/rollcutoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentseparatorsheet/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentseparatorsheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentSeparatorSheet"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントのセパレータシートの使用方法を説明します。"
+type: docs
+weight: 34
+url: /ja/java/com.aspose.xps.metadata/documentseparatorsheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentSeparatorSheet extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+ドキュメントのセパレーターシートの使用方法を説明します。セパレーターシートは、以下で指定されたオプションに従って出力に表示される必要があります。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentseparatorsheet
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentSeparatorSheet(DocumentSeparatorSheet.DocumentSeparatorSheetOption[] options)](#DocumentSeparatorSheet-com.aspose.xps.metadata.DocumentSeparatorSheet.DocumentSeparatorSheetOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentSeparatorSheet(DocumentSeparatorSheet.DocumentSeparatorSheetOption[] options) {#DocumentSeparatorSheet-com.aspose.xps.metadata.DocumentSeparatorSheet.DocumentSeparatorSheetOption...-}
+```
+public DocumentSeparatorSheet(DocumentSeparatorSheet.DocumentSeparatorSheetOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [DocumentSeparatorSheetOption\[\]](../../com.aspose.xps.metadata/documentseparatorsheetoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentseparatorsheetoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentseparatorsheetoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "DocumentSeparatorSheet.DocumentSeparatorSheetOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "DocumentSeparatorSheet 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/documentseparatorsheet.documentseparatorsheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class DocumentSeparatorSheet.DocumentSeparatorSheetOption extends Option
+```
+
+DocumentSeparatorSheet 機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BothSheets](#BothSheets) | ドキュメントの開始と終了に区切りシートを指定します。 |
+| [EndSheet](#EndSheet) | ドキュメントの終了に区切りシートを指定します。 |
+| [None](#None) | 区切りシートを指定しません。 |
+| [StartSheet](#StartSheet) | ドキュメントの開始に区切りシートを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BothSheets {#BothSheets}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption BothSheets
+```
+
+
+ドキュメントの開始と終了に区切りシートを指定します。
+
+### EndSheet {#EndSheet}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption EndSheet
+```
+
+
+ドキュメントの終了に区切りシートを指定します。
+
+### None {#None}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption None
+```
+
+
+区切りシートを指定しません。
+
+### StartSheet {#StartSheet}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption StartSheet
+```
+
+
+ドキュメントの開始に区切りシートを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documentstaple/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documentstaple/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentStaple"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のホチキス特性を説明します。"
+type: docs
+weight: 35
+url: /ja/java/com.aspose.xps.metadata/documentstaple/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Staple](../../com.aspose.xps.metadata/staple)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentStaple extends Staple implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+出力のホチキス留め特性について説明します。各文書は個別にホチキス留めされます。JobStapleAllDocuments と DocumentStaple キーワードは相互に排他的です。これらのキーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documentstaple
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentStaple(Staple.StapleOption[] options)](#DocumentStaple-com.aspose.xps.metadata.Staple.StapleOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentStaple(Staple.StapleOption[] options) {#DocumentStaple-com.aspose.xps.metadata.Staple.StapleOption...-}
+```
+public DocumentStaple(Staple.StapleOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [StapleOption\[\]](../../com.aspose.xps.metadata/stapleoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/documenturi/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/documenturi/_index.md
@@ -1,0 +1,153 @@
+---
+title: "DocumentURI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントの統一リソース識別子（URI）を指定します。"
+type: docs
+weight: 36
+url: /ja/java/com.aspose.xps.metadata/documenturi/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.URIProperty](../../com.aspose.xps.metadata/uriproperty)
+```
+public final class DocumentURI extends URIProperty
+```
+
+ドキュメントの一意リソース識別子 (URI) を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/documenturi
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [DocumentURI(String documentURI)](#DocumentURI-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentURI(String documentURI) {#DocumentURI-java.lang.String-}
+```
+public DocumentURI(String documentURI)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentURI | java.lang.String | ドキュメント URI です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/duplex/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/duplex/_index.md
@@ -1,0 +1,149 @@
+---
+title: "Duplex"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobDuplexAllDocumentsContiguously と DocumentDuplex 機能クラスの基底クラスです。"
+type: docs
+weight: 37
+url: /ja/java/com.aspose.xps.metadata/duplex/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class Duplex extends Feature
+```
+
+JobDuplexAllDocumentsContiguously と DocumentDuplex 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/duplexmode/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/duplexmode/_index.md
@@ -1,0 +1,157 @@
+---
+title: "Duplex.DuplexMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "DuplexOptions の DuplexMode スコア付きプロパティの可能な値を定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/duplex.duplexmode/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+```
+public static final class Duplex.DuplexMode extends ScoredProperty
+```
+
+DuplexOption の DuplexMode スコアドプロパティの可能な値を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Automatic](#Automatic) | 自動値。 |
+| [Manual](#Manual) | 手動値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static final Duplex.DuplexMode Automatic
+```
+
+
+自動値。
+
+### Manual {#Manual}
+```
+public static final Duplex.DuplexMode Manual
+```
+
+
+手動値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/duplexoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/duplexoption/_index.md
@@ -1,0 +1,200 @@
+---
+title: "Duplex.DuplexOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobDuplexAllDocumentsContiguously と DocumentDuplex 機能のオプションを説明します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/duplex.duplexoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class Duplex.DuplexOption extends Option
+```
+
+JobDuplexAllDocumentsContiguously と DocumentDuplex 機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [OneSided](#OneSided) | 片面印刷を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [twoSidedLongEdge(Duplex.DuplexMode duplexMode)](#twoSidedLongEdge-com.aspose.xps.metadata.Duplex.DuplexMode-) | ページが MediaSizeHeight 方向に平行に裏返されるように、両面印刷を指定します。 |
+| [twoSidedShortEdge(Duplex.DuplexMode duplexMode)](#twoSidedShortEdge-com.aspose.xps.metadata.Duplex.DuplexMode-) | ページが MediaSizeWidth 方向に平行に裏返されるように、両面印刷を指定します。 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OneSided {#OneSided}
+```
+public static final Duplex.DuplexOption OneSided
+```
+
+
+片面印刷を指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### twoSidedLongEdge(Duplex.DuplexMode duplexMode) {#twoSidedLongEdge-com.aspose.xps.metadata.Duplex.DuplexMode-}
+```
+public static final Duplex.DuplexOption twoSidedLongEdge(Duplex.DuplexMode duplexMode)
+```
+
+
+ページが MediaSizeHeight 方向に平行に裏返されるように、両面印刷を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| duplexMode | [DuplexMode](../../com.aspose.xps.metadata/duplexmode) | DuplexMode |
+
+**Returns:**
+[DuplexOption](../../com.aspose.xps.metadata/duplexoption) - The  Duplex  option.
+### twoSidedShortEdge(Duplex.DuplexMode duplexMode) {#twoSidedShortEdge-com.aspose.xps.metadata.Duplex.DuplexMode-}
+```
+public static final Duplex.DuplexOption twoSidedShortEdge(Duplex.DuplexMode duplexMode)
+```
+
+
+ページが MediaSizeWidth 方向に平行に裏返されるように、両面印刷を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| duplexMode | [DuplexMode](../../com.aspose.xps.metadata/duplexmode) | DuplexMode |
+
+**Returns:**
+[DuplexOption](../../com.aspose.xps.metadata/duplexoption) - The
+
+```
+Duplex
+```
+
+オプション。
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/errorsheetoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/errorsheetoption/_index.md
@@ -1,0 +1,183 @@
+---
+title: "JobErrorSheet.ErrorSheetOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobErrorSheet 機能オプションを記述します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/joberrorsheet.errorsheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem](../../com.aspose.xps.metadata/ijoberrorsheetitem)
+```
+public static final class JobErrorSheet.ErrorSheetOption extends Option implements JobErrorSheet.IJobErrorSheetItem
+```
+
+JobErrorSheet 機能のオプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Custom](#Custom) | カスタム エラーページを出力すべきことを指定します。 |
+| [None](#None) | エラーシートを出力しないことを指定します。 |
+| [Standard](#Standard) | 標準（デバイス定義）エラーシートを出力することを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Custom {#Custom}
+```
+public static final JobErrorSheet.ErrorSheetOption Custom
+```
+
+
+カスタムエラーシートを出力することを指定します。JobErrorSheetSource ParameterInit 要素が指定されていない場合、このオプションは無視されます。
+
+### None {#None}
+```
+public static final JobErrorSheet.ErrorSheetOption None
+```
+
+
+エラーシートを出力しないことを指定します。
+
+### Standard {#Standard}
+```
+public static final JobErrorSheet.ErrorSheetOption Standard
+```
+
+
+標準（デバイス定義）エラーシートを出力することを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/errorsheetwhen/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/errorsheetwhen/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobErrorSheet.ErrorSheetWhen"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "内部の ErrorSheetWhen 機能を説明します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/joberrorsheet.errorsheetwhen/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem](../../com.aspose.xps.metadata/ijoberrorsheetitem)
+```
+public static final class JobErrorSheet.ErrorSheetWhen extends Feature implements JobErrorSheet.IJobErrorSheetItem
+```
+
+ErrorSheetWhen の内部機能を記述します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ErrorSheetWhen(JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption[] options)](#ErrorSheetWhen-com.aspose.xps.metadata.JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ErrorSheetWhen(JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption[] options) {#ErrorSheetWhen-com.aspose.xps.metadata.JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption...-}
+```
+public ErrorSheetWhen(JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ErrorSheetWhenOption\[\]](../../com.aspose.xps.metadata/errorsheetwhenoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/errorsheetwhenoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/errorsheetwhenoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ErrorSheetWhen 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/joberrorsheet.errorsheetwhen.errorsheetwhenoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption extends Option
+```
+
+ErrorSheetWhen 機能のオプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Always](#Always) | すべてのジョブに対してエラーシートが出力されることを指定します。 |
+| [OnError](#OnError) | エラーが発生した場合にのみエラーシートが出力されることを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Always {#Always}
+```
+public static final JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption Always
+```
+
+
+すべてのジョブに対してエラーシートが出力されることを指定します。
+
+### OnError {#OnError}
+```
+public static final JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption OnError
+```
+
+
+エラーが発生した場合にのみエラーシートが出力されることを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/feature/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/feature/_index.md
@@ -1,0 +1,188 @@
+---
+title: "機能"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の Print Schema 機能をカプセル化するクラスです。"
+type: docs
+weight: 38
+url: /ja/java/com.aspose.xps.metadata/feature/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem), [com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public class Feature extends CompositePrintTicketElement implements IPrintTicketItem, IFeatureItem
+```
+
+共通の Print Schema 機能をカプセル化するクラスです。すべてのスキーマ定義機能の基底クラスです。Feature 要素は、デバイス属性、ジョブの書式設定、その他の関連特性を完全に記述する Option 要素と Property 要素の完全なリストを含みます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/feature
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Feature(String name, Option option, IFeatureItem[] items)](#Feature-java.lang.String-com.aspose.xps.metadata.Option-com.aspose.xps.metadata.IFeatureItem...-) | 新しい PrintTicket 機能インスタンスを作成します。 |
+| [Feature(String name, Feature feature, IFeatureItem[] items)](#Feature-java.lang.String-com.aspose.xps.metadata.Feature-com.aspose.xps.metadata.IFeatureItem...-) | 新しい PrintTicket 機能インスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Feature(String name, Option option, IFeatureItem[] items) {#Feature-java.lang.String-com.aspose.xps.metadata.Option-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public Feature(String name, Option option, IFeatureItem[] items)
+```
+
+
+新しい PrintTicket 機能インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | 機能名。 |
+| option | [Option](../../com.aspose.xps.metadata/option) | 必須の  Option  インスタンス。 |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 任意の  IFeatureItem  インスタンスの配列です。各インスタンスは  Feature 、  Option 、または  Property  インスタンスである必要があります。 |
+
+### Feature(String name, Feature feature, IFeatureItem[] items) {#Feature-java.lang.String-com.aspose.xps.metadata.Feature-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public Feature(String name, Feature feature, IFeatureItem[] items)
+```
+
+
+新しい PrintTicket 機能インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | 機能名。 |
+| feature | [Feature](../../com.aspose.xps.metadata/feature) | 必須 Feature インスタンス。 |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 任意の Property インスタンスの配列です。各要素は Feature、Option、または Property インスタンスでなければなりません。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/feeddirection/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/feeddirection/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.FeedDirection"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "FeedDirection のスコアド プロパティ値の定数を定義します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/inputbin.feeddirection/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.FeedDirection extends Property implements InputBin.IInputBinOptionItem
+```
+
+FeedDirection スコアドプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [LongEdgeFirst](#LongEdgeFirst) | LongEdgeFirst の値です。 |
+| [ShortEdgeFirst](#ShortEdgeFirst) | LongEdgeFirst の値です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongEdgeFirst {#LongEdgeFirst}
+```
+public static final InputBin.FeedDirection LongEdgeFirst
+```
+
+
+LongEdgeFirst の値です。
+
+### ShortEdgeFirst {#ShortEdgeFirst}
+```
+public static final InputBin.FeedDirection ShortEdgeFirst
+```
+
+
+LongEdgeFirst の値です。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/feedface/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/feedface/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.FeedFace"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "FeedFace のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/inputbin.feedface/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.FeedFace extends Property implements InputBin.IInputBinOptionItem
+```
+
+FeedFace スコアドプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [FaceDown](#FaceDown) | FaceDown 値。 |
+| [FaceUp](#FaceUp) | FaceUp 値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FaceDown {#FaceDown}
+```
+public static final InputBin.FeedFace FaceDown
+```
+
+
+FaceDown 値。
+
+### FaceUp {#FaceUp}
+```
+public static final InputBin.FeedFace FaceUp
+```
+
+
+FaceUp 値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/feedtype/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/feedtype/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.FeedType"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "FeedType のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/inputbin.feedtype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.FeedType extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+FeedType スコアドプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Automatic](#Automatic) | 自動値。 |
+| [Manual](#Manual) | 手動値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static final InputBin.FeedType Automatic
+```
+
+
+自動値。
+
+### Manual {#Manual}
+```
+public static final InputBin.FeedType Manual
+```
+
+
+手動値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/frontcoating/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/frontcoating/_index.md
@@ -1,0 +1,196 @@
+---
+title: "PageMediaType.FrontCoating"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "FrontCoating のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.frontcoating/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.FrontCoating extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+FrontCoating スコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Glossy](#Glossy) | 光沢のある値。 |
+| [HighGloss](#HighGloss) | ハイグロスの値。 |
+| [Matte](#Matte) | マットの値。 |
+| [None](#None) | None 値。 |
+| [Satin](#Satin) | サテンの値。 |
+| [SemiGloss](#SemiGloss) | セミグロスの値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Glossy {#Glossy}
+```
+public static PageMediaType.FrontCoating Glossy
+```
+
+
+光沢のある値。
+
+### HighGloss {#HighGloss}
+```
+public static PageMediaType.FrontCoating HighGloss
+```
+
+
+ハイグロスの値。
+
+### Matte {#Matte}
+```
+public static PageMediaType.FrontCoating Matte
+```
+
+
+マットの値。
+
+### None {#None}
+```
+public static PageMediaType.FrontCoating None
+```
+
+
+None 値。
+
+### Satin {#Satin}
+```
+public static PageMediaType.FrontCoating Satin
+```
+
+
+サテンの値。
+
+### SemiGloss {#SemiGloss}
+```
+public static PageMediaType.FrontCoating SemiGloss
+```
+
+
+セミグロスの値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/holepunch/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/holepunch/_index.md
@@ -1,0 +1,149 @@
+---
+title: "HolePunch"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobHolePunch と DocumentHolePunch 機能クラスの基底クラスです。"
+type: docs
+weight: 39
+url: /ja/java/com.aspose.xps.metadata/holepunch/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class HolePunch extends Feature
+```
+
+JobHolePunch と DocumentHolePunch 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/holepunchoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/holepunchoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "HolePunch.HolePunchOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "HolePunch 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/holepunch.holepunchoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class HolePunch.HolePunchOption extends Option
+```
+
+HolePunch 機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BottomEdge](#BottomEdge) | 下端に穴（複数）を指定します。 |
+| [LeftEdge](#LeftEdge) | 左端に穴（複数）を指定します。 |
+| [None](#None) | 穴あけなしを指定します。 |
+| [RightEdge](#RightEdge) | 右端に穴（複数）を指定します。 |
+| [TopEdge](#TopEdge) | 上端に穴（複数）を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BottomEdge {#BottomEdge}
+```
+public static HolePunch.HolePunchOption BottomEdge
+```
+
+
+下端に穴（複数）を指定します。
+
+### LeftEdge {#LeftEdge}
+```
+public static HolePunch.HolePunchOption LeftEdge
+```
+
+
+左端に穴（複数）を指定します。
+
+### None {#None}
+```
+public static HolePunch.HolePunchOption None
+```
+
+
+穴あけなしを指定します。
+
+### RightEdge {#RightEdge}
+```
+public static HolePunch.HolePunchOption RightEdge
+```
+
+
+右端に穴（複数）を指定します。
+
+### TopEdge {#TopEdge}
+```
+public static HolePunch.HolePunchOption TopEdge
+```
+
+
+上端に穴（複数）を指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/ibindingoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ibindingoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "JobBindAllDocuments.IBindingOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の BindingOption アイテムのインターフェイスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/jobbindalldocuments.ibindingoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface JobBindAllDocuments.IBindingOptionItem extends IOptionItem
+```
+
+任意の  BindingOption  アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/idocumentprintticketitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/idocumentprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IDocumentPrintTicketItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメント接頭辞付き印刷チケット項目のインターフェイスです。"
+type: docs
+weight: 153
+url: /ja/java/com.aspose.xps.metadata/idocumentprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public interface IDocumentPrintTicketItem extends IPrintTicketItem
+```
+
+ドキュメント接頭辞付き印刷チケット項目のインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/idproperty/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/idproperty/_index.md
@@ -1,0 +1,135 @@
+---
+title: "IDProperty"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobID と DocumentID プロパティ クラスの基底クラスです。"
+type: docs
+weight: 40
+url: /ja/java/com.aspose.xps.metadata/idproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public class IDProperty extends Property
+```
+
+JobID と DocumentID プロパティクラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/ifeatureitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ifeatureitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IFeatureItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Print Schema の機能項目になる可能性のあるクラスの基本インターフェイスです。"
+type: docs
+weight: 154
+url: /ja/java/com.aspose.xps.metadata/ifeatureitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IFeatureItem extends IPrintTicketElementChild
+```
+
+Print Schema Feature 項目になる可能性のあるクラスの基底インターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/iinputbinitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/iinputbinitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "InputBin.IInputBinItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の JobInputBin、DocumentInputBin、PageInputBin 機能項目のインターフェイスです。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.xps.metadata/inputbin.iinputbinitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface InputBin.IInputBinItem extends IFeatureItem
+```
+
+任意の  JobInputBin 、  DocumentInputBin  および  PageInputBin  機能項目のインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/iinputbinoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/iinputbinoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "InputBin.IInputBinOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の InputBinOption アイテムのインターフェイスです。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.xps.metadata/inputbin.iinputbinoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface InputBin.IInputBinOptionItem extends IOptionItem
+```
+
+任意の InputBinOption アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ijobdevicelanguageoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ijobdevicelanguageoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "JobDeviceLanguage.IJobDeviceLanguageOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の JobDeviceLanguageOption アイテムのインターフェイスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/jobdevicelanguage.ijobdevicelanguageoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface JobDeviceLanguage.IJobDeviceLanguageOptionItem extends IOptionItem
+```
+
+任意の  JobDeviceLanguageOption  アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ijoberrorsheetitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ijoberrorsheetitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "JobErrorSheet.IJobErrorSheetItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の JobErrorSheet 機能アイテムのインターフェイスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/joberrorsheet.ijoberrorsheetitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface JobErrorSheet.IJobErrorSheetItem extends IFeatureItem
+```
+
+任意の  JobErrorSheet  機能アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ijobprintticketitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ijobprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IJobPrintTicketItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブ接頭辞付き印刷チケット項目のインターフェイスです。"
+type: docs
+weight: 155
+url: /ja/java/com.aspose.xps.metadata/ijobprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public interface IJobPrintTicketItem extends IPrintTicketItem
+```
+
+ジョブ接頭辞付き印刷チケット項目のインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/inputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/inputbin/_index.md
@@ -1,0 +1,149 @@
+---
+title: "InputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobInputBin、DocumentInputBin、PageInputBin 機能クラスの基本クラスです。"
+type: docs
+weight: 41
+url: /ja/java/com.aspose.xps.metadata/inputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class InputBin extends Feature
+```
+
+JobInputBin、DocumentInputBin、PageInputBin 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/inputbinoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/inputbinoption/_index.md
@@ -1,0 +1,247 @@
+---
+title: "InputBin.InputBinOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobInputBin、DocumentInputBin、PageInputBin の機能オプションを説明します。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.metadata/inputbin.inputbinoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinItem](../../com.aspose.xps.metadata/iinputbinitem)
+```
+public static final class InputBin.InputBinOption extends Option implements InputBin.IInputBinItem
+```
+
+JobInputBin、DocumentInputBin、PageInputBin 機能のオプションを説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [InputBinOption(String optionName, InputBin.IInputBinOptionItem[] items)](#InputBinOption-java.lang.String-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-) | 新しいインスタンスを作成します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AutoSelect](#AutoSelect) | デバイスは構成に基づいて自動的に最適なオプションを選択します。 |
+| [AutoSheetFeeder](#AutoSheetFeeder) | インクジェットプリンター用のデバイス入力トレイです。 |
+| [Cassette](#Cassette) | 給紙トレイがカセットであることを指定します。 |
+| [Manual](#Manual) | デフォルトの手動給紙トレイを指定します。 |
+| [Tractor](#Tractor) | 給紙トレイがトラクタであることを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(InputBin.IInputBinOptionItem[] items)](#add-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-) | オプションに IInputBinOptionItem インスタンスの配列を追加します。 |
+| [clone()](#clone--) | このオプション インスタンスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InputBinOption(String optionName, InputBin.IInputBinOptionItem[] items) {#InputBinOption-java.lang.String-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-}
+```
+public InputBinOption(String optionName, InputBin.IInputBinOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| optionName | java.lang.String | オプション名です。 |
+| items | [IInputBinOptionItem\[\]](../../com.aspose.xps.metadata/iinputbinoptionitem) | 任意の IInputBinOptionItem インスタンスの配列です。 |
+
+### AutoSelect {#AutoSelect}
+```
+public static final InputBin.InputBinOption AutoSelect
+```
+
+
+デバイスは構成に基づいて自動的に最適なオプションを選択します。
+
+### AutoSheetFeeder {#AutoSheetFeeder}
+```
+public static final InputBin.InputBinOption AutoSheetFeeder
+```
+
+
+インクジェットプリンター用のデバイス入力トレイです。
+
+### Cassette {#Cassette}
+```
+public static final InputBin.InputBinOption Cassette
+```
+
+
+給紙トレイがカセットであることを指定します。
+
+### Manual {#Manual}
+```
+public static final InputBin.InputBinOption Manual
+```
+
+
+デフォルトの手動給紙トレイを指定します。
+
+### Tractor {#Tractor}
+```
+public static final InputBin.InputBinOption Tractor
+```
+
+
+給紙トレイがトラクタであることを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(InputBin.IInputBinOptionItem[] items) {#add-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-}
+```
+public InputBin.InputBinOption add(InputBin.IInputBinOptionItem[] items)
+```
+
+
+オプションに IInputBinOptionItem インスタンスの配列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IInputBinOptionItem\[\]](../../com.aspose.xps.metadata/iinputbinoptionitem) | 任意の IInputBinOptionItem インスタンスの配列です。 |
+
+**Returns:**
+[InputBinOption](../../com.aspose.xps.metadata/inputbinoption) - This options instance.
+### clone() {#clone--}
+```
+public InputBin.InputBinOption clone()
+```
+
+
+このオプション インスタンスをクローンします。
+
+**Returns:**
+[InputBinOption](../../com.aspose.xps.metadata/inputbinoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/integerparameterinit/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/integerparameterinit/_index.md
@@ -1,0 +1,187 @@
+---
+title: "IntegerParameterInit"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "すべての整数パラメータ初期化子の基底クラスです。"
+type: docs
+weight: 42
+url: /ja/java/com.aspose.xps.metadata/integerparameterinit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit)
+```
+public abstract class IntegerParameterInit extends ParameterInit
+```
+
+すべての整数パラメータ初期化子の基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [IntegerParameterInit(String name, int value)](#IntegerParameterInit-java.lang.String-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntegerParameterInit(String name, int value) {#IntegerParameterInit-java.lang.String-int-}
+```
+public IntegerParameterInit(String name, int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | パラメータ名。 |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/integervalue/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/integervalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "IntegerValue"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ドキュメントで整数値をカプセル化するクラスです。"
+type: docs
+weight: 43
+url: /ja/java/com.aspose.xps.metadata/integervalue/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)、[com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class IntegerValue extends Value
+```
+
+PrintTicket ドキュメントで整数値をカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [IntegerValue(int value)](#IntegerValue-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [getValueString()](#getValueString--) | 値を文字列として取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntegerValue(int value) {#IntegerValue-int-}
+```
+public IntegerValue(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 整数値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+値を文字列として取得します。
+
+**Returns:**
+java.lang.String - 値を文字列として取得します。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/inupitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/inupitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "NUp.INUpItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobNUpAllDocumentsContiguously または DocumentNUp 機能項目のインターフェイス。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/nup.inupitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface NUp.INUpItem extends IFeatureItem
+```
+
+JobNUpAllDocumentsContiguously または DocumentNUp 機能項目のインターフェイス。

--- a/japanese/java/com.aspose.xps.metadata/ioptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ioptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Print Schema オプション項目になる可能性のあるクラスのインターフェイスです。"
+type: docs
+weight: 156
+url: /ja/java/com.aspose.xps.metadata/ioptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IOptionItem extends IPrintTicketElementChild
+```
+
+Print Schema  Option  項目になる可能性のあるクラスのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ioutputbinitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ioutputbinitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "OutputBin.IOutputBinItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の JobOutputBin、DocumentOutputBin、PageOutputBin 機能アイテムのインターフェイスです。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/outputbin.ioutputbinitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface OutputBin.IOutputBinItem extends IFeatureItem
+```
+
+任意の  JobOutputBin ,  DocumentOutputBin  と  PageOutputBin  機能アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ioutputbinoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ioutputbinoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "OutputBin.IOutputBinOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の OutputBinOption アイテムのインターフェイスです。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.metadata/outputbin.ioutputbinoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface OutputBin.IOutputBinOptionItem extends IOptionItem
+```
+
+任意の OutputBinOption アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagemediasizeitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagemediasizeitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaSize.IPageMediaSizeItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageMediaSize アイテムのインターフェイスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/pagemediasize.ipagemediasizeitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageMediaSize.IPageMediaSizeItem extends IFeatureItem
+```
+
+任意の  PageMediaSize  アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagemediasizeoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagemediasizeoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaSize.IPageMediaSizeOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageMediaSizeOption アイテムのインターフェイスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/pagemediasize.ipagemediasizeoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageMediaSize.IPageMediaSizeOptionItem extends IOptionItem
+```
+
+任意の  PageMediaSizeOption  アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagemediatypeitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagemediatypeitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaType.IPageMediaTypeItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageMediaType 機能項目のインターフェイスです。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.ipagemediatypeitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageMediaType.IPageMediaTypeItem extends IFeatureItem
+```
+
+任意の PageMediaType 機能項目のインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagemediatypeoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagemediatypeoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaType.IPageMediaTypeOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageMediaType 項目のインターフェイス。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.ipagemediatypeoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageMediaType.IPageMediaTypeOptionItem extends IOptionItem
+```
+
+PageMediaType 項目のインターフェイス。

--- a/japanese/java/com.aspose.xps.metadata/ipageoutputcoloritem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipageoutputcoloritem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageOutputColor.IPageOutputColorItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageOutputColor 機能アイテムのインターフェイスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/pageoutputcolor.ipageoutputcoloritem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageOutputColor.IPageOutputColorItem extends IFeatureItem
+```
+
+任意の  PageOutputColor  機能アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipageoutputcoloroptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipageoutputcoloroptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageOutputColor.IPageOutputColorOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageOutputColorOption アイテムのインターフェイスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/pageoutputcolor.ipageoutputcoloroptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageOutputColor.IPageOutputColorOptionItem extends IOptionItem
+```
+
+任意の PageOutputColorOption アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipageprintticketitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipageprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IPagePrintTicketItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページ接頭辞付き印刷チケット項目のインターフェイスです。"
+type: docs
+weight: 157
+url: /ja/java/com.aspose.xps.metadata/ipageprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public interface IPagePrintTicketItem extends IPrintTicketItem
+```
+
+ページ接頭辞付き印刷チケット項目のインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipageresolutionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipageresolutionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageResolution.IPageResolutionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageResolution 機能項目のインターフェイスです。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/pageresolution.ipageresolutionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageResolution.IPageResolutionItem extends IFeatureItem
+```
+
+任意の PageResolution 機能項目のインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipageresolutionoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipageresolutionoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageResolution.IPageResolutionOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageResolutionOption アイテムのインターフェイスです。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/pageresolution.ipageresolutionoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageResolution.IPageResolutionOptionItem extends IOptionItem
+```
+
+任意の  PageResolutionOption  アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagescalingitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagescalingitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageScaling.IPageScalingItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageScaling 機能アイテムのインターフェイスです。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/pagescaling.ipagescalingitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageScaling.IPageScalingItem extends IFeatureItem
+```
+
+任意の  PageScaling  機能アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagewatermarkitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagewatermarkitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageWatermark.IPageWatermarkItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageWatermark 機能アイテムのインターフェイスです。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/pagewatermark.ipagewatermarkitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageWatermark.IPageWatermarkItem extends IFeatureItem
+```
+
+任意の PageWatermark 機能アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/ipagewatermarkoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipagewatermarkoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageWatermark.IPageWatermarkOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の PageWatermarkOption アイテムのインターフェイスです。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.metadata/pagewatermark.ipagewatermarkoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageWatermark.IPageWatermarkOptionItem extends IOptionItem
+```
+
+任意の  PageWatermarkOption  アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/iprintticketelementchild/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/iprintticketelementchild/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IPrintTicketElementChild"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の Print Schema 要素の子要素の基本インターフェイスです。"
+type: docs
+weight: 158
+url: /ja/java/com.aspose.xps.metadata/iprintticketelementchild/
+---```
+public interface IPrintTicketElementChild
+```
+
+The base interface of a child element of any Print Schema element.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getName()](#getName--) | Returns the child name. |
+### getName() {#getName--}
+```
+public abstract String getName()
+```
+
+
+Returns the child name.
+
+**Returns:**
+java.lang.String - The child name.

--- a/japanese/java/com.aspose.xps.metadata/iprintticketitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/iprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IPrintTicketItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ルート要素項目になる可能性のあるクラスの基本インターフェイスです。"
+type: docs
+weight: 159
+url: /ja/java/com.aspose.xps.metadata/iprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IPrintTicketItem extends IPrintTicketElementChild
+```
+
+PrintTicket ルート要素項目になる可能性のあるクラスの基本インターフェイスです。また、スコーピングプレフィックスを定義するインターフェイスの基本インターフェイスでもあります。

--- a/japanese/java/com.aspose.xps.metadata/ipropertyitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/ipropertyitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IPropertyItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket プロパティ アイテムになる可能性のあるクラスの基本インターフェイスです。"
+type: docs
+weight: 160
+url: /ja/java/com.aspose.xps.metadata/ipropertyitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IPropertyItem extends IPrintTicketElementChild
+```
+
+PrintTicket  Property  項目になる可能性のあるクラスの基本インターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/iscoredpropertyitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/iscoredpropertyitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IScoredPropertyItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ScoredProperty アイテムになる可能性のあるクラスの基本インターフェイスです。"
+type: docs
+weight: 161
+url: /ja/java/com.aspose.xps.metadata/iscoredpropertyitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IScoredPropertyItem extends IPrintTicketElementChild
+```
+
+PrintTicket  ScoredProperty  項目になる可能性のあるクラスの基本インターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/istapleoptionitem/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/istapleoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Staple.IStapleOptionItem"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の StapleOption アイテムのインターフェイスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/staple.istapleoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface Staple.IStapleOptionItem extends IOptionItem
+```
+
+任意の StapleOption アイテムのインターフェイスです。

--- a/japanese/java/com.aspose.xps.metadata/jobaccountingsheet/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobaccountingsheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobAccountingSheet"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブの出力対象となる会計シートを記述します。"
+type: docs
+weight: 44
+url: /ja/java/com.aspose.xps.metadata/jobaccountingsheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobAccountingSheet extends Feature implements IJobPrintTicketItem
+```
+
+ジョブの出力用会計シートを説明します。会計シートはデフォルトの PageMediaSize 上に、デフォルトの PageMediaType を使用して出力する必要があります。会計シートはジョブの残りの部分から分離されている必要があります。つまり、JobDuplex、JobStaple、または JobBinding などの仕上げや処理オプションには会計シートを含めてはいけません。会計シートは実装者の裁量でジョブの最初または最後のページとして配置できる場合があります。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobaccountingsheet
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobAccountingSheet(JobAccountingSheet.JobAccountingSheetOption[] options)](#JobAccountingSheet-com.aspose.xps.metadata.JobAccountingSheet.JobAccountingSheetOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobAccountingSheet(JobAccountingSheet.JobAccountingSheetOption[] options) {#JobAccountingSheet-com.aspose.xps.metadata.JobAccountingSheet.JobAccountingSheetOption...-}
+```
+public JobAccountingSheet(JobAccountingSheet.JobAccountingSheetOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [JobAccountingSheetOption\[\]](../../com.aspose.xps.metadata/jobaccountingsheetoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobaccountingsheetoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobaccountingsheetoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "JobAccountingSheet.JobAccountingSheetOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobAccountingSheet 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobaccountingsheet.jobaccountingsheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobAccountingSheet.JobAccountingSheetOption extends Option
+```
+
+JobAccountingSheet 機能のオプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | 会計シートが出力されないことを指定します。 |
+| [Standard](#Standard) | 標準（デバイス定義）会計シートが出力されることを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final JobAccountingSheet.JobAccountingSheetOption None
+```
+
+
+会計シートが出力されないことを指定します。
+
+### Standard {#Standard}
+```
+public static final JobAccountingSheet.JobAccountingSheetOption Standard
+```
+
+
+標準（デバイス定義）会計シートが出力されることを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobbindalldocuments/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobbindalldocuments/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobBindAllDocuments"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "製本方法を説明します。"
+type: docs
+weight: 45
+url: /ja/java/com.aspose.xps.metadata/jobbindalldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobBindAllDocuments extends Feature implements IJobPrintTicketItem
+```
+
+綴じ方を説明します。ジョブ内のすべてのドキュメントがまとめて綴じられます。JobBindAllDocuments と DocumentBinding は相互に排他的です。これらのキーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobbindalldocuments
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobBindAllDocuments(JobBindAllDocuments.BindingOption[] options)](#JobBindAllDocuments-com.aspose.xps.metadata.JobBindAllDocuments.BindingOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobBindAllDocuments(JobBindAllDocuments.BindingOption[] options) {#JobBindAllDocuments-com.aspose.xps.metadata.JobBindAllDocuments.BindingOption...-}
+```
+public JobBindAllDocuments(JobBindAllDocuments.BindingOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [BindingOption\[\]](../../com.aspose.xps.metadata/bindingoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobbindalldocumentsgutter/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobbindalldocumentsgutter/_index.md
@@ -1,0 +1,189 @@
+---
+title: "JobBindAllDocumentsGutter"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "製本用のガター幅を指定します。"
+type: docs
+weight: 46
+url: /ja/java/com.aspose.xps.metadata/jobbindalldocumentsgutter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobBindAllDocumentsGutter extends IntegerParameterInit implements IJobPrintTicketItem
+```
+
+綴じ込みの溝幅を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobbindalldocumentsgutter
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobBindAllDocumentsGutter(int value)](#JobBindAllDocumentsGutter-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobBindAllDocumentsGutter(int value) {#JobBindAllDocumentsGutter-int-}
+```
+public JobBindAllDocumentsGutter(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobcollatealldocuments/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobcollatealldocuments/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobCollateAllDocuments"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の段組特性を説明します。"
+type: docs
+weight: 47
+url: /ja/java/com.aspose.xps.metadata/jobcollatealldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Collate](../../com.aspose.xps.metadata/collate)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobCollateAllDocuments extends Collate implements IJobPrintTicketItem
+```
+
+出力の連結特性を説明します。各個別ジョブ内のすべてのドキュメントが連結されます。DocumentCollate と JobCollateAllDocuments は相互に排他的です。これらのキーワードの両方または一方のみが実装されるかどうかの動作と実装はドライバーに委ねられます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobcollatealldocuments
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobCollateAllDocuments(Collate.CollateOption[] options)](#JobCollateAllDocuments-com.aspose.xps.metadata.Collate.CollateOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobCollateAllDocuments(Collate.CollateOption[] options) {#JobCollateAllDocuments-com.aspose.xps.metadata.Collate.CollateOption...-}
+```
+public JobCollateAllDocuments(Collate.CollateOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [CollateOption\[\]](../../com.aspose.xps.metadata/collateoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobcomment/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobcomment/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobComment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブに関連付けられたコメントを指定します。"
+type: docs
+weight: 48
+url: /ja/java/com.aspose.xps.metadata/jobcomment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobComment extends StringParameterInit implements IJobPrintTicketItem
+```
+
+ジョブに関連付けられたコメントを指定します。例: "Please deliver to room 1234 when completed". https://docs.microsoft.com/en-us/windows/win32/printdocs/jobcomment
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobComment(String value)](#JobComment-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobComment(String value) {#JobComment-java.lang.String-}
+```
+public JobComment(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobcopiesalldocuments/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobcopiesalldocuments/_index.md
@@ -1,0 +1,189 @@
+---
+title: "JobCopiesAllDocuments"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブのコピー数を指定します。"
+type: docs
+weight: 49
+url: /ja/java/com.aspose.xps.metadata/jobcopiesalldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobCopiesAllDocuments extends IntegerParameterInit implements IJobPrintTicketItem
+```
+
+ジョブのコピー数を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobcopiesalldocuments
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobCopiesAllDocuments(int value)](#JobCopiesAllDocuments-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobCopiesAllDocuments(int value) {#JobCopiesAllDocuments-int-}
+```
+public JobCopiesAllDocuments(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobdevicelanguage/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobdevicelanguage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobDeviceLanguage"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドライバーから物理デバイスへデータを送信する際にサポートされるデバイス言語を記述します。"
+type: docs
+weight: 50
+url: /ja/java/com.aspose.xps.metadata/jobdevicelanguage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobDeviceLanguage extends Feature implements IJobPrintTicketItem
+```
+
+ドライバーから物理デバイスへデータを送信する際にサポートされるデバイス言語を説明します。これはしばしば "Page Description Language" と呼ばれます。このキーワードは、ドライバーと物理デバイスがサポートするページ記述言語を定義します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobdevicelanguage
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobDeviceLanguage(JobDeviceLanguage.JobDeviceLanguageOption[] options)](#JobDeviceLanguage-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDeviceLanguage(JobDeviceLanguage.JobDeviceLanguageOption[] options) {#JobDeviceLanguage-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption...-}
+```
+public JobDeviceLanguage(JobDeviceLanguage.JobDeviceLanguageOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [JobDeviceLanguageOption\[\]](../../com.aspose.xps.metadata/jobdevicelanguageoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobdevicelanguageoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobdevicelanguageoption/_index.md
@@ -1,0 +1,432 @@
+---
+title: "JobDeviceLanguage.JobDeviceLanguageOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobDeviceLanguage 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobdevicelanguage.jobdevicelanguageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobDeviceLanguage.JobDeviceLanguageOption extends Option
+```
+
+JobDeviceLanguage 機能のオプションを記述します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobDeviceLanguageOption(String name, JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)](#JobDeviceLanguageOption-java.lang.String-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-) | 新しいインスタンスを作成します。 |
+| [JobDeviceLanguageOption(JobDeviceLanguage.JobDeviceLanguageOption option)](#JobDeviceLanguageOption-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption-) | このオプション インスタンスをクローンします。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ART](#ART) | 指定されたデバイス言語は ART です。 |
+| [ASCII](#ASCII) | 指定されたデバイス言語は ASCII です。 |
+| [CaPSL](#CaPSL) | 指定されたデバイス言語は CaPSL です。 |
+| [ESCP2](#ESCP2) | 指定されたデバイス言語は ESC/P2 です。 |
+| [ESCPage](#ESCPage) | 指定されたデバイス言語は ESC/Page です。 |
+| [HPGL2](#HPGL2) | 指定されたデバイス言語は HP-GL/2 です。 |
+| [KPDL](#KPDL) | 指定されたデバイス言語は KPDL です。 |
+| [KS](#KS) | 指定されたデバイス言語は KS です。 |
+| [KSSM](#KSSM) | 指定されたデバイス言語は KSSM です。 |
+| [PCL](#PCL) | 指定されたデバイス言語は PCL です。 |
+| [PCL5c](#PCL5c) | 指定されたデバイス言語は PCL5c です。 |
+| [PCL5e](#PCL5e) | 指定されたデバイス言語は PCL5e です。 |
+| [PCLXL](#PCLXL) | 指定されたデバイス言語は PCL-XL です。 |
+| [PPDS](#PPDS) | 指定されたデバイス言語は PPDS です。 |
+| [PostScript](#PostScript) | 指定されたデバイス言語は PostScript です。 |
+| [RPDL](#RPDL) | 指定されたデバイス言語は RPDL です。 |
+| [RTL](#RTL) | 指定されたデバイス言語は RTL です。 |
+| [XPS](#XPS) | デバイス言語は XPS であることを指定します。 |
+| [_201PL](#-201PL) | デバイス言語は PC-PR201 であることを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)](#add-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-) | オプションに IJobDeviceLanguageOptionItem インスタンスのリストを追加します。 |
+| [clone()](#clone--) | このオプション インスタンスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLanguageEncoding(String languageEncoding)](#setLanguageEncoding-java.lang.String-) | LanguageEncoding のスコア付きプロパティ値を設定します。 |
+| [setLanguageLevel(String languageLevel)](#setLanguageLevel-java.lang.String-) | LanguageLevel のスコア付きプロパティ値を設定します。 |
+| [setLanguageVersion(String languageVersion)](#setLanguageVersion-java.lang.String-) | LanguageVersion のスコア付きプロパティ値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDeviceLanguageOption(String name, JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items) {#JobDeviceLanguageOption-java.lang.String-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-}
+```
+public JobDeviceLanguageOption(String name, JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | オプション名。 |
+| items | [IJobDeviceLanguageOptionItem\[\]](../../com.aspose.xps.metadata/ijobdevicelanguageoptionitem) | 任意の IJobDeviceLanguageOptionItem インスタンスの配列。 |
+
+### JobDeviceLanguageOption(JobDeviceLanguage.JobDeviceLanguageOption option) {#JobDeviceLanguageOption-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption-}
+```
+public JobDeviceLanguageOption(JobDeviceLanguage.JobDeviceLanguageOption option)
+```
+
+
+このオプション インスタンスをクローンします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| option | [JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) | クローン対象のインスタンス。 |
+
+### ART {#ART}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ART
+```
+
+
+指定されたデバイス言語は ART です。
+
+### ASCII {#ASCII}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ASCII
+```
+
+
+指定されたデバイス言語は ASCII です。
+
+### CaPSL {#CaPSL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption CaPSL
+```
+
+
+指定されたデバイス言語は CaPSL です。
+
+### ESCP2 {#ESCP2}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ESCP2
+```
+
+
+指定されたデバイス言語は ESC/P2 です。
+
+### ESCPage {#ESCPage}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ESCPage
+```
+
+
+指定されたデバイス言語は ESC/Page です。
+
+### HPGL2 {#HPGL2}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption HPGL2
+```
+
+
+指定されたデバイス言語は HP-GL/2 です。
+
+### KPDL {#KPDL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption KPDL
+```
+
+
+指定されたデバイス言語は KPDL です。
+
+### KS {#KS}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption KS
+```
+
+
+指定されたデバイス言語は KS です。
+
+### KSSM {#KSSM}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption KSSM
+```
+
+
+指定されたデバイス言語は KSSM です。
+
+### PCL {#PCL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCL
+```
+
+
+指定されたデバイス言語は PCL です。
+
+### PCL5c {#PCL5c}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCL5c
+```
+
+
+指定されたデバイス言語は PCL5c です。
+
+### PCL5e {#PCL5e}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCL5e
+```
+
+
+指定されたデバイス言語は PCL5e です。
+
+### PCLXL {#PCLXL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCLXL
+```
+
+
+指定されたデバイス言語は PCL-XL です。
+
+### PPDS {#PPDS}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PPDS
+```
+
+
+指定されたデバイス言語は PPDS です。
+
+### PostScript {#PostScript}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PostScript
+```
+
+
+指定されたデバイス言語は PostScript です。
+
+### RPDL {#RPDL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption RPDL
+```
+
+
+指定されたデバイス言語は RPDL です。
+
+### RTL {#RTL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption RTL
+```
+
+
+指定されたデバイス言語は RTL です。
+
+### XPS {#XPS}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption XPS
+```
+
+
+デバイス言語は XPS であることを指定します。
+
+### _201PL {#-201PL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption _201PL
+```
+
+
+デバイス言語は PC-PR201 であることを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items) {#add-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption add(JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)
+```
+
+
+オプションに IJobDeviceLanguageOptionItem インスタンスのリストを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IJobDeviceLanguageOptionItem\[\]](../../com.aspose.xps.metadata/ijobdevicelanguageoptionitem) | 任意の IJobDeviceLanguageOptionItem インスタンスの配列。 |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### clone() {#clone--}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption clone()
+```
+
+
+このオプションインスタンスをクローンします。クローン作成コンストラクタへのショートカットです。
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLanguageEncoding(String languageEncoding) {#setLanguageEncoding-java.lang.String-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption setLanguageEncoding(String languageEncoding)
+```
+
+
+LanguageEncoding のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| languageEncoding | java.lang.String | LanguageEncoding のスコア付きプロパティ値。 |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### setLanguageLevel(String languageLevel) {#setLanguageLevel-java.lang.String-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption setLanguageLevel(String languageLevel)
+```
+
+
+LanguageLevel のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| languageLevel | java.lang.String | LanguageLevel のスコア付きプロパティ値。 |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### setLanguageVersion(String languageVersion) {#setLanguageVersion-java.lang.String-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption setLanguageVersion(String languageVersion)
+```
+
+
+LanguageVersion のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| languageVersion | java.lang.String | LanguageVersion のスコア付きプロパティ値。 |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobDigitalSignatureProcessing"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブ全体のデジタル署名処理の構成方法を記述します。"
+type: docs
+weight: 51
+url: /ja/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobDigitalSignatureProcessing extends Feature implements IJobPrintTicketItem
+```
+
+ジョブ全体のデジタル署名処理の設定方法を説明します。デジタル署名を含むコンテンツにのみ適用されます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobdigitalsignatureprocessing
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobDigitalSignatureProcessing(JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption[] options)](#JobDigitalSignatureProcessing-com.aspose.xps.metadata.JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDigitalSignatureProcessing(JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption[] options) {#JobDigitalSignatureProcessing-com.aspose.xps.metadata.JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption...-}
+```
+public JobDigitalSignatureProcessing(JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [JobDigitalSignatureProcessingOption\[\]](../../com.aspose.xps.metadata/jobdigitalsignatureprocessingoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobdigitalsignatureprocessingoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobdigitalsignatureprocessingoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobDigitalSignatureProcessing 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing.jobdigitalsignatureprocessingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption extends Option
+```
+
+JobDigitalSignatureProcessing 機能のオプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [PrintInvalidSignatures](#PrintInvalidSignatures) | デジタル署名の有効性に関係なくジョブを印刷します。 |
+| [PrintInvalidSignaturesWithErrorReport](#PrintInvalidSignaturesWithErrorReport) | デジタル署名の有効性に関係なくジョブを印刷します。 |
+| [PrintOnlyValidSignatures](#PrintOnlyValidSignatures) | すべてのデジタル署名が有効な場合にのみジョブを印刷します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintInvalidSignatures {#PrintInvalidSignatures}
+```
+public static final JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption PrintInvalidSignatures
+```
+
+
+デジタル署名の有効性に関係なくジョブを印刷します。デジタル署名は無視されても構いません。
+
+### PrintInvalidSignaturesWithErrorReport {#PrintInvalidSignaturesWithErrorReport}
+```
+public static final JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption PrintInvalidSignaturesWithErrorReport
+```
+
+
+デジタル署名の有効性に関係なくジョブを印刷します。無効な署名が検出された場合、ジョブの最後にエラーページが印刷されるべきです。デジタル署名は無視してはなりません。
+
+### PrintOnlyValidSignatures {#PrintOnlyValidSignatures}
+```
+public static final JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption PrintOnlyValidSignatures
+```
+
+
+すべてのデジタル署名が有効な場合にのみジョブを印刷します。デジタル署名は無視してはなりません。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobduplexalldocumentscontiguously/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobduplexalldocumentscontiguously/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobDuplexAllDocumentsContiguously"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の両面印刷特性を説明します。"
+type: docs
+weight: 52
+url: /ja/java/com.aspose.xps.metadata/jobduplexalldocumentscontiguously/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Duplex](../../com.aspose.xps.metadata/duplex)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobDuplexAllDocumentsContiguously extends Duplex implements IJobPrintTicketItem
+```
+
+出力の両面印刷特性を説明します。duplex 機能は媒体の両面に印刷できるようにします。ジョブ内のすべてのドキュメントは連続して両面印刷されます。JobDuplexAllDocumentsContiguously と DocumentDuplex は相互に排他的です。これらのキーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobduplexalldocumentscontiguously
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobDuplexAllDocumentsContiguously(Duplex.DuplexOption[] options)](#JobDuplexAllDocumentsContiguously-com.aspose.xps.metadata.Duplex.DuplexOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDuplexAllDocumentsContiguously(Duplex.DuplexOption[] options) {#JobDuplexAllDocumentsContiguously-com.aspose.xps.metadata.Duplex.DuplexOption...-}
+```
+public JobDuplexAllDocumentsContiguously(Duplex.DuplexOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [DuplexOption\[\]](../../com.aspose.xps.metadata/duplexoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joberrorsheet/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joberrorsheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobErrorSheet"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "エラー�シートの出力を記述します。"
+type: docs
+weight: 53
+url: /ja/java/com.aspose.xps.metadata/joberrorsheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobErrorSheet extends Feature implements IJobPrintTicketItem
+```
+
+エラーシートの出力を説明します。ジョブ全体でエラーシートは 1 枚だけです。エラーシートはデフォルトの PageMediaSize とデフォルトの PageMediaType を使用して出力する必要があります。エラーシートはジョブの残りの部分から分離されるべきです。つまり、JobDuplex、JobStaple、JobBinding などの仕上げや処理オプションにはエラーシートを含めてはいけません。エラーシートはジョブの最終シートとして配置されるべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/joberrorsheet
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobErrorSheet(JobErrorSheet.IJobErrorSheetItem[] items)](#JobErrorSheet-com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobErrorSheet(JobErrorSheet.IJobErrorSheetItem[] items) {#JobErrorSheet-com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem...-}
+```
+public JobErrorSheet(JobErrorSheet.IJobErrorSheetItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IJobErrorSheetItem\[\]](../../com.aspose.xps.metadata/ijoberrorsheetitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joberrorsheetsource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joberrorsheetsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobErrorSheetSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタムエラー�シートのソースを指定します。"
+type: docs
+weight: 54
+url: /ja/java/com.aspose.xps.metadata/joberrorsheetsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobErrorSheetSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+カスタムエラーシートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/joberrorsheetsource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobErrorSheetSource(String value)](#JobErrorSheetSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobErrorSheetSource(String value) {#JobErrorSheetSource-java.lang.String-}
+```
+public JobErrorSheetSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobholepunch/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobholepunch/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobHolePunch"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の穴あけ特性を説明します。"
+type: docs
+weight: 55
+url: /ja/java/com.aspose.xps.metadata/jobholepunch/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.HolePunch](../../com.aspose.xps.metadata/holepunch)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobHolePunch extends HolePunch implements IJobPrintTicketItem
+```
+
+出力の穴あけ特性を説明します。すべてのドキュメントは一緒に穴あけされます。JobHolePunch と DocumentHolePunch キーワードは相互に排他的です。PrintTicket または Print Capabilities ドキュメントで両方を同時に指定してはいけません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobholepunch
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobHolePunch(HolePunch.HolePunchOption[] options)](#JobHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobHolePunch(HolePunch.HolePunchOption[] options) {#JobHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-}
+```
+public JobHolePunch(HolePunch.HolePunchOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [HolePunchOption\[\]](../../com.aspose.xps.metadata/holepunchoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobid/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobid/_index.md
@@ -1,0 +1,153 @@
+---
+title: "JobID"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブの一意の ID を指定します。"
+type: docs
+weight: 56
+url: /ja/java/com.aspose.xps.metadata/jobid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.IDProperty](../../com.aspose.xps.metadata/idproperty)
+```
+public final class JobID extends IDProperty
+```
+
+ジョブの一意の ID を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobid
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobID(String jobID)](#JobID-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobID(String jobID) {#JobID-java.lang.String-}
+```
+public JobID(String jobID)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| jobID | java.lang.String | ジョブ IDです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobinputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobinputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobInputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスにインストールされた入力ビン、またはデバイスがサポートするビンの全リストを説明します。"
+type: docs
+weight: 57
+url: /ja/java/com.aspose.xps.metadata/jobinputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.InputBin](../../com.aspose.xps.metadata/inputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobInputBin extends InputBin implements IJobPrintTicketItem
+```
+
+デバイスにインストールされている入力ビン、またはデバイスがサポートするビンの完全なリストを記述します。ジョブ単位で入力ビンを指定できます。JobInputBin、DocumentInputBin、PageInputBin キーワードは相互に排他的です。PrintTicket または Print Capabilities ドキュメントで同時に指定すべきではありません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobinputbin
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobInputBin(InputBin.IInputBinItem[] items)](#JobInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobInputBin(InputBin.IInputBinItem[] items) {#JobInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-}
+```
+public JobInputBin(InputBin.IInputBinItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IInputBinItem\[\]](../../com.aspose.xps.metadata/iinputbinitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobname/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobname/_index.md
@@ -1,0 +1,153 @@
+---
+title: "JobName"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブの説明名を指定します。"
+type: docs
+weight: 59
+url: /ja/java/com.aspose.xps.metadata/jobname/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.NameProperty](../../com.aspose.xps.metadata/nameproperty)
+```
+public final class JobName extends NameProperty
+```
+
+ジョブの説明名を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobname
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobName(String jobName)](#JobName-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobName(String jobName) {#JobName-java.lang.String-}
+```
+public JobName(String jobName)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| jobName | java.lang.String | ジョブ名です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobnupalldocumentscontiguously/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobnupalldocumentscontiguously/_index.md
@@ -1,0 +1,186 @@
+---
+title: "JobNUpAllDocumentsContiguously"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "複数の論理ページを 1 枚の物理シートに出力する方法を記述します。"
+type: docs
+weight: 58
+url: /ja/java/com.aspose.xps.metadata/jobnupalldocumentscontiguously/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.NUp](../../com.aspose.xps.metadata/nup)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobNUpAllDocumentsContiguously extends NUp implements IJobPrintTicketItem
+```
+
+複数の論理ページを 1 枚の物理シートに出力することを説明します。ジョブ内のすべてのドキュメントは連続してまとめられます。JobNUpAllDocumentsContiguously と DocumentNUp は相互に排他的です。これらのキーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobnupalldocumentscontiguously
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobNUpAllDocumentsContiguously(NUp.INUpItem[] items)](#JobNUpAllDocumentsContiguously-com.aspose.xps.metadata.NUp.INUpItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [addPagesPerSheetOption(int value)](#addPagesPerSheetOption-int-) | PagesPerSheet スコアドプロパティ値を持つオプションを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobNUpAllDocumentsContiguously(NUp.INUpItem[] items) {#JobNUpAllDocumentsContiguously-com.aspose.xps.metadata.NUp.INUpItem...-}
+```
+public JobNUpAllDocumentsContiguously(NUp.INUpItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [INUpItem\[\]](../../com.aspose.xps.metadata/inupitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### addPagesPerSheetOption(int value) {#addPagesPerSheetOption-int-}
+```
+public JobNUpAllDocumentsContiguously addPagesPerSheetOption(int value)
+```
+
+
+PagesPerSheet スコアドプロパティ値を持つオプションを追加します。物理シートあたりの論理ページ数を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | PagesPerSheet スコアドプロパティ値です。サポートされるセットは任意の整数集合で構いません。例: \{1,2,4,6,8,9,16\}。 |
+
+**Returns:**
+[JobNUpAllDocumentsContiguously](../../com.aspose.xps.metadata/jobnupalldocumentscontiguously) - This feature instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile/_index.md
@@ -1,0 +1,158 @@
+---
+title: "JobOptimalDestinationColorProfile"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "現在のデバイス構成に基づく最適なカラープロファイルを指定します。"
+type: docs
+weight: 60
+url: /ja/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobOptimalDestinationColorProfile extends Property implements IJobPrintTicketItem
+```
+
+現在のデバイス構成に基づく最適なカラープロファイルを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/joboptimaldestinationcolorprofile
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobOptimalDestinationColorProfile(JobOptimalDestinationColorProfile.Profile profile, String profileData, String path)](#JobOptimalDestinationColorProfile-com.aspose.xps.metadata.JobOptimalDestinationColorProfile.Profile-java.lang.String-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobOptimalDestinationColorProfile(JobOptimalDestinationColorProfile.Profile profile, String profileData, String path) {#JobOptimalDestinationColorProfile-com.aspose.xps.metadata.JobOptimalDestinationColorProfile.Profile-java.lang.String-java.lang.String-}
+```
+public JobOptimalDestinationColorProfile(JobOptimalDestinationColorProfile.Profile profile, String profileData, String path)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| profile | [Profile](../../com.aspose.xps.metadata/profile) | カラープロファイルです。 |
+| profileData | java.lang.String | カラープロファイルデータの内容です。 |
+| path | java.lang.String | カラープロファイルへのパスです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joboutputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joboutputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobOutputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスにインストールされた出力ビン、またはデバイスがサポートするビンの全リストを記述します。"
+type: docs
+weight: 61
+url: /ja/java/com.aspose.xps.metadata/joboutputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.OutputBin](../../com.aspose.xps.metadata/outputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobOutputBin extends OutputBin implements IJobPrintTicketItem
+```
+
+デバイスにインストールされている出力トレイ、またはデバイスがサポートするトレイの完全なリストを記述します。JobOutputBin、DocumentOutputBin、PageOutputBin キーワードは相互に排他的で、PrintTicket または Print Capabilities ドキュメントで1つだけ指定すべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/joboutputbin
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobOutputBin(OutputBin.IOutputBinItem[] items)](#JobOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobOutputBin(OutputBin.IOutputBinItem[] items) {#JobOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-}
+```
+public JobOutputBin(OutputBin.IOutputBinItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOutputBinItem\[\]](../../com.aspose.xps.metadata/ioutputbinitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joboutputoptimization/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joboutputoptimization/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobOutputOptimization"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "指定されたオプションで示される特定の使用シナリオに合わせて出力を最適化することを目的としたジョブ処理を説明します。"
+type: docs
+weight: 62
+url: /ja/java/com.aspose.xps.metadata/joboutputoptimization/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobOutputOptimization extends Feature implements IJobPrintTicketItem
+```
+
+ジョブ処理を説明します。指定されたオプションで示される特定の使用シナリオに合わせて出力を最適化することを目的としています。 https://docs.microsoft.com/en-us/windows/win32/printdocs/joboutputoptimization
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobOutputOptimization(JobOutputOptimization.JobOutputOptimizationOption[] options)](#JobOutputOptimization-com.aspose.xps.metadata.JobOutputOptimization.JobOutputOptimizationOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobOutputOptimization(JobOutputOptimization.JobOutputOptimizationOption[] options) {#JobOutputOptimization-com.aspose.xps.metadata.JobOutputOptimization.JobOutputOptimizationOption...-}
+```
+public JobOutputOptimization(JobOutputOptimization.JobOutputOptimizationOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [JobOutputOptimizationOption\[\]](../../com.aspose.xps.metadata/joboutputoptimizationoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joboutputoptimizationoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joboutputoptimizationoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "JobOutputOptimization.JobOutputOptimizationOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobOutputOptimization 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/joboutputoptimization.joboutputoptimizationoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobOutputOptimization.JobOutputOptimizationOption extends Option
+```
+
+JobOutputOptimization機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ArchiveFormat](#ArchiveFormat) | ジョブ処理がアーカイブ出力向けに最適化されるように指定します。 |
+| [None](#None) | ジョブ処理が特定のシナリオ向けに最適化されないように指定します。 |
+| [OptimizeForPortability](#OptimizeForPortability) | ジョブ処理が出力のポータビリティ（デバイス間）向けに最適化されるように指定します。 |
+| [OptimizeForQuality](#OptimizeForQuality) | ジョブ処理が出力の品質向けに最適化されるように指定します。 |
+| [OptimizeForSpeed](#OptimizeForSpeed) | ジョブ処理が出力の速度向けに最適化されるように指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArchiveFormat {#ArchiveFormat}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption ArchiveFormat
+```
+
+
+ジョブ処理がアーカイブ出力向けに最適化されるように指定します。
+
+### None {#None}
+```
+public static JobOutputOptimization.JobOutputOptimizationOption None
+```
+
+
+ジョブ処理が特定のシナリオ向けに最適化されないように指定します。
+
+### OptimizeForPortability {#OptimizeForPortability}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption OptimizeForPortability
+```
+
+
+ジョブ処理が出力のポータビリティ（デバイス間）向けに最適化されるように指定します。
+
+### OptimizeForQuality {#OptimizeForQuality}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption OptimizeForQuality
+```
+
+
+ジョブ処理が出力の品質向けに最適化されるように指定します。
+
+### OptimizeForSpeed {#OptimizeForSpeed}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption OptimizeForSpeed
+```
+
+
+ジョブ処理が出力の速度向けに最適化されるように指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobpageorder/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobpageorder/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobPageOrder"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の物理ページの順序を定義します。"
+type: docs
+weight: 63
+url: /ja/java/com.aspose.xps.metadata/jobpageorder/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPageOrder extends Feature implements IJobPrintTicketItem
+```
+
+出力の物理ページ順序を定義します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobpageorder
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPageOrder(JobPageOrder.JobPageOrderOption[] options)](#JobPageOrder-com.aspose.xps.metadata.JobPageOrder.JobPageOrderOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPageOrder(JobPageOrder.JobPageOrderOption[] options) {#JobPageOrder-com.aspose.xps.metadata.JobPageOrder.JobPageOrderOption...-}
+```
+public JobPageOrder(JobPageOrder.JobPageOrderOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [JobPageOrderOption\[\]](../../com.aspose.xps.metadata/jobpageorderoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobpageorderoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobpageorderoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "JobPageOrder.JobPageOrderOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobPageOrder 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/jobpageorder.jobpageorderoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPageOrder.JobPageOrderOption extends Option
+```
+
+JobPageOrder機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Reverse](#Reverse) | ページの裏面から表面への順序を指定します。 |
+| [Standard](#Standard) | ページの表面から裏面への順序を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reverse {#Reverse}
+```
+public static final JobPageOrder.JobPageOrderOption Reverse
+```
+
+
+ページの裏面から表面への順序を指定します。
+
+### Standard {#Standard}
+```
+public static final JobPageOrder.JobPageOrderOption Standard
+```
+
+
+ページの表面から裏面への順序を指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprimarybannersheet/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprimarybannersheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobPrimaryBannerSheet"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブの出力バナーシートを説明します。"
+type: docs
+weight: 64
+url: /ja/java/com.aspose.xps.metadata/jobprimarybannersheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryBannerSheet extends Feature implements IJobPrintTicketItem
+```
+
+ジョブの出力バナーシートについて説明します。バナーシートはデフォルトの  PageMediaSize  で、デフォルトの  PageMediaType  を使用して出力する必要があります。バナーシートはジョブの残りの部分から分離されている必要があります。つまり、JobDuplexAllDocumentsContiguously、JobStapleAllDocuments、または JobBindAllDocuments などの仕上げや処理オプションにはバナーシートを含めてはなりません。バナーシートはジョブの最初のシートとして配置されるべきです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPrimaryBannerSheet(JobPrimaryBannerSheet.BannerSheetOption[] options)](#JobPrimaryBannerSheet-com.aspose.xps.metadata.JobPrimaryBannerSheet.BannerSheetOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryBannerSheet(JobPrimaryBannerSheet.BannerSheetOption[] options) {#JobPrimaryBannerSheet-com.aspose.xps.metadata.JobPrimaryBannerSheet.BannerSheetOption...-}
+```
+public JobPrimaryBannerSheet(JobPrimaryBannerSheet.BannerSheetOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [BannerSheetOption\[\]](../../com.aspose.xps.metadata/bannersheetoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprimarybannersheetsource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprimarybannersheetsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobPrimaryBannerSheetSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブのプライマリカスタムバナーシートのソースを指定します。"
+type: docs
+weight: 65
+url: /ja/java/com.aspose.xps.metadata/jobprimarybannersheetsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryBannerSheetSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+ジョブのプライマリカスタムバナーシートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarybannersheetsource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPrimaryBannerSheetSource(String value)](#JobPrimaryBannerSheetSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryBannerSheetSource(String value) {#JobPrimaryBannerSheetSource-java.lang.String-}
+```
+public JobPrimaryBannerSheetSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprimarycoverback/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprimarycoverback/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobPrimaryCoverBack"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "裏面のカバーシートを説明します。"
+type: docs
+weight: 66
+url: /ja/java/com.aspose.xps.metadata/jobprimarycoverback/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverBack extends Feature implements IJobPrintTicketItem
+```
+
+裏面（終了）カバーシートを説明します。各ジョブは別々のプライマリシートを持ちます。カバーシートはジョブの最終ページに使用される PageMediaSize と PageMediaType に印刷される必要があります。カバーシートは、指定されたオプションで示されるように、処理オプション（例: JobDuplexAllDocumentsContiguously、JobNUpAllDocumentsContiguously）に統合されるべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverback
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPrimaryCoverBack(JobPrimaryCoverBack.CoverBackOption[] options)](#JobPrimaryCoverBack-com.aspose.xps.metadata.JobPrimaryCoverBack.CoverBackOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryCoverBack(JobPrimaryCoverBack.CoverBackOption[] options) {#JobPrimaryCoverBack-com.aspose.xps.metadata.JobPrimaryCoverBack.CoverBackOption...-}
+```
+public JobPrimaryCoverBack(JobPrimaryCoverBack.CoverBackOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [CoverBackOption\[\]](../../com.aspose.xps.metadata/coverbackoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprimarycoverbacksource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprimarycoverbacksource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobPrimaryCoverBackSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブのカスタム裏表紙プライマリシートのソースを指定します。"
+type: docs
+weight: 67
+url: /ja/java/com.aspose.xps.metadata/jobprimarycoverbacksource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverBackSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+ジョブのカスタム裏表紙一次シートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverbacksource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPrimaryCoverBackSource(String value)](#JobPrimaryCoverBackSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryCoverBackSource(String value) {#JobPrimaryCoverBackSource-java.lang.String-}
+```
+public JobPrimaryCoverBackSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprimarycoverfront/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprimarycoverfront/_index.md
@@ -1,0 +1,152 @@
+---
+title: "JobPrimaryCoverFront"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "前面の開始カバーシートを説明します。"
+type: docs
+weight: 68
+url: /ja/java/com.aspose.xps.metadata/jobprimarycoverfront/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverFront extends Feature implements IJobPrintTicketItem
+```
+
+前面（開始）カバーシートを説明します。ジョブ全体は単一のプライマリシートを持ちます。カバーシートはジョブの最初のページに使用される PageMediaSize と PageMediaType に印刷される必要があります。カバーシートは、指定されたオプションで示されるように、処理オプション（例: JobDuplexAllDocumentsContiguously、JobNUpAllDocumentsContiguously）に統合されるべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverfront
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprimarycoverfrontsource/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprimarycoverfrontsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobPrimaryCoverFrontSource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブのカスタム表紙プライマリシートのソースを指定します。"
+type: docs
+weight: 69
+url: /ja/java/com.aspose.xps.metadata/jobprimarycoverfrontsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverFrontSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+ジョブのカスタム表紙一次シートのソースを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverfrontsource
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPrimaryCoverFrontSource(String value)](#JobPrimaryCoverFrontSource-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryCoverFrontSource(String value) {#JobPrimaryCoverFrontSource-java.lang.String-}
+```
+public JobPrimaryCoverFrontSource(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobprintticket/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobprintticket/_index.md
@@ -1,0 +1,181 @@
+---
+title: "JobPrintTicket"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ジョブレベルの印刷チケットをカプセル化するクラスです。"
+type: docs
+weight: 70
+url: /ja/java/com.aspose.xps.metadata/jobprintticket/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicket](../../com.aspose.xps.metadata/printticket)
+```
+public final class JobPrintTicket extends PrintTicket
+```
+
+ジョブレベルの印刷チケットをカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobPrintTicket(IJobPrintTicketItem[] items)](#JobPrintTicket-com.aspose.xps.metadata.IJobPrintTicketItem...-) | ジョブレベルの印刷チケット インスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IJobPrintTicketItem[] items)](#add-com.aspose.xps.metadata.IJobPrintTicketItem...-) | この PrintTicket アイテムリストの末尾にアイテムの配列を追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 印刷チケット アイテム名のイテレータを返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | この PrintTicket アイテムリストからアイテムを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrintTicket(IJobPrintTicketItem[] items) {#JobPrintTicket-com.aspose.xps.metadata.IJobPrintTicketItem...-}
+```
+public JobPrintTicket(IJobPrintTicketItem[] items)
+```
+
+
+ジョブレベルの印刷チケット インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IJobPrintTicketItem\[\]](../../com.aspose.xps.metadata/ijobprintticketitem) | 任意の IJobPrintTicketItem インスタンスの配列です。各インスタンスは Feature、ParameterInit、または Property のいずれかです。 |
+
+### add(IJobPrintTicketItem[] items) {#add-com.aspose.xps.metadata.IJobPrintTicketItem...-}
+```
+public void add(IJobPrintTicketItem[] items)
+```
+
+
+この PrintTicket アイテムリストの末尾にアイテムの配列を追加します。各要素は  Feature 、  ParameterInit 、または  Property  インスタンスである可能性があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IJobPrintTicketItem\[\]](../../com.aspose.xps.metadata/ijobprintticketitem) | 追加するアイテムの配列です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+印刷チケット アイテム名のイテレータを返します。
+
+**Returns:**
+java.util.Iterator<java.lang.String> - リストのイテレータを返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+この PrintTicket アイテムリストからアイテムを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String[] | アイテム名の配列です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobrollcutatendofjob/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobrollcutatendofjob/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobRollCutAtEndOfJob"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ロール紙のカット方法を説明します。"
+type: docs
+weight: 71
+url: /ja/java/com.aspose.xps.metadata/jobrollcutatendofjob/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.RollCut](../../com.aspose.xps.metadata/rollcut)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobRollCutAtEndOfJob extends RollCut implements IJobPrintTicketItem
+```
+
+ロール紙のカット方法を説明します。ロールはジョブの最後でカットされるべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobrollcutatendofjob
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobRollCutAtEndOfJob(RollCut.RollCutOption[] options)](#JobRollCutAtEndOfJob-com.aspose.xps.metadata.RollCut.RollCutOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobRollCutAtEndOfJob(RollCut.RollCutOption[] options) {#JobRollCutAtEndOfJob-com.aspose.xps.metadata.RollCut.RollCutOption...-}
+```
+public JobRollCutAtEndOfJob(RollCut.RollCutOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [RollCutOption\[\]](../../com.aspose.xps.metadata/rollcutoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/jobstaplealldocuments/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/jobstaplealldocuments/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobStapleAllDocuments"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のホチキス特性を説明します。"
+type: docs
+weight: 72
+url: /ja/java/com.aspose.xps.metadata/jobstaplealldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Staple](../../com.aspose.xps.metadata/staple)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobStapleAllDocuments extends Staple implements IJobPrintTicketItem
+```
+
+出力の綴じ特性を説明します。ジョブ内のすべてのドキュメントが一緒に綴じられます。JobStapleAllDocuments と DocumentStaple キーワードは相互に排他的です。これらのキーワード間の制約処理はドライバーが決定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/jobstaplealldocuments
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobStapleAllDocuments(Staple.StapleOption[] options)](#JobStapleAllDocuments-com.aspose.xps.metadata.Staple.StapleOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobStapleAllDocuments(Staple.StapleOption[] options) {#JobStapleAllDocuments-com.aspose.xps.metadata.Staple.StapleOption...-}
+```
+public JobStapleAllDocuments(Staple.StapleOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [StapleOption\[\]](../../com.aspose.xps.metadata/stapleoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/joburi/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/joburi/_index.md
@@ -1,0 +1,153 @@
+---
+title: "JobURI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメントの統一リソース識別子（URI）を指定します。"
+type: docs
+weight: 73
+url: /ja/java/com.aspose.xps.metadata/joburi/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.URIProperty](../../com.aspose.xps.metadata/uriproperty)
+```
+public final class JobURI extends URIProperty
+```
+
+ドキュメントの統一リソース識別子（URI）を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/joburi
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JobURI(String jobURI)](#JobURI-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobURI(String jobURI) {#JobURI-java.lang.String-}
+```
+public JobURI(String jobURI)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| jobURI | java.lang.String | ジョブ URI。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/layering/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/layering/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageWatermark.Layering"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "内部の Layering 機能について説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagewatermark.layering/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem](../../com.aspose.xps.metadata/ipagewatermarkitem)
+```
+public static final class PageWatermark.Layering extends Feature implements PageWatermark.IPageWatermarkItem
+```
+
+内部の Layering 機能について説明します。ウォーターマークのレイヤリング動作を定義します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Layering(PageWatermark.LayeringOption[] options)](#Layering-com.aspose.xps.metadata.PageWatermark.LayeringOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layering(PageWatermark.LayeringOption[] options) {#Layering-com.aspose.xps.metadata.PageWatermark.LayeringOption...-}
+```
+public Layering(PageWatermark.LayeringOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [LayeringOption\[\]](../../com.aspose.xps.metadata/layeringoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/layeringoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/layeringoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageWatermark.LayeringOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "レイヤリング機能のオプションを説明します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/pagewatermark.layeringoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageWatermark.LayeringOption extends Option
+```
+
+Layering の機能オプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Overlay](#Overlay) | 透かしはページコンテンツの上に表示されます。 |
+| [Underlay](#Underlay) | 透かしはページコンテンツの下に表示されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Overlay {#Overlay}
+```
+public static PageWatermark.LayeringOption Overlay
+```
+
+
+透かしはページコンテンツの上に表示されます。
+
+### Underlay {#Underlay}
+```
+public static PageWatermark.LayeringOption Underlay
+```
+
+
+透かしはページコンテンツの下に表示されます。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/material/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/material/_index.md
@@ -1,0 +1,205 @@
+---
+title: "PageMediaType.Material"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Material スコアプロパティの値の定数を定義します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.material/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.Material extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+Material スコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Aluminum](#Aluminum) | アルミニウム値。 |
+| [Display](#Display) | 表示値。 |
+| [DryFilm](#DryFilm) | ドライフィルム値。 |
+| [Paper](#Paper) | 紙の値。 |
+| [Polyester](#Polyester) | ポリエステル値。 |
+| [Transparency](#Transparency) | 透明度の値。 |
+| [WetFilm](#WetFilm) | ウェットフィルム値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Aluminum {#Aluminum}
+```
+public static PageMediaType.Material Aluminum
+```
+
+
+アルミニウム値。
+
+### Display {#Display}
+```
+public static PageMediaType.Material Display
+```
+
+
+表示値。
+
+### DryFilm {#DryFilm}
+```
+public static PageMediaType.Material DryFilm
+```
+
+
+ドライフィルム値。
+
+### Paper {#Paper}
+```
+public static PageMediaType.Material Paper
+```
+
+
+紙の値。
+
+### Polyester {#Polyester}
+```
+public static PageMediaType.Material Polyester
+```
+
+
+ポリエステル値。
+
+### Transparency {#Transparency}
+```
+public static PageMediaType.Material Transparency
+```
+
+
+透明度の値。
+
+### WetFilm {#WetFilm}
+```
+public static PageMediaType.Material WetFilm
+```
+
+
+ウェットフィルム値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/mediacapacity/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/mediacapacity/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaCapacity"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "バイナリが高容量バイナリかどうかを示す MediaCapacity スコアドプロパティ値の定数を定義します。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.xps.metadata/inputbin.mediacapacity/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaCapacity extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaCapacity スコアドプロパティ値の定数を定義し、ビンが高容量ビンかどうか（定性的）を指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [High](#High) | 高い値。 |
+| [Standard](#Standard) | 標準値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### High {#High}
+```
+public static final InputBin.MediaCapacity High
+```
+
+
+高い値。
+
+### Standard {#Standard}
+```
+public static final InputBin.MediaCapacity Standard
+```
+
+
+標準値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/mediapath/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/mediapath/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaPath"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "MediaPath スコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.xps.metadata/inputbin.mediapath/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaPath extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaPath スコアドプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Serpentine](#Serpentine) | 蛇行値。 |
+| [Straight](#Straight) | 直線値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Serpentine {#Serpentine}
+```
+public static final InputBin.MediaPath Serpentine
+```
+
+
+蛇行値。
+
+### Straight {#Straight}
+```
+public static final InputBin.MediaPath Straight
+```
+
+
+直線値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/mediasheetcapacity/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/mediasheetcapacity/_index.md
@@ -1,0 +1,156 @@
+---
+title: "OutputBin.MediaSheetCapacity"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "MediaSheetCapacity のスコア付きプロパティ値を定義し、ビンのフルレベルにおけるページ数でメディア容量を指定します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/outputbin.mediasheetcapacity/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem](../../com.aspose.xps.metadata/ioutputbinoptionitem)
+```
+public static final class OutputBin.MediaSheetCapacity extends ScoredProperty implements OutputBin.IOutputBinOptionItem
+```
+
+MediaSheetCapacity スコアドプロパティ値を定義し、ビンのページ数（フルレベル）でのメディア容量を指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [MediaSheetCapacity(int mediaSheetCapacity)](#MediaSheetCapacity-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MediaSheetCapacity(int mediaSheetCapacity) {#MediaSheetCapacity-int-}
+```
+public MediaSheetCapacity(int mediaSheetCapacity)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| mediaSheetCapacity | int | MediaSheetCapacity のスコア付きプロパティ値です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/mediasizeautosense/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/mediasizeautosense/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaSizeAutoSense"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "MediaSizeAutoSense のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.xps.metadata/inputbin.mediasizeautosense/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaSizeAutoSense extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaSizeAutoSense のスコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | None 値。 |
+| [Supported](#Supported) | サポートされている値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final InputBin.MediaSizeAutoSense None
+```
+
+
+None 値。
+
+### Supported {#Supported}
+```
+public static final InputBin.MediaSizeAutoSense Supported
+```
+
+
+サポートされている値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/mediatypeautosense/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/mediatypeautosense/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaTypeAutoSense"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "MediaTypeAutoSense スコア プロパティ値の定数を定義します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.xps.metadata/inputbin.mediatypeautosense/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaTypeAutoSense extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaTypeAutoSense のスコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | None 値。 |
+| [Supported](#Supported) | サポートされている値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final InputBin.MediaTypeAutoSense None
+```
+
+
+None 値。
+
+### Supported {#Supported}
+```
+public static final InputBin.MediaTypeAutoSense Supported
+```
+
+
+サポートされている値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/nameproperty/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/nameproperty/_index.md
@@ -1,0 +1,135 @@
+---
+title: "NameProperty"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobName と DocumentName プロパティクラスの基底クラスです。"
+type: docs
+weight: 75
+url: /ja/java/com.aspose.xps.metadata/nameproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public class NameProperty extends Property
+```
+
+JobName と DocumentName プロパティクラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/nup/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/nup/_index.md
@@ -1,0 +1,149 @@
+---
+title: "NUp"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobNUpAllDocumentsContiguously と DocumentNUp 機能クラスの基本クラスです。"
+type: docs
+weight: 74
+url: /ja/java/com.aspose.xps.metadata/nup/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class NUp extends Feature
+```
+
+JobNUpAllDocumentsContiguously と DocumentNUp 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/option/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/option/_index.md
@@ -1,0 +1,199 @@
+---
+title: "Option"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の PrintTicket Option を実装するクラスです。"
+type: docs
+weight: 76
+url: /ja/java/com.aspose.xps.metadata/option/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public class Option extends CompositePrintTicketElement implements IFeatureItem
+```
+
+共通の PrintTicket  Option を実装するクラスです。すべてのスキーマ定義オプションの基底クラスです。Option 要素は、このオプションに関連付けられたすべての Property と ScoredProperty 要素を含みます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/option
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Option(String name, IOptionItem[] items)](#Option-java.lang.String-com.aspose.xps.metadata.IOptionItem...-) | 新しい PrintTicket オプション インスタンスを作成します。 |
+| [Option(IOptionItem[] items)](#Option-com.aspose.xps.metadata.IOptionItem...-) | 新しい PrintTicket オプション インスタンスを作成します。 |
+| [Option(Option option)](#Option-com.aspose.xps.metadata.Option-) | クローン オプション インスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Option(String name, IOptionItem[] items) {#Option-java.lang.String-com.aspose.xps.metadata.IOptionItem...-}
+```
+public Option(String name, IOptionItem[] items)
+```
+
+
+新しい PrintTicket オプション インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | 任意のオプション名です。 |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 任意の IOptionItem インスタンスの配列です。各項目は ScoredProperty または Property のインスタンスである必要があります。 |
+
+### Option(IOptionItem[] items) {#Option-com.aspose.xps.metadata.IOptionItem...-}
+```
+public Option(IOptionItem[] items)
+```
+
+
+新しい PrintTicket オプション インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 任意の IOptionItem インスタンスの配列です。各項目は ScoredProperty または Property のインスタンスである必要があります。 |
+
+### Option(Option option) {#Option-com.aspose.xps.metadata.Option-}
+```
+public Option(Option option)
+```
+
+
+クローン オプション インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| option | [Option](../../com.aspose.xps.metadata/option) | クローンするオプション インスタンスです。 |
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/outputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/outputbin/_index.md
@@ -1,0 +1,149 @@
+---
+title: "OutputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobOutputBin、DocumentOutputBin、PageOutputBin 機能クラスの基底クラスです。"
+type: docs
+weight: 77
+url: /ja/java/com.aspose.xps.metadata/outputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class OutputBin extends Feature
+```
+
+JobOutputBin、DocumentOutputBin、PageOutputBin 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/outputbinoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/outputbinoption/_index.md
@@ -1,0 +1,186 @@
+---
+title: "OutputBin.OutputBinOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobOutputBin、DocumentOutputBin、および PageOutputBin の機能オプションについて説明します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/outputbin.outputbinoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.OutputBin.IOutputBinItem](../../com.aspose.xps.metadata/ioutputbinitem)
+```
+public static final class OutputBin.OutputBinOption extends Option implements OutputBin.IOutputBinItem
+```
+
+JobOutputBin、DocumentOutputBin、PageOutputBin 機能のオプションを説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [OutputBinOption(OutputBin.IOutputBinOptionItem[] items)](#OutputBinOption-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(OutputBin.IOutputBinOptionItem[] items)](#add-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-) | 機能に IOutputBinOptionItem インスタンスの配列を追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputBinOption(OutputBin.IOutputBinOptionItem[] items) {#OutputBinOption-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-}
+```
+public OutputBinOption(OutputBin.IOutputBinOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOutputBinOptionItem\[\]](../../com.aspose.xps.metadata/ioutputbinoptionitem) | 任意の IOutputBinOptionItem インスタンスの配列です。 |
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(OutputBin.IOutputBinOptionItem[] items) {#add-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-}
+```
+public OutputBin.OutputBinOption add(OutputBin.IOutputBinOptionItem[] items)
+```
+
+
+機能に IOutputBinOptionItem インスタンスの配列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOutputBinOptionItem\[\]](../../com.aspose.xps.metadata/ioutputbinoptionitem) | 任意の IOutputBinOptionItem インスタンスの配列です。 |
+
+**Returns:**
+[OutputBinOption](../../com.aspose.xps.metadata/outputbinoption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessing/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessing/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageBlackGenerationProcessing"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "CMYK 分離の黒生成動作を指定します。"
+type: docs
+weight: 78
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessing/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessing extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+CMYK 分離に対するブラック生成の動作を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessing
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessing(PageBlackGenerationProcessing.PageBlackGenerationProcessingOption[] options)](#PageBlackGenerationProcessing-com.aspose.xps.metadata.PageBlackGenerationProcessing.PageBlackGenerationProcessingOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessing(PageBlackGenerationProcessing.PageBlackGenerationProcessingOption[] options) {#PageBlackGenerationProcessing-com.aspose.xps.metadata.PageBlackGenerationProcessing.PageBlackGenerationProcessingOption...-}
+```
+public PageBlackGenerationProcessing(PageBlackGenerationProcessing.PageBlackGenerationProcessingOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageBlackGenerationProcessingOption\[\]](../../com.aspose.xps.metadata/pageblackgenerationprocessingoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingBlackInkLimit"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "指定された名前色でラベル付けされたアプリケーションコンテンツは、すべてのカラ―分離に必ず表示されなければなりません。"
+type: docs
+weight: 79
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingBlackInkLimit extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+指定された名前付きカラーでラベル付けされたアプリケーション コンテンツは、すべてのカラ―分離に表示されなければなりません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingblackinklimit
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingBlackInkLimit(int value)](#PageBlackGenerationProcessingBlackInkLimit-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingBlackInkLimit(int value) {#PageBlackGenerationProcessingBlackInkLimit-int-}
+```
+public PageBlackGenerationProcessingBlackInkLimit(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingGrayComponentReplacementExtent"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "GCR が適用する、中立色から彩色への拡張範囲を説明します。0 は均一成分置換、100 はグレイ成分置換です。"
+type: docs
+weight: 80
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingGrayComponentReplacementExtent extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+GCR が適用する、中立色から彩色への拡張範囲を説明します。0% = 均一成分置換、100% = グレイ成分置換。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessinggraycomponentreplacementextent
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingGrayComponentReplacementExtent(int value)](#PageBlackGenerationProcessingGrayComponentReplacementExtent-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingGrayComponentReplacementExtent(int value) {#PageBlackGenerationProcessingGrayComponentReplacementExtent-int-}
+```
+public PageBlackGenerationProcessingGrayComponentReplacementExtent(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingGrayComponentReplacementLevel"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "実行するグレイコンポーネント置換の割合を指定します。"
+type: docs
+weight: 81
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingGrayComponentReplacementLevel extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+実行するグレイコンポーネント置換の割合を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessinggraycomponentreplacementlevel
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingGrayComponentReplacementLevel(int value)](#PageBlackGenerationProcessingGrayComponentReplacementLevel-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingGrayComponentReplacementLevel(int value) {#PageBlackGenerationProcessingGrayComponentReplacementLevel-int-}
+```
+public PageBlackGenerationProcessingGrayComponentReplacementLevel(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingGrayComponentReplacementStart"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ハイライトからシャドウの範囲で、GCRが開始すべき点（最も暗いシャドウの100%）を説明します。"
+type: docs
+weight: 82
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingGrayComponentReplacementStart extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ハイライトからシャドウの範囲で、GCRが開始すべき点（最も暗いシャドウの100%）を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessinggraycomponentreplacementstart
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingGrayComponentReplacementStart(int value)](#PageBlackGenerationProcessingGrayComponentReplacementStart-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingGrayComponentReplacementStart(int value) {#PageBlackGenerationProcessingGrayComponentReplacementStart-int-}
+```
+public PageBlackGenerationProcessingGrayComponentReplacementStart(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageBlackGenerationProcessing.PageBlackGenerationProcessingOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageBlackGenerationProcessing 機能のオプションを記述します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessing.pageblackgenerationprocessingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageBlackGenerationProcessing.PageBlackGenerationProcessingOption extends Option
+```
+
+PageBlackGenerationProcessing 機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Automatic](#Automatic) | 自動オプション。 |
+| [Custom](#Custom) | カスタムオプション。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static PageBlackGenerationProcessing.PageBlackGenerationProcessingOption Automatic
+```
+
+
+自動オプション。
+
+### Custom {#Custom}
+```
+public static PageBlackGenerationProcessing.PageBlackGenerationProcessingOption Custom
+```
+
+
+カスタムオプション。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingTotalInkCoverageLimit"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "画像内の任意の場所で許容されるインクカバレッジ4色の合計最大値を指定します。"
+type: docs
+weight: 83
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingTotalInkCoverageLimit extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+画像内の任意の場所での4つのインクカバレッジの最大許容合計を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingtotalinkcoveragelimit
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingTotalInkCoverageLimit(int value)](#PageBlackGenerationProcessingTotalInkCoverageLimit-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingTotalInkCoverageLimit(int value) {#PageBlackGenerationProcessingTotalInkCoverageLimit-int-}
+```
+public PageBlackGenerationProcessingTotalInkCoverageLimit(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingUnderColorAdditionLevel"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "GCR/UCR が BlackInkLimit または UCAStart を生成した暗い中間色およびほぼ中性領域に、灰色成分比で追加する色彩インクの量を説明します。"
+type: docs
+weight: 84
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingUnderColorAdditionLevel extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+GCR/UCR が暗い中間色およびほぼ中性領域で \"BlackInkLimit\"（または指定された場合は UCAStart）を生成した領域に、灰色成分比で追加する色彩インクの量を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingundercoloradditionlevel
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingUnderColorAdditionLevel(int value)](#PageBlackGenerationProcessingUnderColorAdditionLevel-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingUnderColorAdditionLevel(int value) {#PageBlackGenerationProcessingUnderColorAdditionLevel-int-}
+```
+public PageBlackGenerationProcessingUnderColorAdditionLevel(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingUnderColorAdditionStart"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "UCA が適用される影レベル以下を説明します。"
+type: docs
+weight: 85
+url: /ja/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingUnderColorAdditionStart extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+UCA が適用される影のレベルを記述します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingundercoloradditionstart
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlackGenerationProcessingUnderColorAdditionStart(int value)](#PageBlackGenerationProcessingUnderColorAdditionStart-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingUnderColorAdditionStart(int value) {#PageBlackGenerationProcessingUnderColorAdditionStart-int-}
+```
+public PageBlackGenerationProcessingUnderColorAdditionStart(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblendcolorspace/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblendcolorspace/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageBlendColorSpace"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ブレンド操作に使用すべきカラースペースを説明します。"
+type: docs
+weight: 86
+url: /ja/java/com.aspose.xps.metadata/pageblendcolorspace/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlendColorSpace extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ブレンド操作に使用すべきカラースペースを記述します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblendcolorspace
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlendColorSpace(PageBlendColorSpace.PageBlendColorSpaceOption[] options)](#PageBlendColorSpace-com.aspose.xps.metadata.PageBlendColorSpace.PageBlendColorSpaceOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlendColorSpace(PageBlendColorSpace.PageBlendColorSpaceOption[] options) {#PageBlendColorSpace-com.aspose.xps.metadata.PageBlendColorSpace.PageBlendColorSpaceOption...-}
+```
+public PageBlendColorSpace(PageBlendColorSpace.PageBlendColorSpaceOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageBlendColorSpaceOption\[\]](../../com.aspose.xps.metadata/pageblendcolorspaceoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageBlendColorSpaceICCProfileURI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ブレンドに使用すべきカラースペースを定義する ICC プロファイルへの相対 URI 参照を指定します。"
+type: docs
+weight: 87
+url: /ja/java/com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlendColorSpaceICCProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ブレンドに使用すべきカラー空間を定義する ICC プロファイルへの相対 URI 参照を指定します。<Uri> はパッケージルートに対する絶対 part\_name です。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblendcolorspaceiccprofileuri
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBlendColorSpaceICCProfileURI(String value)](#PageBlendColorSpaceICCProfileURI-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlendColorSpaceICCProfileURI(String value) {#PageBlendColorSpaceICCProfileURI-java.lang.String-}
+```
+public PageBlendColorSpaceICCProfileURI(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageblendcolorspaceoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageblendcolorspaceoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "PageBlendColorSpace.PageBlendColorSpaceOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageBlendColorSpace 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageblendcolorspace.pageblendcolorspaceoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageBlendColorSpace.PageBlendColorSpaceOption extends Option
+```
+
+PageBlendColorSpace 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ICCProfile](#ICCProfile) | ブレンドに使用すべきカラー空間を定義する ICC プロファイルを指定します。 |
+| [sRGB](#sRGB) | ブレンドには sRGB カラースペースを使用すべきです。 |
+| [scRGB](#scRGB) | ブレンドには scRGB カラースペースを使用すべきです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ICCProfile {#ICCProfile}
+```
+public static PageBlendColorSpace.PageBlendColorSpaceOption ICCProfile
+```
+
+
+ブレンドに使用すべきカラースペースを定義する ICC プロファイルを指定します。注: これは XPS ドキュメントにのみ適用され、任意の PrintTicket では使用すべきではありません。
+
+### sRGB {#sRGB}
+```
+public static PageBlendColorSpace.PageBlendColorSpaceOption sRGB
+```
+
+
+ブレンドには sRGB カラースペースを使用すべきです。
+
+### scRGB {#scRGB}
+```
+public static PageBlendColorSpace.PageBlendColorSpaceOption scRGB
+```
+
+
+ブレンドには scRGB カラースペースを使用すべきです。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageborderless/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageborderless/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageBorderless"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "画像コンテンツを媒体の物理的な端まで印刷すべきタイミングを説明します。"
+type: docs
+weight: 88
+url: /ja/java/com.aspose.xps.metadata/pageborderless/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBorderless extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+画像コンテンツをメディアの物理的な端まで印刷すべきタイミングを説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageborderless
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageBorderless(PageBorderless.PageBorderlessOption[] options)](#PageBorderless-com.aspose.xps.metadata.PageBorderless.PageBorderlessOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBorderless(PageBorderless.PageBorderlessOption[] options) {#PageBorderless-com.aspose.xps.metadata.PageBorderless.PageBorderlessOption...-}
+```
+public PageBorderless(PageBorderless.PageBorderlessOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageBorderlessOption\[\]](../../com.aspose.xps.metadata/pageborderlessoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageborderlessoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageborderlessoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageBorderless.PageBorderlessOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageBorderless 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageborderless.pageborderlessoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageBorderless.PageBorderlessOption extends Option
+```
+
+PageBorderless 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Borderless](#Borderless) | ボーダーレス印刷を指定します。 |
+| [None](#None) | ボーダーレス印刷を行わないことを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Borderless {#Borderless}
+```
+public static PageBorderless.PageBorderlessOption Borderless
+```
+
+
+ボーダーレス印刷を指定します。
+
+### None {#None}
+```
+public static PageBorderless.PageBorderlessOption None
+```
+
+
+ボーダーレス印刷を行わないことを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagecolormanagement/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagecolormanagement/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageColorManagement"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "現在のページのカラーマネジメントを構成します。"
+type: docs
+weight: 89
+url: /ja/java/com.aspose.xps.metadata/pagecolormanagement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageColorManagement extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+現在のページのカラー管理を構成します。これは SHIM の DM\_ICMMethod Add System では自動と見なされます。どのコンポーネントがカラー管理を実行すべきか（例: ドライバー）を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagecolormanagement
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageColorManagement(PageColorManagement.PageColorManagementOption[] options)](#PageColorManagement-com.aspose.xps.metadata.PageColorManagement.PageColorManagementOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageColorManagement(PageColorManagement.PageColorManagementOption[] options) {#PageColorManagement-com.aspose.xps.metadata.PageColorManagement.PageColorManagementOption...-}
+```
+public PageColorManagement(PageColorManagement.PageColorManagementOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageColorManagementOption\[\]](../../com.aspose.xps.metadata/pagecolormanagementoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagecolormanagementoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagecolormanagementoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageColorManagement.PageColorManagementOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageColorManagement 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagecolormanagement.pagecolormanagementoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageColorManagement.PageColorManagementOption extends Option
+```
+
+PageColorManagement 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Device](#Device) | アプリケーションはカラー管理を実行せず、デバイスがカラー管理を決定します。 |
+| [Driver](#Driver) | アプリケーションはカラー管理を実行せず、ドライバーがカラー管理を決定します。 |
+| [None](#None) | アプリケーションは宛先プロファイルに対してカラー管理を実行しました。 |
+| [System](#System) | カラー管理はシステムによって実行されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Device {#Device}
+```
+public static PageColorManagement.PageColorManagementOption Device
+```
+
+
+アプリケーションはカラー管理を実行せず、デバイスがカラー管理を決定します。
+
+### Driver {#Driver}
+```
+public static PageColorManagement.PageColorManagementOption Driver
+```
+
+
+アプリケーションはカラー管理を実行せず、ドライバーがカラー管理を決定します。
+
+### None {#None}
+```
+public static PageColorManagement.PageColorManagementOption None
+```
+
+
+アプリケーションは宛先プロファイルに対してカラー管理を実行しました。
+
+### System {#System}
+```
+public static PageColorManagement.PageColorManagementOption System
+```
+
+
+カラー管理はシステムによって実行されます。XPSDrv プリントドライバーで印刷する場合は使用しないでください。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagecopies/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagecopies/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageCopies"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページのコピー数を指定します。"
+type: docs
+weight: 90
+url: /ja/java/com.aspose.xps.metadata/pagecopies/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageCopies extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ページのコピー数を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagecopies
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageCopies(int value)](#PageCopies-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageCopies(int value) {#PageCopies-int-}
+```
+public PageCopies(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofile/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofile/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageDestinationColorProfile"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "宛先カラープロファイルの特性を定義します。"
+type: docs
+weight: 91
+url: /ja/java/com.aspose.xps.metadata/pagedestinationcolorprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDestinationColorProfile extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+宛先カラープロファイルの特性を定義します。アプリケーションまたはドライバーが使用する宛先カラープロファイルを選択するかどうかを説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedestinationcolorprofile
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageDestinationColorProfile(PageDestinationColorProfile.PageDestinationColorProfileOption[] options)](#PageDestinationColorProfile-com.aspose.xps.metadata.PageDestinationColorProfile.PageDestinationColorProfileOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDestinationColorProfile(PageDestinationColorProfile.PageDestinationColorProfileOption[] options) {#PageDestinationColorProfile-com.aspose.xps.metadata.PageDestinationColorProfile.PageDestinationColorProfileOption...-}
+```
+public PageDestinationColorProfile(PageDestinationColorProfile.PageDestinationColorProfileOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageDestinationColorProfileOption\[\]](../../com.aspose.xps.metadata/pagedestinationcolorprofileoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofileembedded/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofileembedded/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageDestinationColorProfileEmbedded"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "埋め込まれた宛先カラープロファイルを指定します。"
+type: docs
+weight: 92
+url: /ja/java/com.aspose.xps.metadata/pagedestinationcolorprofileembedded/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDestinationColorProfileEmbedded extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+埋め込み先のカラープロファイルを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedestinationcolorprofileembedded
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageDestinationColorProfileEmbedded(String value)](#PageDestinationColorProfileEmbedded-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDestinationColorProfileEmbedded(String value) {#PageDestinationColorProfileEmbedded-java.lang.String-}
+```
+public PageDestinationColorProfileEmbedded(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofileoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofileoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageDestinationColorProfile.PageDestinationColorProfileOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageDestinationColorProfile の機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagedestinationcolorprofile.pagedestinationcolorprofileoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageDestinationColorProfile.PageDestinationColorProfileOption extends Option
+```
+
+PageDestinationColorProfile 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Application](#Application) | アプリケーションは使用する宛先プロファイルを指定します。 |
+| [DriverConfiguration](#DriverConfiguration) | カラー管理を実行するために使用される宛先プロファイル。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Application {#Application}
+```
+public static PageDestinationColorProfile.PageDestinationColorProfileOption Application
+```
+
+
+アプリケーションは使用する宛先プロファイルを指定します。
+
+### DriverConfiguration {#DriverConfiguration}
+```
+public static PageDestinationColorProfile.PageDestinationColorProfileOption DriverConfiguration
+```
+
+
+カラー管理を実行するために使用される宛先プロファイル。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofileuri/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedestinationcolorprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageDestinationColorProfileURI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS ドキュメントに含まれる ICC プロファイルへの相対 URI 参照を指定します。"
+type: docs
+weight: 93
+url: /ja/java/com.aspose.xps.metadata/pagedestinationcolorprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDestinationColorProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+XPS ドキュメントに含まれる ICC プロファイルへの相対 URI 参照を指定します。このオプションの処理は PageDeviceColorSpaceUsage 機能の設定に依存します。そのプロファイルを使用するすべての要素は、既に適切なデバイス カラースペースにあるとみなされ、ドライバーやデバイスでカラー管理されません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedestinationcolorprofileuri
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageDestinationColorProfileURI(String value)](#PageDestinationColorProfileURI-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDestinationColorProfileURI(String value) {#PageDestinationColorProfileURI-java.lang.String-}
+```
+public PageDestinationColorProfileURI(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedevicecolorspaceprofileuri/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedevicecolorspaceprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageDeviceColorSpaceProfileURI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS ドキュメントに含まれる ICC プロファイルへのパッケージルートからの相対 URI を指定します。"
+type: docs
+weight: 94
+url: /ja/java/com.aspose.xps.metadata/pagedevicecolorspaceprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDeviceColorSpaceProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+XPS ドキュメントに含まれる ICC プロファイルへの、パッケージルートへの相対 URI を指定します。このオプションの処理は PageDeviceColorSpaceUsage 機能の設定に依存します。このプロファイルを使用するすべての要素は、既に適切なデバイスカラースペースにあるとみなされ、ドライバーやデバイスでカラー管理されません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedevicecolorspaceprofileuri
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageDeviceColorSpaceProfileURI(String value)](#PageDeviceColorSpaceProfileURI-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDeviceColorSpaceProfileURI(String value) {#PageDeviceColorSpaceProfileURI-java.lang.String-}
+```
+public PageDeviceColorSpaceProfileURI(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedevicecolorspaceusage/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedevicecolorspaceusage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageDeviceColorSpaceUsage"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageDeviceColorSpaceProfileURI パラメーターと組み合わせて、このパラメーターはデバイスカラースペースで提示される要素のレンダリング動作を定義します。"
+type: docs
+weight: 95
+url: /ja/java/com.aspose.xps.metadata/pagedevicecolorspaceusage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDeviceColorSpaceUsage extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+PageDeviceColorSpaceProfileURI パラメーターと組み合わせて、このパラメーターはデバイスカラースペースで提示される要素のレンダリング動作を定義します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedevicecolorspaceusage
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageDeviceColorSpaceUsage(PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption[] options)](#PageDeviceColorSpaceUsage-com.aspose.xps.metadata.PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDeviceColorSpaceUsage(PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption[] options) {#PageDeviceColorSpaceUsage-com.aspose.xps.metadata.PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption...-}
+```
+public PageDeviceColorSpaceUsage(PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageDeviceColorSpaceUsageOption\[\]](../../com.aspose.xps.metadata/pagedevicecolorspaceusageoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedevicecolorspaceusageoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedevicecolorspaceusageoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageDeviceColorSpaceUsage 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagedevicecolorspaceusage.pagedevicecolorspaceusageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption extends Option
+```
+
+PageDeviceColorSpaceUsage 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [MatchToDefault](#MatchToDefault) | デバイスが、  PageDeviceColorSpaceProfileURI  パラメータで指定されたプロファイルをデバイス カラースペース プロファイルとして使用できると判断した場合、同じプロファイルを使用しているすべての要素は、すでにデバイス カラースペースで指定されているものとして扱われます。 |
+| [OverrideDeviceDefault](#OverrideDeviceDefault) | PageDeviceColorSpaceProfileURI パラメータで指定されたプロファイルのチャンネル数がデバイスのプライマリ数と一致する場合、すべての要素に対してデバイスの内部カラー管理の代わりに SHOULD 使用されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MatchToDefault {#MatchToDefault}
+```
+public static PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption MatchToDefault
+```
+
+
+デバイスが PageDeviceColorSpaceProfileURI パラメータで指定されたプロファイルをデバイス カラースペース プロファイルとして使用できると判断した場合、同じプロファイルを使用するすべての要素は既にデバイス カラースペースで指定されているものとして扱われます。その他のすべての要素は、その要素に指定されたプロファイルを必ず使用しなければなりません。プロファイルをデバイス カラースペース プロファイルとして使用できない場合、プロファイルを使用する要素は他のカラープロファイルを使用する要素と同様にカラー管理されなければなりません。
+
+### OverrideDeviceDefault {#OverrideDeviceDefault}
+```
+public static PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption OverrideDeviceDefault
+```
+
+
+PageDeviceColorSpaceProfileURI パラメータで指定されたプロファイルのチャンネル数がデバイスのプライマリ数と一致する場合、すべての要素に対してデバイスの内部カラー管理の代わりに使用すべきです。このプロファイルを使用する要素はデバイス カラースペースにあるとみなされ、これ以上カラー管理されません。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedevicefontsubstitution/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedevicefontsubstitution/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageDeviceFontSubstitution"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスフォント置換の有効/無効状態を説明します。"
+type: docs
+weight: 96
+url: /ja/java/com.aspose.xps.metadata/pagedevicefontsubstitution/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDeviceFontSubstitution extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+デバイスフォント置換の有効/無効状態を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedevicefontsubstitution
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageDeviceFontSubstitution(PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption[] options)](#PageDeviceFontSubstitution-com.aspose.xps.metadata.PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDeviceFontSubstitution(PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption[] options) {#PageDeviceFontSubstitution-com.aspose.xps.metadata.PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption...-}
+```
+public PageDeviceFontSubstitution(PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageDeviceFontSubstitutionOption\[\]](../../com.aspose.xps.metadata/pagedevicefontsubstitutionoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagedevicefontsubstitutionoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagedevicefontsubstitutionoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageDeviceFontSubstitution 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagedevicefontsubstitution.pagedevicefontsubstitutionoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption extends Option
+```
+
+PageDeviceFontSubstitution 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Off](#Off) | ページデバイスフォント置換はオフです。 |
+| [On](#On) | ページデバイスフォント置換はオンです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Off {#Off}
+```
+public static PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption Off
+```
+
+
+ページデバイスフォント置換はオフです。
+
+### On {#On}
+```
+public static PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption On
+```
+
+
+ページデバイスフォント置換はオンです。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageforcefrontside/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageforcefrontside/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageForceFrontSide"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力が媒体シートの表面に表示されるよう強制します。"
+type: docs
+weight: 97
+url: /ja/java/com.aspose.xps.metadata/pageforcefrontside/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageForceFrontSide extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力がメディアシートの表面に表示されるように強制します。各面が異なる表面を持つメディアシートに関連します。この機能が処理オプション（例: DocumentDuplex）と競合する場合、PageForceFrontSide はその機能が適用される特定のページに対して優先されます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageForceFrontSide(PageForceFrontSide.PageForceFrontSideOption[] options)](#PageForceFrontSide-com.aspose.xps.metadata.PageForceFrontSide.PageForceFrontSideOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageForceFrontSide(PageForceFrontSide.PageForceFrontSideOption[] options) {#PageForceFrontSide-com.aspose.xps.metadata.PageForceFrontSide.PageForceFrontSideOption...-}
+```
+public PageForceFrontSide(PageForceFrontSide.PageForceFrontSideOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageForceFrontSideOption\[\]](../../com.aspose.xps.metadata/pageforcefrontsideoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageforcefrontsideoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageforcefrontsideoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageForceFrontSide.PageForceFrontSideOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageForceFrontSide 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageforcefrontside.pageforcefrontsideoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageForceFrontSide.PageForceFrontSideOption extends Option
+```
+
+PageForceFrontSide 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [ForceFrontSide](#ForceFrontSide) | 出力がシートの表面に限定されることを指定します。 |
+| [None](#None) | 出力制限がないことを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ForceFrontSide {#ForceFrontSide}
+```
+public static PageForceFrontSide.PageForceFrontSideOption ForceFrontSide
+```
+
+
+出力がシートの表面に限定されることを指定します。
+
+### None {#None}
+```
+public static PageForceFrontSide.PageForceFrontSideOption None
+```
+
+
+出力制限がないことを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageicmrenderingintent/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageicmrenderingintent/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageICMRenderingIntent"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ICC v2 仕様で定義されたレンダリングインテントを説明します。"
+type: docs
+weight: 98
+url: /ja/java/com.aspose.xps.metadata/pageicmrenderingintent/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageICMRenderingIntent extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ICC v2 仕様で定義されたレンダリングインテントを説明します。画像またはグラフィック要素に埋め込みプロファイルがあり、レンダリングインテントが指定されている場合は、この値は無視すべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageicmrenderingintent
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageICMRenderingIntent(PageICMRenderingIntent.PageICMRenderingIntentOption[] options)](#PageICMRenderingIntent-com.aspose.xps.metadata.PageICMRenderingIntent.PageICMRenderingIntentOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageICMRenderingIntent(PageICMRenderingIntent.PageICMRenderingIntentOption[] options) {#PageICMRenderingIntent-com.aspose.xps.metadata.PageICMRenderingIntent.PageICMRenderingIntentOption...-}
+```
+public PageICMRenderingIntent(PageICMRenderingIntent.PageICMRenderingIntentOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageICMRenderingIntentOption\[\]](../../com.aspose.xps.metadata/pageicmrenderingintentoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageicmrenderingintentoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageicmrenderingintentoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageICMRenderingIntent.PageICMRenderingIntentOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageICMRenderingIntent 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageicmrenderingintent.pageicmrenderingintentoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageICMRenderingIntent.PageICMRenderingIntentOption extends Option
+```
+
+PageICMRenderingIntent 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AbsoluteColorimetric](#AbsoluteColorimetric) | 絶対カラー測光レンダリングインテント。 |
+| [BusinessGraphics](#BusinessGraphics) | ビジネスグラフィックスレンダリングインテント。 |
+| [Photographs](#Photographs) | 写真レンダリングインテント。 |
+| [RelativeColorimetric](#RelativeColorimetric) | 相対カラー測光レンダリングインテント。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbsoluteColorimetric {#AbsoluteColorimetric}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption AbsoluteColorimetric
+```
+
+
+絶対カラー測光レンダリングインテント。
+
+### BusinessGraphics {#BusinessGraphics}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption BusinessGraphics
+```
+
+
+ビジネスグラフィックスレンダリングインテント。
+
+### Photographs {#Photographs}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption Photographs
+```
+
+
+写真レンダリングインテント。
+
+### RelativeColorimetric {#RelativeColorimetric}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption RelativeColorimetric
+```
+
+
+相対カラー測光レンダリングインテント。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageimageablesize/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageimageablesize/_index.md
@@ -1,0 +1,248 @@
+---
+title: "PageImageableSize"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "レイアウトとレンダリングのためのイメージ化されたキャンバスを説明します。"
+type: docs
+weight: 99
+url: /ja/java/com.aspose.xps.metadata/pageimageablesize/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageImageableSize extends Property implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+レイアウトとレンダリングのためのイメージ化されたキャンバスを説明します。これは PageMediaSize と PageOrientation に基づいて報告されます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageimageablesize
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageImageableSize(int width, int height)](#PageImageableSize-int-int-) | 新しいインスタンスを作成します。 |
+| [PageImageableSize(int width, int height, int originWidth, int originHeight, int extentWidth, int extentHeight)](#PageImageableSize-int-int-int-int-int-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageImageableSize(int width, int height) {#PageImageableSize-int-int-}
+```
+public PageImageableSize(int width, int height)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+|  | width | int | ある |
+
+```
+ImageableSizeWidth
+```
+
+プロパティ値。 |
+|  | height | int | ある |
+
+```
+ImageableSizeHeight
+```
+
+プロパティ値。 |
+
+### PageImageableSize(int width, int height, int originWidth, int originHeight, int extentWidth, int extentHeight) {#PageImageableSize-int-int-int-int-int-int-}
+```
+public PageImageableSize(int width, int height, int originWidth, int originHeight, int extentWidth, int extentHeight)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+|  | width | int | ある |
+
+```
+ImageableSizeWidth
+```
+
+プロパティ値。 |
+|  | height | int | ある |
+
+```
+ImageableSizeHeight
+```
+
+プロパティ値。 |
+|  | originWidth | int | ある |
+
+```
+ImageableArea
+```
+
+サブプロパティの
+
+```
+OriginWidth
+```
+
+プロパティ値。 |
+|  | originHeight | int | ある |
+
+```
+ImageableArea
+```
+
+サブプロパティの
+
+```
+OriginHeight
+```
+
+プロパティ値。 |
+|  | extentWidth | int | ある |
+
+```
+ImageableArea
+```
+
+サブプロパティの
+
+```
+ExtentWidth
+```
+
+プロパティ値。 |
+|  | extentHeight | int | ある |
+
+```
+ImageableArea
+```
+
+サブプロパティの
+
+```
+ExtentHeight
+```
+
+プロパティ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageinputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageinputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageInputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスにインストールされた入力ビン、またはデバイスがサポートするビンの全リストを説明します。"
+type: docs
+weight: 100
+url: /ja/java/com.aspose.xps.metadata/pageinputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.InputBin](../../com.aspose.xps.metadata/inputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageInputBin extends InputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+デバイスにインストールされている入力トレイ、またはデバイスがサポートするトレイの完全なリストを記述します。ページ単位で入力トレイを指定できます。JobInputBin、DocumentInputBin、PageInputBin キーワードは相互に排他的です。PrintTicket または Print Capabilities ドキュメントで同時に指定すべきではありません。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageinputbin
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageInputBin(InputBin.IInputBinItem[] items)](#PageInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageInputBin(InputBin.IInputBinItem[] items) {#PageInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-}
+```
+public PageInputBin(InputBin.IInputBinItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IInputBinItem\[\]](../../com.aspose.xps.metadata/iinputbinitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediacolor/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediacolor/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMediaColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "メディアカラーオプションと各オプションの特性を説明します。"
+type: docs
+weight: 101
+url: /ja/java/com.aspose.xps.metadata/pagemediacolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaColor extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+Media Color のオプションと各オプションの特性を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediacolor
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaColor(PageMediaColor.PageMediaColorOption[] options)](#PageMediaColor-com.aspose.xps.metadata.PageMediaColor.PageMediaColorOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaColor(PageMediaColor.PageMediaColorOption[] options) {#PageMediaColor-com.aspose.xps.metadata.PageMediaColor.PageMediaColorOption...-}
+```
+public PageMediaColor(PageMediaColor.PageMediaColorOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageMediaColorOption\[\]](../../com.aspose.xps.metadata/pagemediacoloroption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediacoloroption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediacoloroption/_index.md
@@ -1,0 +1,322 @@
+---
+title: "PageMediaColor.PageMediaColorOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageMediaColor 機能のオプションを記述します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagemediacolor.pagemediacoloroption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageMediaColor.PageMediaColorOption extends Option
+```
+
+PageMediaColor 機能オプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Black](#Black) | 黒。 |
+| [Blue](#Blue) | 青。 |
+| [Brown](#Brown) | 茶色。 |
+| [Gold](#Gold) | 金。 |
+| [GoldenRod](#GoldenRod) | ゴールデンロッド。 |
+| [Gray](#Gray) | 灰色。 |
+| [Green](#Green) | 緑。 |
+| [Ivory](#Ivory) | アイボリー。 |
+| [NoColor](#NoColor) | 色なし。 |
+| [Orange](#Orange) | オレンジ。 |
+| [Pink](#Pink) | ピンク。 |
+| [Red](#Red) | 赤。 |
+| [Silver](#Silver) | シルバー。 |
+| [Turquoise](#Turquoise) | ターコイズ。 |
+| [Violet](#Violet) | バイオレット。 |
+| [White](#White) | 白。 |
+| [Yellow](#Yellow) | 黄色。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustom(String mediaColorsRGB)](#getCustom-java.lang.String-) | カスタムページカラーを指定します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Black {#Black}
+```
+public static PageMediaColor.PageMediaColorOption Black
+```
+
+
+黒。
+
+### Blue {#Blue}
+```
+public static PageMediaColor.PageMediaColorOption Blue
+```
+
+
+青。
+
+### Brown {#Brown}
+```
+public static PageMediaColor.PageMediaColorOption Brown
+```
+
+
+茶色。
+
+### Gold {#Gold}
+```
+public static PageMediaColor.PageMediaColorOption Gold
+```
+
+
+金。
+
+### GoldenRod {#GoldenRod}
+```
+public static PageMediaColor.PageMediaColorOption GoldenRod
+```
+
+
+ゴールデンロッド。
+
+### Gray {#Gray}
+```
+public static PageMediaColor.PageMediaColorOption Gray
+```
+
+
+灰色。
+
+### Green {#Green}
+```
+public static PageMediaColor.PageMediaColorOption Green
+```
+
+
+緑。
+
+### Ivory {#Ivory}
+```
+public static PageMediaColor.PageMediaColorOption Ivory
+```
+
+
+アイボリー。
+
+### NoColor {#NoColor}
+```
+public static PageMediaColor.PageMediaColorOption NoColor
+```
+
+
+色なし。
+
+### Orange {#Orange}
+```
+public static PageMediaColor.PageMediaColorOption Orange
+```
+
+
+オレンジ。
+
+### Pink {#Pink}
+```
+public static PageMediaColor.PageMediaColorOption Pink
+```
+
+
+ピンク。
+
+### Red {#Red}
+```
+public static PageMediaColor.PageMediaColorOption Red
+```
+
+
+赤。
+
+### Silver {#Silver}
+```
+public static PageMediaColor.PageMediaColorOption Silver
+```
+
+
+シルバー。
+
+### Turquoise {#Turquoise}
+```
+public static PageMediaColor.PageMediaColorOption Turquoise
+```
+
+
+ターコイズ。
+
+### Violet {#Violet}
+```
+public static PageMediaColor.PageMediaColorOption Violet
+```
+
+
+バイオレット。
+
+### White {#White}
+```
+public static PageMediaColor.PageMediaColorOption White
+```
+
+
+白。
+
+### Yellow {#Yellow}
+```
+public static PageMediaColor.PageMediaColorOption Yellow
+```
+
+
+黄色。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustom(String mediaColorsRGB) {#getCustom-java.lang.String-}
+```
+public static PageMediaColor.PageMediaColorOption getCustom(String mediaColorsRGB)
+```
+
+
+カスタムページカラーを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| mediaColorsRGB | java.lang.String | ページの色。 |
+
+**Returns:**
+[PageMediaColorOption](../../com.aspose.xps.metadata/pagemediacoloroption) - The option element for a custom color.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasize/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasize/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMediaSize"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力に使用される物理メディアの寸法を説明します。"
+type: docs
+weight: 102
+url: /ja/java/com.aspose.xps.metadata/pagemediasize/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSize extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力に使用される物理メディアの寸法について説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasize
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSize(PageMediaSize.IPageMediaSizeItem[] options)](#PageMediaSize-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSize(PageMediaSize.IPageMediaSizeItem[] options) {#PageMediaSize-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeItem...-}
+```
+public PageMediaSize(PageMediaSize.IPageMediaSizeItem[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [IPageMediaSizeItem\[\]](../../com.aspose.xps.metadata/ipagemediasizeitem) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizemediasizeheight/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizemediasizeheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizeMediaSizeHeight"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタム MediaSize オプションの MediaSizeWidth 方向の寸法を指定します。"
+type: docs
+weight: 103
+url: /ja/java/com.aspose.xps.metadata/pagemediasizemediasizeheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizeMediaSizeHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタム MediaSize オプションの MediaSizeWidth 方向の寸法を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizemediasizeheight
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizeMediaSizeHeight(int value)](#PageMediaSizeMediaSizeHeight-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizeMediaSizeHeight(int value) {#PageMediaSizeMediaSizeHeight-int-}
+```
+public PageMediaSizeMediaSizeHeight(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizemediasizewidth/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizemediasizewidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizeMediaSizeWidth"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタム MediaSize オプションの MediaSizeHeight 方向の寸法を指定します。"
+type: docs
+weight: 104
+url: /ja/java/com.aspose.xps.metadata/pagemediasizemediasizewidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizeMediaSizeWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタム MediaSize オプションの MediaSizeHeight 方向の寸法を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizemediasizewidth
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizeMediaSizeWidth(int value)](#PageMediaSizeMediaSizeWidth-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizeMediaSizeWidth(int value) {#PageMediaSizeMediaSizeWidth-int-}
+```
+public PageMediaSizeMediaSizeWidth(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizeoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizeoption/_index.md
@@ -1,0 +1,1787 @@
+---
+title: "PageMediaSize.PageMediaSizeOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageMediaSize 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagemediasize.pagemediasizeoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeItem](../../com.aspose.xps.metadata/ipagemediasizeitem)
+```
+public static final class PageMediaSize.PageMediaSizeOption extends Option implements PageMediaSize.IPageMediaSizeItem
+```
+
+PageMediaSize 機能のオプションを説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizeOption(String name, PageMediaSize.IPageMediaSizeOptionItem[] items)](#PageMediaSizeOption-java.lang.String-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-) | 新しいインスタンスを作成します。 |
+| [PageMediaSizeOption(PageMediaSize.PageMediaSizeOption option)](#PageMediaSizeOption-com.aspose.xps.metadata.PageMediaSize.PageMediaSizeOption-) | このオプション インスタンスをクローンします。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BusinessCard](#BusinessCard) | 名刺 |
+| [CreditCard](#CreditCard) | クレジットカード |
+| [CustomMediaSize](#CustomMediaSize) | カスタムメディアサイズを指定します。 |
+| [ISOA0](#ISOA0) | ISOA0 |
+| [ISOA1](#ISOA1) | ISOA1 |
+| [ISOA10](#ISOA10) | ISOA10 |
+| [ISOA2](#ISOA2) | ISOA2 |
+| [ISOA3](#ISOA3) | ISOA3 |
+| [ISOA3Extra](#ISOA3Extra) | ISOA3 エクストラ |
+| [ISOA3Rotated](#ISOA3Rotated) | ISOA3 回転 |
+| [ISOA4](#ISOA4) | ISOA4 |
+| [ISOA4Extra](#ISOA4Extra) | ISOA4 エクストラ |
+| [ISOA4Rotated](#ISOA4Rotated) | ISOA4 回転 |
+| [ISOA5](#ISOA5) | ISOA5 |
+| [ISOA5Extra](#ISOA5Extra) | ISOA5 エクストラ |
+| [ISOA5Rotated](#ISOA5Rotated) | ISOA5 回転 |
+| [ISOA6](#ISOA6) | ISOA6 |
+| [ISOA6Rotated](#ISOA6Rotated) | ISOA6 回転 |
+| [ISOA7](#ISOA7) | ISOA7 |
+| [ISOA8](#ISOA8) | ISOA8 |
+| [ISOA9](#ISOA9) | ISOA9 |
+| [ISOB0](#ISOB0) | ISOB0 |
+| [ISOB1](#ISOB1) | ISOB1 |
+| [ISOB10](#ISOB10) | ISOB10 |
+| [ISOB2](#ISOB2) | ISOB2 |
+| [ISOB3](#ISOB3) | ISOB3 |
+| [ISOB4](#ISOB4) | ISOB4 |
+| [ISOB4Envelope](#ISOB4Envelope) | ISOB4 封筒 |
+| [ISOB5Envelope](#ISOB5Envelope) | ISOB5 封筒 |
+| [ISOB5Extra](#ISOB5Extra) | ISOB5 追加 |
+| [ISOB7](#ISOB7) | ISOB7 |
+| [ISOB8](#ISOB8) | ISOB8 |
+| [ISOB9](#ISOB9) | ISOB9 |
+| [ISOC0](#ISOC0) | ISOC0 |
+| [ISOC1](#ISOC1) | ISOC1 |
+| [ISOC10](#ISOC10) | ISOC10 |
+| [ISOC2](#ISOC2) | ISOC2 |
+| [ISOC3](#ISOC3) | ISOC3 |
+| [ISOC3Envelope](#ISOC3Envelope) | ISOC3 封筒 |
+| [ISOC4](#ISOC4) | ISOC4 |
+| [ISOC4Envelope](#ISOC4Envelope) | ISOC4 封筒 |
+| [ISOC5](#ISOC5) | ISOC5 |
+| [ISOC5Envelope](#ISOC5Envelope) | ISOC5 封筒 |
+| [ISOC6](#ISOC6) | ISOC6 |
+| [ISOC6C5Envelope](#ISOC6C5Envelope) | ISOC6C5 封筒 |
+| [ISOC6Envelope](#ISOC6Envelope) | ISOC6 封筒 |
+| [ISOC7](#ISOC7) | ISOC7 |
+| [ISOC8](#ISOC8) | ISOC8 |
+| [ISOC9](#ISOC9) | ISOC9 |
+| [ISODLEnvelope](#ISODLEnvelope) | ISODL 封筒 |
+| [ISODLEnvelopeRotated](#ISODLEnvelopeRotated) | ISODL 回転封筒 |
+| [ISOSRA3](#ISOSRA3) | ISOSRA3 |
+| [JISB0](#JISB0) | JISB0 |
+| [JISB1](#JISB1) | JISB1 |
+| [JISB10](#JISB10) | JISB10 |
+| [JISB2](#JISB2) | JISB2 |
+| [JISB3](#JISB3) | JISB3 |
+| [JISB4](#JISB4) | JISB4 |
+| [JISB4Rotated](#JISB4Rotated) | JISB4 回転 |
+| [JISB5](#JISB5) | JISB5 |
+| [JISB5Rotated](#JISB5Rotated) | JISB5 回転 |
+| [JISB6](#JISB6) | JISB6 |
+| [JISB6Rotated](#JISB6Rotated) | JISB6 回転 |
+| [JISB7](#JISB7) | JISB7 |
+| [JISB8](#JISB8) | JISB8 |
+| [JISB9](#JISB9) | JISB9 |
+| [Japan2LPhoto](#Japan2LPhoto) | Japan 2L 写真 |
+| [JapanChou3Envelope](#JapanChou3Envelope) | Japan Chou3 封筒 |
+| [JapanChou3EnvelopeRotated](#JapanChou3EnvelopeRotated) | Japan Chou3 回転封筒 |
+| [JapanChou4Envelope](#JapanChou4Envelope) | Japan Chou4 封筒 |
+| [JapanChou4EnvelopeRotated](#JapanChou4EnvelopeRotated) | Japan Chou4 回転封筒 |
+| [JapanDoubleHagakiPostcard](#JapanDoubleHagakiPostcard) | 日本 ダブル葉書ポストカード |
+| [JapanDoubleHagakiPostcardRotated](#JapanDoubleHagakiPostcardRotated) | 日本 ダブル葉書ポストカード 回転 |
+| [JapanHagakiPostcard](#JapanHagakiPostcard) | 日本 葉書ポストカード |
+| [JapanHagakiPostcardRotated](#JapanHagakiPostcardRotated) | 日本 葉書ポストカード 回転 |
+| [JapanKaku2Envelope](#JapanKaku2Envelope) | 日本 カク2封筒 |
+| [JapanKaku2EnvelopeRotated](#JapanKaku2EnvelopeRotated) | 日本 カク2封筒 回転 |
+| [JapanKaku3Envelope](#JapanKaku3Envelope) | 日本 カク3封筒 |
+| [JapanKaku3EnvelopeRotated](#JapanKaku3EnvelopeRotated) | 日本 カク3封筒 回転 |
+| [JapanLPhoto](#JapanLPhoto) | 日本 L 写真 |
+| [JapanQuadrupleHagakiPostcard](#JapanQuadrupleHagakiPostcard) | 日本 クアドラプル葉書ポストカード |
+| [JapanYou1Envelope](#JapanYou1Envelope) | 日本 ユー1封筒 |
+| [JapanYou2Envelope](#JapanYou2Envelope) | 日本 ユー2封筒 |
+| [JapanYou3Envelope](#JapanYou3Envelope) | 日本 ユー3封筒 |
+| [JapanYou4Envelope](#JapanYou4Envelope) | 日本 ユー4封筒 |
+| [JapanYou4EnvelopeRotated](#JapanYou4EnvelopeRotated) | 日本 ユー4封筒 回転 |
+| [JapanYou6Envelope](#JapanYou6Envelope) | 日本 ユー6封筒 |
+| [JapanYou6EnvelopeRotated](#JapanYou6EnvelopeRotated) | 日本 ユー6封筒 回転 |
+| [NorthAmerica10x11](#NorthAmerica10x11) | 北米 10x11 |
+| [NorthAmerica10x12](#NorthAmerica10x12) | 北米 10x12 |
+| [NorthAmerica10x14](#NorthAmerica10x14) | 北米 10x14 |
+| [NorthAmerica11x17](#NorthAmerica11x17) | 北米 11x17 |
+| [NorthAmerica14x17](#NorthAmerica14x17) | 北米 14x17 |
+| [NorthAmerica4x6](#NorthAmerica4x6) | 北米 4x6 |
+| [NorthAmerica4x8](#NorthAmerica4x8) | 北米 4x8 |
+| [NorthAmerica5x7](#NorthAmerica5x7) | 北米 5x7 |
+| [NorthAmerica8x10](#NorthAmerica8x10) | 北米 8x10 |
+| [NorthAmerica9x11](#NorthAmerica9x11) | 北米 9x11 |
+| [NorthAmericaArchitectureASheet](#NorthAmericaArchitectureASheet) | 北米 アーキテクチャ A シート |
+| [NorthAmericaArchitectureBSheet](#NorthAmericaArchitectureBSheet) | 北米 アーキテクチャ B シート |
+| [NorthAmericaArchitectureCSheet](#NorthAmericaArchitectureCSheet) | 北米 アーキテクチャ C シート |
+| [NorthAmericaArchitectureDSheet](#NorthAmericaArchitectureDSheet) | 北米 アーキテクチャ D シート |
+| [NorthAmericaArchitectureESheet](#NorthAmericaArchitectureESheet) | 北米 アーキテクチャ E シート |
+| [NorthAmericaCSheet](#NorthAmericaCSheet) | 北米 C シート |
+| [NorthAmericaDSheet](#NorthAmericaDSheet) | 北米 D シート |
+| [NorthAmericaESheet](#NorthAmericaESheet) | 北米 E シート |
+| [NorthAmericaExecutive](#NorthAmericaExecutive) | 北米 エグゼクティブ |
+| [NorthAmericaGermanLegalFanfold](#NorthAmericaGermanLegalFanfold) | 北米 ドイツ 法的 ファンフォールド |
+| [NorthAmericaGermanStandardFanfold](#NorthAmericaGermanStandardFanfold) | 北米 ドイツ 標準 ファンフォールド |
+| [NorthAmericaLegal](#NorthAmericaLegal) | 北米 リーガル |
+| [NorthAmericaLegalExtra](#NorthAmericaLegalExtra) | 北米 リーガル エクストラ |
+| [NorthAmericaLetter](#NorthAmericaLetter) | 北米 レター |
+| [NorthAmericaLetterExtra](#NorthAmericaLetterExtra) | 北米 レター エクストラ |
+| [NorthAmericaLetterPlus](#NorthAmericaLetterPlus) | 北米 レター プラス |
+| [NorthAmericaLetterRotated](#NorthAmericaLetterRotated) | 北米 レター 回転 |
+| [NorthAmericaMonarchEnvelope](#NorthAmericaMonarchEnvelope) | 北米 モナーク封筒 |
+| [NorthAmericaNote](#NorthAmericaNote) | 北米 ノート |
+| [NorthAmericaNumber10Envelope](#NorthAmericaNumber10Envelope) | 北米 ナンバー10封筒 |
+| [NorthAmericaNumber10EnvelopeRotated](#NorthAmericaNumber10EnvelopeRotated) | 北米 ナンバー10封筒 回転 |
+| [NorthAmericaNumber11Envelope](#NorthAmericaNumber11Envelope) | 北米 ナンバー11封筒 |
+| [NorthAmericaNumber12Envelope](#NorthAmericaNumber12Envelope) | 北米 ナンバー12封筒 |
+| [NorthAmericaNumber14Envelope](#NorthAmericaNumber14Envelope) | 北米 ナンバー14封筒 |
+| [NorthAmericaNumber9Envelope](#NorthAmericaNumber9Envelope) | 北米 ナンバー9封筒 |
+| [NorthAmericaPersonalEnvelope](#NorthAmericaPersonalEnvelope) | 北米 パーソナル封筒 |
+| [NorthAmericaQuarto](#NorthAmericaQuarto) | 北米 クォート |
+| [NorthAmericaStatement](#NorthAmericaStatement) | 北米 ステートメント |
+| [NorthAmericaSuperA](#NorthAmericaSuperA) | 北米 スーパA |
+| [NorthAmericaSuperB](#NorthAmericaSuperB) | 北米 スーパB |
+| [NorthAmericaTabloid](#NorthAmericaTabloid) | 北米 タブロイド |
+| [NorthAmericaTabloidExtra](#NorthAmericaTabloidExtra) | 北米 タブロイドエクストラ |
+| [OtherMetricA3Plus](#OtherMetricA3Plus) | その他 メートル法 A3 プラス |
+| [OtherMetricA4Plus](#OtherMetricA4Plus) | その他 メートル法 A4 プラス |
+| [OtherMetricFolio](#OtherMetricFolio) | その他 メートル法 フォリオ |
+| [OtherMetricInviteEnvelope](#OtherMetricInviteEnvelope) | その他 メートル法 招待封筒 |
+| [OtherMetricItalianEnvelope](#OtherMetricItalianEnvelope) | その他 メートル法 イタリア封筒 |
+| [PRC10Envelope](#PRC10Envelope) | PRC10封筒 |
+| [PRC10EnvelopeRotated](#PRC10EnvelopeRotated) | PRC10封筒（回転） |
+| [PRC16K](#PRC16K) | PRC16K |
+| [PRC16KRotated](#PRC16KRotated) | PRC16K（回転） |
+| [PRC1Envelope](#PRC1Envelope) | PRC1封筒 |
+| [PRC1EnvelopeRotated](#PRC1EnvelopeRotated) | PRC1封筒（回転） |
+| [PRC2Envelope](#PRC2Envelope) | PRC2封筒 |
+| [PRC2EnvelopeRotated](#PRC2EnvelopeRotated) | PRC2封筒（回転） |
+| [PRC32K](#PRC32K) | PRC32K |
+| [PRC32KBig](#PRC32KBig) | PRC32K（大） |
+| [PRC32KRotated](#PRC32KRotated) | PRC32K（回転） |
+| [PRC3Envelope](#PRC3Envelope) | PRC3 封筒 |
+| [PRC3EnvelopeRotated](#PRC3EnvelopeRotated) | PRC3 封筒（回転） |
+| [PRC4Envelope](#PRC4Envelope) | PRC4 封筒 |
+| [PRC4EnvelopeRotated](#PRC4EnvelopeRotated) | PRC4 封筒（回転） |
+| [PRC5Envelope](#PRC5Envelope) | PRC 封筒 |
+| [PRC5EnvelopeRotated](#PRC5EnvelopeRotated) | PRC5 封筒（回転） |
+| [PRC6Envelope](#PRC6Envelope) | PRC6 封筒 |
+| [PRC6EnvelopeRotated](#PRC6EnvelopeRotated) | PRC6 封筒（回転） |
+| [PRC7Envelope](#PRC7Envelope) | PRC7 封筒 |
+| [PRC7EnvelopeRotated](#PRC7EnvelopeRotated) | PRC7 封筒（回転） |
+| [PRC8Envelope](#PRC8Envelope) | PRC8 封筒 |
+| [PRC8EnvelopeRotated](#PRC8EnvelopeRotated) | PRC8 封筒（回転） |
+| [PRC9Envelope](#PRC9Envelope) | PRC9 封筒 |
+| [PRC9EnvelopeRotated](#PRC9EnvelopeRotated) | PRC9 封筒（回転） |
+| [PSCustomMediaSize](#PSCustomMediaSize) | カスタムメディアサイズを指定します（PostScript 固有）。 |
+| [Roll06Inch](#Roll06Inch) | ロール 06 インチ |
+| [Roll08Inch](#Roll08Inch) | ロール 08 インチ |
+| [Roll12Inch](#Roll12Inch) | ロール 12 インチ |
+| [Roll15Inch](#Roll15Inch) | ロール 15 インチ |
+| [Roll18Inch](#Roll18Inch) | ロール 18 インチ |
+| [Roll22Inch](#Roll22Inch) | ロール 22 インチ |
+| [Roll24Inch](#Roll24Inch) | ロール 24 インチ |
+| [Roll30Inch](#Roll30Inch) | ロール 30 インチ |
+| [Roll36Inch](#Roll36Inch) | ロール 36 インチ |
+| [Roll54Inch](#Roll54Inch) | ロール 54 インチ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(PageMediaSize.IPageMediaSizeOptionItem[] items)](#add-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-) | オプションに項目を追加します。 |
+| [clone()](#clone--) | このオプション インスタンスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMediaSizeHeight(int mediaSizeHeight)](#setMediaSizeHeight-int-) | MediaSizeWidth のスコア付きプロパティ値を追加します。 |
+| [setMediaSizeWidth(int mediaSizeWidth)](#setMediaSizeWidth-int-) | MediaSizeWidth のスコア付きプロパティ値を追加します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizeOption(String name, PageMediaSize.IPageMediaSizeOptionItem[] items) {#PageMediaSizeOption-java.lang.String-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-}
+```
+public PageMediaSizeOption(String name, PageMediaSize.IPageMediaSizeOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | オプション名です。 |
+| items | [IPageMediaSizeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediasizeoptionitem) | オプション項目です。 |
+
+### PageMediaSizeOption(PageMediaSize.PageMediaSizeOption option) {#PageMediaSizeOption-com.aspose.xps.metadata.PageMediaSize.PageMediaSizeOption-}
+```
+public PageMediaSizeOption(PageMediaSize.PageMediaSizeOption option)
+```
+
+
+このオプション インスタンスをクローンします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| option | [PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) | クローン対象のインスタンス。 |
+
+### BusinessCard {#BusinessCard}
+```
+public static PageMediaSize.PageMediaSizeOption BusinessCard
+```
+
+
+名刺
+
+### CreditCard {#CreditCard}
+```
+public static PageMediaSize.PageMediaSizeOption CreditCard
+```
+
+
+クレジットカード
+
+### CustomMediaSize {#CustomMediaSize}
+```
+public static PageMediaSize.PageMediaSizeOption CustomMediaSize
+```
+
+
+カスタムメディアサイズを指定します。DeviceMediaSize に対して検証する必要があります。
+
+### ISOA0 {#ISOA0}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA0
+```
+
+
+ISOA0
+
+### ISOA1 {#ISOA1}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA1
+```
+
+
+ISOA1
+
+### ISOA10 {#ISOA10}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA10
+```
+
+
+ISOA10
+
+### ISOA2 {#ISOA2}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA2
+```
+
+
+ISOA2
+
+### ISOA3 {#ISOA3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA3
+```
+
+
+ISOA3
+
+### ISOA3Extra {#ISOA3Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA3Extra
+```
+
+
+ISOA3 エクストラ
+
+### ISOA3Rotated {#ISOA3Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA3Rotated
+```
+
+
+ISOA3 回転
+
+### ISOA4 {#ISOA4}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA4
+```
+
+
+ISOA4
+
+### ISOA4Extra {#ISOA4Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA4Extra
+```
+
+
+ISOA4 エクストラ
+
+### ISOA4Rotated {#ISOA4Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA4Rotated
+```
+
+
+ISOA4 回転
+
+### ISOA5 {#ISOA5}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA5
+```
+
+
+ISOA5
+
+### ISOA5Extra {#ISOA5Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA5Extra
+```
+
+
+ISOA5 エクストラ
+
+### ISOA5Rotated {#ISOA5Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA5Rotated
+```
+
+
+ISOA5 回転
+
+### ISOA6 {#ISOA6}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA6
+```
+
+
+ISOA6
+
+### ISOA6Rotated {#ISOA6Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA6Rotated
+```
+
+
+ISOA6 回転
+
+### ISOA7 {#ISOA7}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA7
+```
+
+
+ISOA7
+
+### ISOA8 {#ISOA8}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA8
+```
+
+
+ISOA8
+
+### ISOA9 {#ISOA9}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA9
+```
+
+
+ISOA9
+
+### ISOB0 {#ISOB0}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB0
+```
+
+
+ISOB0
+
+### ISOB1 {#ISOB1}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB1
+```
+
+
+ISOB1
+
+### ISOB10 {#ISOB10}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB10
+```
+
+
+ISOB10
+
+### ISOB2 {#ISOB2}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB2
+```
+
+
+ISOB2
+
+### ISOB3 {#ISOB3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB3
+```
+
+
+ISOB3
+
+### ISOB4 {#ISOB4}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB4
+```
+
+
+ISOB4
+
+### ISOB4Envelope {#ISOB4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB4Envelope
+```
+
+
+ISOB4 封筒
+
+### ISOB5Envelope {#ISOB5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB5Envelope
+```
+
+
+ISOB5 封筒
+
+### ISOB5Extra {#ISOB5Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB5Extra
+```
+
+
+ISOB5 追加
+
+### ISOB7 {#ISOB7}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB7
+```
+
+
+ISOB7
+
+### ISOB8 {#ISOB8}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB8
+```
+
+
+ISOB8
+
+### ISOB9 {#ISOB9}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB9
+```
+
+
+ISOB9
+
+### ISOC0 {#ISOC0}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC0
+```
+
+
+ISOC0
+
+### ISOC1 {#ISOC1}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC1
+```
+
+
+ISOC1
+
+### ISOC10 {#ISOC10}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC10
+```
+
+
+ISOC10
+
+### ISOC2 {#ISOC2}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC2
+```
+
+
+ISOC2
+
+### ISOC3 {#ISOC3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC3
+```
+
+
+ISOC3
+
+### ISOC3Envelope {#ISOC3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC3Envelope
+```
+
+
+ISOC3 封筒
+
+### ISOC4 {#ISOC4}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC4
+```
+
+
+ISOC4
+
+### ISOC4Envelope {#ISOC4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC4Envelope
+```
+
+
+ISOC4 封筒
+
+### ISOC5 {#ISOC5}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC5
+```
+
+
+ISOC5
+
+### ISOC5Envelope {#ISOC5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC5Envelope
+```
+
+
+ISOC5 封筒
+
+### ISOC6 {#ISOC6}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC6
+```
+
+
+ISOC6
+
+### ISOC6C5Envelope {#ISOC6C5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC6C5Envelope
+```
+
+
+ISOC6C5 封筒
+
+### ISOC6Envelope {#ISOC6Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC6Envelope
+```
+
+
+ISOC6 封筒
+
+### ISOC7 {#ISOC7}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC7
+```
+
+
+ISOC7
+
+### ISOC8 {#ISOC8}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC8
+```
+
+
+ISOC8
+
+### ISOC9 {#ISOC9}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC9
+```
+
+
+ISOC9
+
+### ISODLEnvelope {#ISODLEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISODLEnvelope
+```
+
+
+ISODL 封筒
+
+### ISODLEnvelopeRotated {#ISODLEnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISODLEnvelopeRotated
+```
+
+
+ISODL 回転封筒
+
+### ISOSRA3 {#ISOSRA3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOSRA3
+```
+
+
+ISOSRA3
+
+### JISB0 {#JISB0}
+```
+public static PageMediaSize.PageMediaSizeOption JISB0
+```
+
+
+JISB0
+
+### JISB1 {#JISB1}
+```
+public static PageMediaSize.PageMediaSizeOption JISB1
+```
+
+
+JISB1
+
+### JISB10 {#JISB10}
+```
+public static PageMediaSize.PageMediaSizeOption JISB10
+```
+
+
+JISB10
+
+### JISB2 {#JISB2}
+```
+public static PageMediaSize.PageMediaSizeOption JISB2
+```
+
+
+JISB2
+
+### JISB3 {#JISB3}
+```
+public static PageMediaSize.PageMediaSizeOption JISB3
+```
+
+
+JISB3
+
+### JISB4 {#JISB4}
+```
+public static PageMediaSize.PageMediaSizeOption JISB4
+```
+
+
+JISB4
+
+### JISB4Rotated {#JISB4Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption JISB4Rotated
+```
+
+
+JISB4 回転
+
+### JISB5 {#JISB5}
+```
+public static PageMediaSize.PageMediaSizeOption JISB5
+```
+
+
+JISB5
+
+### JISB5Rotated {#JISB5Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption JISB5Rotated
+```
+
+
+JISB5 回転
+
+### JISB6 {#JISB6}
+```
+public static PageMediaSize.PageMediaSizeOption JISB6
+```
+
+
+JISB6
+
+### JISB6Rotated {#JISB6Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption JISB6Rotated
+```
+
+
+JISB6 回転
+
+### JISB7 {#JISB7}
+```
+public static PageMediaSize.PageMediaSizeOption JISB7
+```
+
+
+JISB7
+
+### JISB8 {#JISB8}
+```
+public static PageMediaSize.PageMediaSizeOption JISB8
+```
+
+
+JISB8
+
+### JISB9 {#JISB9}
+```
+public static PageMediaSize.PageMediaSizeOption JISB9
+```
+
+
+JISB9
+
+### Japan2LPhoto {#Japan2LPhoto}
+```
+public static PageMediaSize.PageMediaSizeOption Japan2LPhoto
+```
+
+
+Japan 2L 写真
+
+### JapanChou3Envelope {#JapanChou3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou3Envelope
+```
+
+
+Japan Chou3 封筒
+
+### JapanChou3EnvelopeRotated {#JapanChou3EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou3EnvelopeRotated
+```
+
+
+Japan Chou3 回転封筒
+
+### JapanChou4Envelope {#JapanChou4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou4Envelope
+```
+
+
+Japan Chou4 封筒
+
+### JapanChou4EnvelopeRotated {#JapanChou4EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou4EnvelopeRotated
+```
+
+
+Japan Chou4 回転封筒
+
+### JapanDoubleHagakiPostcard {#JapanDoubleHagakiPostcard}
+```
+public static PageMediaSize.PageMediaSizeOption JapanDoubleHagakiPostcard
+```
+
+
+日本 ダブル葉書ポストカード
+
+### JapanDoubleHagakiPostcardRotated {#JapanDoubleHagakiPostcardRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanDoubleHagakiPostcardRotated
+```
+
+
+日本 ダブル葉書ポストカード 回転
+
+### JapanHagakiPostcard {#JapanHagakiPostcard}
+```
+public static PageMediaSize.PageMediaSizeOption JapanHagakiPostcard
+```
+
+
+日本 葉書ポストカード
+
+### JapanHagakiPostcardRotated {#JapanHagakiPostcardRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanHagakiPostcardRotated
+```
+
+
+日本 葉書ポストカード 回転
+
+### JapanKaku2Envelope {#JapanKaku2Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku2Envelope
+```
+
+
+日本 カク2封筒
+
+### JapanKaku2EnvelopeRotated {#JapanKaku2EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku2EnvelopeRotated
+```
+
+
+日本 カク2封筒 回転
+
+### JapanKaku3Envelope {#JapanKaku3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku3Envelope
+```
+
+
+日本 カク3封筒
+
+### JapanKaku3EnvelopeRotated {#JapanKaku3EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku3EnvelopeRotated
+```
+
+
+日本 カク3封筒 回転
+
+### JapanLPhoto {#JapanLPhoto}
+```
+public static PageMediaSize.PageMediaSizeOption JapanLPhoto
+```
+
+
+日本 L 写真
+
+### JapanQuadrupleHagakiPostcard {#JapanQuadrupleHagakiPostcard}
+```
+public static PageMediaSize.PageMediaSizeOption JapanQuadrupleHagakiPostcard
+```
+
+
+日本 クアドラプル葉書ポストカード
+
+### JapanYou1Envelope {#JapanYou1Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou1Envelope
+```
+
+
+日本 ユー1封筒
+
+### JapanYou2Envelope {#JapanYou2Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou2Envelope
+```
+
+
+日本 ユー2封筒
+
+### JapanYou3Envelope {#JapanYou3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou3Envelope
+```
+
+
+日本 ユー3封筒
+
+### JapanYou4Envelope {#JapanYou4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou4Envelope
+```
+
+
+日本 ユー4封筒
+
+### JapanYou4EnvelopeRotated {#JapanYou4EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou4EnvelopeRotated
+```
+
+
+日本 ユー4封筒 回転
+
+### JapanYou6Envelope {#JapanYou6Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou6Envelope
+```
+
+
+日本 ユー6封筒
+
+### JapanYou6EnvelopeRotated {#JapanYou6EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou6EnvelopeRotated
+```
+
+
+日本 ユー6封筒 回転
+
+### NorthAmerica10x11 {#NorthAmerica10x11}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica10x11
+```
+
+
+北米 10x11
+
+### NorthAmerica10x12 {#NorthAmerica10x12}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica10x12
+```
+
+
+北米 10x12
+
+### NorthAmerica10x14 {#NorthAmerica10x14}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica10x14
+```
+
+
+北米 10x14
+
+### NorthAmerica11x17 {#NorthAmerica11x17}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica11x17
+```
+
+
+北米 11x17
+
+### NorthAmerica14x17 {#NorthAmerica14x17}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica14x17
+```
+
+
+北米 14x17
+
+### NorthAmerica4x6 {#NorthAmerica4x6}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica4x6
+```
+
+
+北米 4x6
+
+### NorthAmerica4x8 {#NorthAmerica4x8}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica4x8
+```
+
+
+北米 4x8
+
+### NorthAmerica5x7 {#NorthAmerica5x7}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica5x7
+```
+
+
+北米 5x7
+
+### NorthAmerica8x10 {#NorthAmerica8x10}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica8x10
+```
+
+
+北米 8x10
+
+### NorthAmerica9x11 {#NorthAmerica9x11}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica9x11
+```
+
+
+北米 9x11
+
+### NorthAmericaArchitectureASheet {#NorthAmericaArchitectureASheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureASheet
+```
+
+
+北米 アーキテクチャ A シート
+
+### NorthAmericaArchitectureBSheet {#NorthAmericaArchitectureBSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureBSheet
+```
+
+
+北米 アーキテクチャ B シート
+
+### NorthAmericaArchitectureCSheet {#NorthAmericaArchitectureCSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureCSheet
+```
+
+
+北米 アーキテクチャ C シート
+
+### NorthAmericaArchitectureDSheet {#NorthAmericaArchitectureDSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureDSheet
+```
+
+
+北米 アーキテクチャ D シート
+
+### NorthAmericaArchitectureESheet {#NorthAmericaArchitectureESheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureESheet
+```
+
+
+北米 アーキテクチャ E シート
+
+### NorthAmericaCSheet {#NorthAmericaCSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaCSheet
+```
+
+
+北米 C シート
+
+### NorthAmericaDSheet {#NorthAmericaDSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaDSheet
+```
+
+
+北米 D シート
+
+### NorthAmericaESheet {#NorthAmericaESheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaESheet
+```
+
+
+北米 E シート
+
+### NorthAmericaExecutive {#NorthAmericaExecutive}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaExecutive
+```
+
+
+北米 エグゼクティブ
+
+### NorthAmericaGermanLegalFanfold {#NorthAmericaGermanLegalFanfold}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaGermanLegalFanfold
+```
+
+
+北米 ドイツ 法的 ファンフォールド
+
+### NorthAmericaGermanStandardFanfold {#NorthAmericaGermanStandardFanfold}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaGermanStandardFanfold
+```
+
+
+北米 ドイツ 標準 ファンフォールド
+
+### NorthAmericaLegal {#NorthAmericaLegal}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLegal
+```
+
+
+北米 リーガル
+
+### NorthAmericaLegalExtra {#NorthAmericaLegalExtra}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLegalExtra
+```
+
+
+北米 リーガル エクストラ
+
+### NorthAmericaLetter {#NorthAmericaLetter}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetter
+```
+
+
+北米 レター
+
+### NorthAmericaLetterExtra {#NorthAmericaLetterExtra}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetterExtra
+```
+
+
+北米 レター エクストラ
+
+### NorthAmericaLetterPlus {#NorthAmericaLetterPlus}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetterPlus
+```
+
+
+北米 レター プラス
+
+### NorthAmericaLetterRotated {#NorthAmericaLetterRotated}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetterRotated
+```
+
+
+北米 レター 回転
+
+### NorthAmericaMonarchEnvelope {#NorthAmericaMonarchEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaMonarchEnvelope
+```
+
+
+北米 モナーク封筒
+
+### NorthAmericaNote {#NorthAmericaNote}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNote
+```
+
+
+北米 ノート
+
+### NorthAmericaNumber10Envelope {#NorthAmericaNumber10Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber10Envelope
+```
+
+
+北米 ナンバー10封筒
+
+### NorthAmericaNumber10EnvelopeRotated {#NorthAmericaNumber10EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber10EnvelopeRotated
+```
+
+
+北米 ナンバー10封筒 回転
+
+### NorthAmericaNumber11Envelope {#NorthAmericaNumber11Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber11Envelope
+```
+
+
+北米 ナンバー11封筒
+
+### NorthAmericaNumber12Envelope {#NorthAmericaNumber12Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber12Envelope
+```
+
+
+北米 ナンバー12封筒
+
+### NorthAmericaNumber14Envelope {#NorthAmericaNumber14Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber14Envelope
+```
+
+
+北米 ナンバー14封筒
+
+### NorthAmericaNumber9Envelope {#NorthAmericaNumber9Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber9Envelope
+```
+
+
+北米 ナンバー9封筒
+
+### NorthAmericaPersonalEnvelope {#NorthAmericaPersonalEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaPersonalEnvelope
+```
+
+
+北米 パーソナル封筒
+
+### NorthAmericaQuarto {#NorthAmericaQuarto}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaQuarto
+```
+
+
+北米 クォート
+
+### NorthAmericaStatement {#NorthAmericaStatement}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaStatement
+```
+
+
+北米 ステートメント
+
+### NorthAmericaSuperA {#NorthAmericaSuperA}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaSuperA
+```
+
+
+北米 スーパA
+
+### NorthAmericaSuperB {#NorthAmericaSuperB}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaSuperB
+```
+
+
+北米 スーパB
+
+### NorthAmericaTabloid {#NorthAmericaTabloid}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaTabloid
+```
+
+
+北米 タブロイド
+
+### NorthAmericaTabloidExtra {#NorthAmericaTabloidExtra}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaTabloidExtra
+```
+
+
+北米 タブロイドエクストラ
+
+### OtherMetricA3Plus {#OtherMetricA3Plus}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricA3Plus
+```
+
+
+その他 メートル法 A3 プラス
+
+### OtherMetricA4Plus {#OtherMetricA4Plus}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricA4Plus
+```
+
+
+その他 メートル法 A4 プラス
+
+### OtherMetricFolio {#OtherMetricFolio}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricFolio
+```
+
+
+その他 メートル法 フォリオ
+
+### OtherMetricInviteEnvelope {#OtherMetricInviteEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricInviteEnvelope
+```
+
+
+その他 メートル法 招待封筒
+
+### OtherMetricItalianEnvelope {#OtherMetricItalianEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricItalianEnvelope
+```
+
+
+その他 メートル法 イタリア封筒
+
+### PRC10Envelope {#PRC10Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC10Envelope
+```
+
+
+PRC10封筒
+
+### PRC10EnvelopeRotated {#PRC10EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC10EnvelopeRotated
+```
+
+
+PRC10封筒（回転）
+
+### PRC16K {#PRC16K}
+```
+public static PageMediaSize.PageMediaSizeOption PRC16K
+```
+
+
+PRC16K
+
+### PRC16KRotated {#PRC16KRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC16KRotated
+```
+
+
+PRC16K（回転）
+
+### PRC1Envelope {#PRC1Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC1Envelope
+```
+
+
+PRC1封筒
+
+### PRC1EnvelopeRotated {#PRC1EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC1EnvelopeRotated
+```
+
+
+PRC1封筒（回転）
+
+### PRC2Envelope {#PRC2Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC2Envelope
+```
+
+
+PRC2封筒
+
+### PRC2EnvelopeRotated {#PRC2EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC2EnvelopeRotated
+```
+
+
+PRC2封筒（回転）
+
+### PRC32K {#PRC32K}
+```
+public static PageMediaSize.PageMediaSizeOption PRC32K
+```
+
+
+PRC32K
+
+### PRC32KBig {#PRC32KBig}
+```
+public static PageMediaSize.PageMediaSizeOption PRC32KBig
+```
+
+
+PRC32K（大）
+
+### PRC32KRotated {#PRC32KRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC32KRotated
+```
+
+
+PRC32K（回転）
+
+### PRC3Envelope {#PRC3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC3Envelope
+```
+
+
+PRC3 封筒
+
+### PRC3EnvelopeRotated {#PRC3EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC3EnvelopeRotated
+```
+
+
+PRC3 封筒（回転）
+
+### PRC4Envelope {#PRC4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC4Envelope
+```
+
+
+PRC4 封筒
+
+### PRC4EnvelopeRotated {#PRC4EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC4EnvelopeRotated
+```
+
+
+PRC4 封筒（回転）
+
+### PRC5Envelope {#PRC5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC5Envelope
+```
+
+
+PRC 封筒
+
+### PRC5EnvelopeRotated {#PRC5EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC5EnvelopeRotated
+```
+
+
+PRC5 封筒（回転）
+
+### PRC6Envelope {#PRC6Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC6Envelope
+```
+
+
+PRC6 封筒
+
+### PRC6EnvelopeRotated {#PRC6EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC6EnvelopeRotated
+```
+
+
+PRC6 封筒（回転）
+
+### PRC7Envelope {#PRC7Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC7Envelope
+```
+
+
+PRC7 封筒
+
+### PRC7EnvelopeRotated {#PRC7EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC7EnvelopeRotated
+```
+
+
+PRC7 封筒（回転）
+
+### PRC8Envelope {#PRC8Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC8Envelope
+```
+
+
+PRC8 封筒
+
+### PRC8EnvelopeRotated {#PRC8EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC8EnvelopeRotated
+```
+
+
+PRC8 封筒（回転）
+
+### PRC9Envelope {#PRC9Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC9Envelope
+```
+
+
+PRC9 封筒
+
+### PRC9EnvelopeRotated {#PRC9EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC9EnvelopeRotated
+```
+
+
+PRC9 封筒（回転）
+
+### PSCustomMediaSize {#PSCustomMediaSize}
+```
+public static PageMediaSize.PageMediaSizeOption PSCustomMediaSize
+```
+
+
+カスタムメディアサイズ（PostScript 固有）を指定します。DeviceMediaSize に対して検証する必要があります。
+
+### Roll06Inch {#Roll06Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll06Inch
+```
+
+
+ロール 06 インチ
+
+### Roll08Inch {#Roll08Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll08Inch
+```
+
+
+ロール 08 インチ
+
+### Roll12Inch {#Roll12Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll12Inch
+```
+
+
+ロール 12 インチ
+
+### Roll15Inch {#Roll15Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll15Inch
+```
+
+
+ロール 15 インチ
+
+### Roll18Inch {#Roll18Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll18Inch
+```
+
+
+ロール 18 インチ
+
+### Roll22Inch {#Roll22Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll22Inch
+```
+
+
+ロール 22 インチ
+
+### Roll24Inch {#Roll24Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll24Inch
+```
+
+
+ロール 24 インチ
+
+### Roll30Inch {#Roll30Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll30Inch
+```
+
+
+ロール 30 インチ
+
+### Roll36Inch {#Roll36Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll36Inch
+```
+
+
+ロール 36 インチ
+
+### Roll54Inch {#Roll54Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll54Inch
+```
+
+
+ロール 54 インチ
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(PageMediaSize.IPageMediaSizeOptionItem[] items) {#add-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-}
+```
+public PageMediaSize.PageMediaSizeOption add(PageMediaSize.IPageMediaSizeOptionItem[] items)
+```
+
+
+オプションに項目を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageMediaSizeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediasizeoptionitem) | 追加する項目。 |
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - This options.
+### clone() {#clone--}
+```
+public PageMediaSize.PageMediaSizeOption clone()
+```
+
+
+このオプションインスタンスをクローンします。クローン作成コンストラクタへのショートカットです。
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMediaSizeHeight(int mediaSizeHeight) {#setMediaSizeHeight-int-}
+```
+public PageMediaSize.PageMediaSizeOption setMediaSizeHeight(int mediaSizeHeight)
+```
+
+
+MediaSizeWidth のスコア付きプロパティ値を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| mediaSizeHeight | int | MediaSizeHeight のスコア付きプロパティ値です。 |
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - This option.
+### setMediaSizeWidth(int mediaSizeWidth) {#setMediaSizeWidth-int-}
+```
+public PageMediaSize.PageMediaSizeOption setMediaSizeWidth(int mediaSizeWidth)
+```
+
+
+MediaSizeWidth のスコア付きプロパティ値を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| mediaSizeWidth | int | MediaSizeWidth のスコア付きプロパティ値です。 |
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - This option.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizepsheight/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizepsheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSHeight"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "給紙方向に平行なページの高さを指定します。"
+type: docs
+weight: 105
+url: /ja/java/com.aspose.xps.metadata/pagemediasizepsheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+給紙方向に平行なページの高さを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsheight
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizePSHeight(int value)](#PageMediaSizePSHeight-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSHeight(int value) {#PageMediaSizePSHeight-int-}
+```
+public PageMediaSizePSHeight(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizepsheightoffset/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizepsheightoffset/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSHeightOffset"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "給紙方向に平行なオフセットを指定します。"
+type: docs
+weight: 106
+url: /ja/java/com.aspose.xps.metadata/pagemediasizepsheightoffset/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSHeightOffset extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+給紙方向に平行なオフセットを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsheightoffset
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizePSHeightOffset(int value)](#PageMediaSizePSHeightOffset-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSHeightOffset(int value) {#PageMediaSizePSHeightOffset-int-}
+```
+public PageMediaSizePSHeightOffset(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizepsorientation/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizepsorientation/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSOrientation"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "給紙方向に対する向きを指定します https//docs.microsoft.com/en-us/windows/win32rintdocsagemediasizepsorientation"
+type: docs
+weight: 107
+url: /ja/java/com.aspose.xps.metadata/pagemediasizepsorientation/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSOrientation extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+給紙方向に対する向きを指定します https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsorientation
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizePSOrientation(int value)](#PageMediaSizePSOrientation-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSOrientation(int value) {#PageMediaSizePSOrientation-int-}
+```
+public PageMediaSizePSOrientation(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizepswidth/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizepswidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSWidth"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページの幅を、給紙方向に垂直に指定します。"
+type: docs
+weight: 108
+url: /ja/java/com.aspose.xps.metadata/pagemediasizepswidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ページの給紙方向に対して垂直な幅を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepswidth
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizePSWidth(int value)](#PageMediaSizePSWidth-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSWidth(int value) {#PageMediaSizePSWidth-int-}
+```
+public PageMediaSizePSWidth(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediasizepswidthoffset/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediasizepswidthoffset/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSWidthOffset"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "給紙方向に垂直なオフセットを指定します。"
+type: docs
+weight: 109
+url: /ja/java/com.aspose.xps.metadata/pagemediasizepswidthoffset/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSWidthOffset extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+給紙方向に対して垂直なオフセットを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepswidthoffset
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaSizePSWidthOffset(int value)](#PageMediaSizePSWidthOffset-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSWidthOffset(int value) {#PageMediaSizePSWidthOffset-int-}
+```
+public PageMediaSizePSWidthOffset(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediatype/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediatype/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMediaType"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "MediaType オプションと各オプションの特性を説明します。"
+type: docs
+weight: 110
+url: /ja/java/com.aspose.xps.metadata/pagemediatype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaType extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+MediaType オプションと各オプションの特性を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediatype
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaType(PageMediaType.IPageMediaTypeItem[] items)](#PageMediaType-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaType(PageMediaType.IPageMediaTypeItem[] items) {#PageMediaType-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeItem...-}
+```
+public PageMediaType(PageMediaType.IPageMediaTypeItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageMediaTypeItem\[\]](../../com.aspose.xps.metadata/ipagemediatypeitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemediatypeoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemediatypeoption/_index.md
@@ -1,0 +1,493 @@
+---
+title: "PageMediaType.PageMediaTypeOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageMediaType 機能のオプションを説明します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.pagemediatypeoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeItem](../../com.aspose.xps.metadata/ipagemediatypeitem)
+```
+public static final class PageMediaType.PageMediaTypeOption extends Option implements PageMediaType.IPageMediaTypeItem
+```
+
+PageMediaType 機能のオプションを説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMediaTypeOption(String optionName, PageMediaType.IPageMediaTypeOptionItem[] items)](#PageMediaTypeOption-java.lang.String-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-) | 新しいインスタンスを作成します。 |
+| [PageMediaTypeOption(PageMediaType.PageMediaTypeOption option)](#PageMediaTypeOption-com.aspose.xps.metadata.PageMediaType.PageMediaTypeOption-) | このオプション インスタンスをクローンします。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Archival](#Archival) | アーカイブ品質のメディアを指定します。 |
+| [AutoSelect](#AutoSelect) | メディアが自動的に選択されることを指定します。 |
+| [BackPrintFilm](#BackPrintFilm) | 特殊な裏面印刷フィルムメディアを指定します。 |
+| [Bond](#Bond) | 標準的なボンドメディアを指定します。 |
+| [CardStock](#CardStock) | 標準的なカードストックメディアを指定します。 |
+| [Continous](#Continous) | 連続供給メディアを指定します。 |
+| [EnvelopePlain](#EnvelopePlain) | 標準的な封筒メディアを指定します。 |
+| [EnvelopeWindow](#EnvelopeWindow) | 窓付き封筒メディアを指定します。 |
+| [Fabric](#Fabric) | 布製メディアを指定します。 |
+| [HighResolution](#HighResolution) | 特殊な高解像度メディアを指定します。 |
+| [Label](#Label) | ラベルメディアを指定します。 |
+| [MultiLayerForm](#MultiLayerForm) | 付属の多部構成フォームメディアを指定します。 |
+| [MultiPartForm](#MultiPartForm) | 別々の多部構成フォームメディアを指定します。 |
+| [None](#None) | 不明またはリストにないメディアを指定します。 |
+| [Photographic](#Photographic) | 標準的な写真メディアを指定します。 |
+| [PhotographicFilm](#PhotographicFilm) | フィルム写真メディアを指定します。 |
+| [PhotographicGlossy](#PhotographicGlossy) | 光沢写真メディアを指定します。 |
+| [PhotographicHighGloss](#PhotographicHighGloss) | 高光沢写真メディアを指定します。 |
+| [PhotographicMatte](#PhotographicMatte) | マット写真メディアを指定します。 |
+| [PhotographicSatin](#PhotographicSatin) | サテン写真メディアを指定します。 |
+| [PhotographicSemiGloss](#PhotographicSemiGloss) | セミグロス写真メディアを指定します。 |
+| [Plain](#Plain) | 標準的な紙メディアを指定します。 |
+| [Screen](#Screen) | 連続形式で出力ディスプレイに出力することを指定します。 |
+| [ScreenPaged](#ScreenPaged) | ページ形式で出力ディスプレイに出力することを指定します。 |
+| [Stationary](#Stationary) | 特殊な文房具メディアを指定します。 |
+| [TShirtTransfer](#TShirtTransfer) | 特殊なTシャツ転写メディアを指定します。 |
+| [TabStockFull](#TabStockFull) | 事前にカットされていないタブストックメディア（シングルタブ）を指定します。 |
+| [TabStockPreCut](#TabStockPreCut) | 事前にカットされたタブストックメディア（複数タブ）を指定します。 |
+| [Transparency](#Transparency) | 透明メディアを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(PageMediaType.IPageMediaTypeOptionItem[] items)](#add-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-) | オプションに IPageMediaTypeOptionItem インスタンスの配列を追加します。 |
+| [clone()](#clone--) | このオプション インスタンスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setWeight(int weight)](#setWeight-int-) | Weight スコアプロパティの値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaTypeOption(String optionName, PageMediaType.IPageMediaTypeOptionItem[] items) {#PageMediaTypeOption-java.lang.String-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-}
+```
+public PageMediaTypeOption(String optionName, PageMediaType.IPageMediaTypeOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| optionName | java.lang.String | オプション名です。 |
+| items | [IPageMediaTypeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediatypeoptionitem) | 任意の IPageMediaTypeOptionItem インスタンスの配列です。 |
+
+### PageMediaTypeOption(PageMediaType.PageMediaTypeOption option) {#PageMediaTypeOption-com.aspose.xps.metadata.PageMediaType.PageMediaTypeOption-}
+```
+public PageMediaTypeOption(PageMediaType.PageMediaTypeOption option)
+```
+
+
+このオプション インスタンスをクローンします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| option | [PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) | クローン対象のインスタンス。 |
+
+### Archival {#Archival}
+```
+public static PageMediaType.PageMediaTypeOption Archival
+```
+
+
+アーカイブ品質のメディアを指定します。
+
+### AutoSelect {#AutoSelect}
+```
+public static PageMediaType.PageMediaTypeOption AutoSelect
+```
+
+
+メディアが自動的に選択されることを指定します。
+
+### BackPrintFilm {#BackPrintFilm}
+```
+public static PageMediaType.PageMediaTypeOption BackPrintFilm
+```
+
+
+特殊な裏面印刷フィルムメディアを指定します。
+
+### Bond {#Bond}
+```
+public static PageMediaType.PageMediaTypeOption Bond
+```
+
+
+標準的なボンドメディアを指定します。
+
+### CardStock {#CardStock}
+```
+public static PageMediaType.PageMediaTypeOption CardStock
+```
+
+
+標準的なカードストックメディアを指定します。
+
+### Continous {#Continous}
+```
+public static PageMediaType.PageMediaTypeOption Continous
+```
+
+
+連続供給メディアを指定します。
+
+### EnvelopePlain {#EnvelopePlain}
+```
+public static PageMediaType.PageMediaTypeOption EnvelopePlain
+```
+
+
+標準的な封筒メディアを指定します。
+
+### EnvelopeWindow {#EnvelopeWindow}
+```
+public static PageMediaType.PageMediaTypeOption EnvelopeWindow
+```
+
+
+窓付き封筒メディアを指定します。
+
+### Fabric {#Fabric}
+```
+public static PageMediaType.PageMediaTypeOption Fabric
+```
+
+
+布製メディアを指定します。
+
+### HighResolution {#HighResolution}
+```
+public static PageMediaType.PageMediaTypeOption HighResolution
+```
+
+
+特殊な高解像度メディアを指定します。
+
+### Label {#Label}
+```
+public static PageMediaType.PageMediaTypeOption Label
+```
+
+
+ラベルメディアを指定します。
+
+### MultiLayerForm {#MultiLayerForm}
+```
+public static PageMediaType.PageMediaTypeOption MultiLayerForm
+```
+
+
+付属の多部構成フォームメディアを指定します。
+
+### MultiPartForm {#MultiPartForm}
+```
+public static PageMediaType.PageMediaTypeOption MultiPartForm
+```
+
+
+別々の多部構成フォームメディアを指定します。
+
+### None {#None}
+```
+public static PageMediaType.PageMediaTypeOption None
+```
+
+
+不明またはリストにないメディアを指定します。
+
+### Photographic {#Photographic}
+```
+public static PageMediaType.PageMediaTypeOption Photographic
+```
+
+
+標準的な写真メディアを指定します。
+
+### PhotographicFilm {#PhotographicFilm}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicFilm
+```
+
+
+フィルム写真メディアを指定します。
+
+### PhotographicGlossy {#PhotographicGlossy}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicGlossy
+```
+
+
+光沢写真メディアを指定します。
+
+### PhotographicHighGloss {#PhotographicHighGloss}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicHighGloss
+```
+
+
+高光沢写真メディアを指定します。
+
+### PhotographicMatte {#PhotographicMatte}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicMatte
+```
+
+
+マット写真メディアを指定します。
+
+### PhotographicSatin {#PhotographicSatin}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicSatin
+```
+
+
+サテン写真メディアを指定します。
+
+### PhotographicSemiGloss {#PhotographicSemiGloss}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicSemiGloss
+```
+
+
+セミグロス写真メディアを指定します。
+
+### Plain {#Plain}
+```
+public static PageMediaType.PageMediaTypeOption Plain
+```
+
+
+標準的な紙メディアを指定します。
+
+### Screen {#Screen}
+```
+public static PageMediaType.PageMediaTypeOption Screen
+```
+
+
+連続形式で出力ディスプレイに出力することを指定します。
+
+### ScreenPaged {#ScreenPaged}
+```
+public static PageMediaType.PageMediaTypeOption ScreenPaged
+```
+
+
+ページ形式で出力ディスプレイに出力することを指定します。
+
+### Stationary {#Stationary}
+```
+public static PageMediaType.PageMediaTypeOption Stationary
+```
+
+
+特殊な文房具メディアを指定します。
+
+### TShirtTransfer {#TShirtTransfer}
+```
+public static PageMediaType.PageMediaTypeOption TShirtTransfer
+```
+
+
+特殊なTシャツ転写メディアを指定します。
+
+### TabStockFull {#TabStockFull}
+```
+public static PageMediaType.PageMediaTypeOption TabStockFull
+```
+
+
+事前にカットされていないタブストックメディア（シングルタブ）を指定します。
+
+### TabStockPreCut {#TabStockPreCut}
+```
+public static PageMediaType.PageMediaTypeOption TabStockPreCut
+```
+
+
+事前にカットされたタブストックメディア（複数タブ）を指定します。
+
+### Transparency {#Transparency}
+```
+public static PageMediaType.PageMediaTypeOption Transparency
+```
+
+
+透明メディアを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(PageMediaType.IPageMediaTypeOptionItem[] items) {#add-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-}
+```
+public PageMediaType.PageMediaTypeOption add(PageMediaType.IPageMediaTypeOptionItem[] items)
+```
+
+
+オプションに IPageMediaTypeOptionItem インスタンスの配列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageMediaTypeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediatypeoptionitem) | 任意の IPageMediaTypeOptionItem インスタンスの配列です。 |
+
+**Returns:**
+[PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) - This options instance.
+### clone() {#clone--}
+```
+public PageMediaType.PageMediaTypeOption clone()
+```
+
+
+このオプションインスタンスをクローンします。クローン作成コンストラクタへのショートカットです。
+
+**Returns:**
+[PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setWeight(int weight) {#setWeight-int-}
+```
+public PageMediaType.PageMediaTypeOption setWeight(int weight)
+```
+
+
+Weight スコアプロパティの値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 重み | int | Weight スコアプロパティの値です。 |
+
+**Returns:**
+[PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemirrorimage/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemirrorimage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMirrorImage"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のミラーリング設定を説明します。"
+type: docs
+weight: 111
+url: /ja/java/com.aspose.xps.metadata/pagemirrorimage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMirrorImage extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力のミラー設定を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemirrorimage
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageMirrorImage(PageMirrorImage.PageMirrorImageOption[] options)](#PageMirrorImage-com.aspose.xps.metadata.PageMirrorImage.PageMirrorImageOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMirrorImage(PageMirrorImage.PageMirrorImageOption[] options) {#PageMirrorImage-com.aspose.xps.metadata.PageMirrorImage.PageMirrorImageOption...-}
+```
+public PageMirrorImage(PageMirrorImage.PageMirrorImageOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageMirrorImageOption\[\]](../../com.aspose.xps.metadata/pagemirrorimageoption) | 配列または機能オプションです。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagemirrorimageoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagemirrorimageoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "PageMirrorImage.PageMirrorImageOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageMirrorImage 機能オプションを定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagemirrorimage.pagemirrorimageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageMirrorImage.PageMirrorImageOption extends Option
+```
+
+PageMirrorImage 機能のオプションを定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [MirrorImageHeight](#MirrorImageHeight) | 出力が MediaSizeHeight 方向に平行に鏡像化されるよう指定します。 |
+| [MirrorImageWidth](#MirrorImageWidth) | 出力が MediaSizeWidth 方向に平行に鏡像化されるよう指定します。 |
+| [None](#None) | 出力が鏡像化されないよう指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MirrorImageHeight {#MirrorImageHeight}
+```
+public static PageMirrorImage.PageMirrorImageOption MirrorImageHeight
+```
+
+
+出力が MediaSizeHeight 方向に平行に鏡像化されるよう指定します。
+
+### MirrorImageWidth {#MirrorImageWidth}
+```
+public static PageMirrorImage.PageMirrorImageOption MirrorImageWidth
+```
+
+
+出力が MediaSizeWidth 方向に平行に鏡像化されるよう指定します。
+
+### None {#None}
+```
+public static PageMirrorImage.PageMirrorImageOption None
+```
+
+
+出力が鏡像化されないよう指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagenegativeimage/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagenegativeimage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageNegativeImage"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のネガティブ設定を説明します。"
+type: docs
+weight: 112
+url: /ja/java/com.aspose.xps.metadata/pagenegativeimage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageNegativeImage extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力のネガティブ設定を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagenegativeimage
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageNegativeImage(PageNegativeImage.PageNegativeImageOption[] options)](#PageNegativeImage-com.aspose.xps.metadata.PageNegativeImage.PageNegativeImageOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageNegativeImage(PageNegativeImage.PageNegativeImageOption[] options) {#PageNegativeImage-com.aspose.xps.metadata.PageNegativeImage.PageNegativeImageOption...-}
+```
+public PageNegativeImage(PageNegativeImage.PageNegativeImageOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageNegativeImageOption\[\]](../../com.aspose.xps.metadata/pagenegativeimageoption) | 配列または機能オプションです。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagenegativeimageoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagenegativeimageoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageNegativeImage.PageNegativeImageOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageNegativeImage の機能オプションを定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagenegativeimage.pagenegativeimageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageNegativeImage.PageNegativeImageOption extends Option
+```
+
+PageNegativeImage 機能のオプションを定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Negative](#Negative) | 出力がネガティブ画像になるように指定します。 |
+| [None](#None) | 出力が非ネガティブ画像になるように指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Negative {#Negative}
+```
+public static PageNegativeImage.PageNegativeImageOption Negative
+```
+
+
+出力がネガティブ画像になるように指定します。
+
+### None {#None}
+```
+public static PageNegativeImage.PageNegativeImageOption None
+```
+
+
+出力が非ネガティブ画像になるように指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageorientation/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageorientation/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOrientation"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "物理メディアシートの向きを説明します。"
+type: docs
+weight: 113
+url: /ja/java/com.aspose.xps.metadata/pageorientation/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOrientation extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+物理メディアシートの向きを説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageorientation
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageOrientation(PageOrientation.PageOrientationOption[] options)](#PageOrientation-com.aspose.xps.metadata.PageOrientation.PageOrientationOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOrientation(PageOrientation.PageOrientationOption[] options) {#PageOrientation-com.aspose.xps.metadata.PageOrientation.PageOrientationOption...-}
+```
+public PageOrientation(PageOrientation.PageOrientationOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageOrientationOption\[\]](../../com.aspose.xps.metadata/pageorientationoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageorientationoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageorientationoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageOrientation.PageOrientationOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageOrientation 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageorientation.pageorientationoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageOrientation.PageOrientationOption extends Option
+```
+
+PageOrientation 機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Landscape](#Landscape) | コンテンツは標準（縦）向きに対してページ上で 90 度反時計回りに回転します。 |
+| [Portrait](#Portrait) | 標準向き。 |
+| [ReverseLandscape](#ReverseLandscape) | コンテンツはページ上で標準（縦）向きに対して反時計回りに270度回転しています。 |
+| [ReversePortrait](#ReversePortrait) | コンテンツはページ上で標準（縦）向きに対して180度回転しています。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Landscape {#Landscape}
+```
+public static final PageOrientation.PageOrientationOption Landscape
+```
+
+
+コンテンツは標準（縦）向きに対してページ上で 90 度反時計回りに回転します。
+
+### Portrait {#Portrait}
+```
+public static final PageOrientation.PageOrientationOption Portrait
+```
+
+
+標準向き。
+
+### ReverseLandscape {#ReverseLandscape}
+```
+public static final PageOrientation.PageOrientationOption ReverseLandscape
+```
+
+
+コンテンツはページ上で標準（縦）向きに対して反時計回りに270度回転しています。
+
+### ReversePortrait {#ReversePortrait}
+```
+public static final PageOrientation.PageOrientationOption ReversePortrait
+```
+
+
+コンテンツはページ上で標準（縦）向きに対して180度回転しています。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageoutputbin/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageoutputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOutputBin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "デバイスでサポートされるビンの完全なリストを説明します。"
+type: docs
+weight: 114
+url: /ja/java/com.aspose.xps.metadata/pageoutputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.OutputBin](../../com.aspose.xps.metadata/outputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOutputBin extends OutputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+デバイスでサポートされているビンの完全なリストを説明します。ページ単位で出力ビンを指定できます。  JobOutputBin 、  DocumentOutputBin 、  PageOutputBin  キーワードは相互に排他的であり、PrintTicket または Print Capabilities ドキュメントではいずれか一つだけを指定すべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageoutputbin
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageOutputBin(OutputBin.IOutputBinItem[] items)](#PageOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputBin(OutputBin.IOutputBinItem[] items) {#PageOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-}
+```
+public PageOutputBin(OutputBin.IOutputBinItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOutputBinItem\[\]](../../com.aspose.xps.metadata/ioutputbinitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageoutputcolor/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageoutputcolor/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOutputColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のカラ設定の特性を説明します。"
+type: docs
+weight: 115
+url: /ja/java/com.aspose.xps.metadata/pageoutputcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOutputColor extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力のカラー設定の特性について説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageoutputcolor
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageOutputColor(PageOutputColor.IPageOutputColorItem[] items)](#PageOutputColor-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputColor(PageOutputColor.IPageOutputColorItem[] items) {#PageOutputColor-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorItem...-}
+```
+public PageOutputColor(PageOutputColor.IPageOutputColorItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageOutputColorItem\[\]](../../com.aspose.xps.metadata/ipageoutputcoloritem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageoutputcoloroption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageoutputcoloroption/_index.md
@@ -1,0 +1,238 @@
+---
+title: "PageOutputColor.PageOutputColorOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageOutputColor 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageoutputcolor.pageoutputcoloroption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageOutputColor.IPageOutputColorItem](../../com.aspose.xps.metadata/ipageoutputcoloritem)
+```
+public static final class PageOutputColor.PageOutputColorOption extends Option implements PageOutputColor.IPageOutputColorItem
+```
+
+PageOutputColor 機能のオプションを説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageOutputColorOption(String optionName, PageOutputColor.IPageOutputColorOptionItem[] items)](#PageOutputColorOption-java.lang.String-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [Color(int deviceBitsPerPixel, int driverBitsPerPixel)](#Color-int-int-) | 出力がカラーであることを指定します。 |
+| [Grayscale(int deviceBitsPerPixel, int driverBitsPerPixel)](#Grayscale-int-int-) | 出力がグレースケールであることを指定します。 |
+| [Monochrome(int deviceBitsPerPixel, int driverBitsPerPixel)](#Monochrome-int-int-) | 出力がモノクロ（黒）であることを指定します。 |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(PageOutputColor.IPageOutputColorOptionItem[] items)](#add-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-) | オプションに IPageOutputColorOptionItem インスタンスの配列を追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputColorOption(String optionName, PageOutputColor.IPageOutputColorOptionItem[] items) {#PageOutputColorOption-java.lang.String-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-}
+```
+public PageOutputColorOption(String optionName, PageOutputColor.IPageOutputColorOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| optionName | java.lang.String | オプション名です。 |
+| items | [IPageOutputColorOptionItem\[\]](../../com.aspose.xps.metadata/ipageoutputcoloroptionitem) | 任意の IPageOutputColorOptionItem インスタンスの配列です。 |
+
+### Color(int deviceBitsPerPixel, int driverBitsPerPixel) {#Color-int-int-}
+```
+public static final PageOutputColor.PageOutputColorOption Color(int deviceBitsPerPixel, int driverBitsPerPixel)
+```
+
+
+出力がカラーであることを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| deviceBitsPerPixel | int | プリンターがサポートするカラー データのピクセルあたりビット数を示す DeviceBitsPerPixel スコア付きプロパティ値です。 |
+| driverBitsPerPixel | int | コアドライバーがビットマップレンダリングバッファに使用すべきピクセルあたりビット数を示す DriverBitsPerPixel スコア付きプロパティ値です。 |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - The  PageOutputColor  options.
+### Grayscale(int deviceBitsPerPixel, int driverBitsPerPixel) {#Grayscale-int-int-}
+```
+public static final PageOutputColor.PageOutputColorOption Grayscale(int deviceBitsPerPixel, int driverBitsPerPixel)
+```
+
+
+出力がグレースケールであることを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| deviceBitsPerPixel | int | プリンターがサポートするカラー データのピクセルあたりビット数を示す DeviceBitsPerPixel スコア付きプロパティ値です。 |
+| driverBitsPerPixel | int | コアドライバーがビットマップレンダリングバッファに使用すべきピクセルあたりビット数を示す DriverBitsPerPixel スコア付きプロパティ値です。 |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - The  PageOutputColor  options.
+### Monochrome(int deviceBitsPerPixel, int driverBitsPerPixel) {#Monochrome-int-int-}
+```
+public static final PageOutputColor.PageOutputColorOption Monochrome(int deviceBitsPerPixel, int driverBitsPerPixel)
+```
+
+
+出力がモノクロ（黒）であることを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| deviceBitsPerPixel | int | プリンターがサポートするカラー データのピクセルあたりビット数を示す DeviceBitsPerPixel スコア付きプロパティ値です。 |
+| driverBitsPerPixel | int | コアドライバーがビットマップレンダリングバッファに使用すべきピクセルあたりビット数を示す DriverBitsPerPixel スコア付きプロパティ値です。 |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - The  PageOutputColor  options.
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(PageOutputColor.IPageOutputColorOptionItem[] items) {#add-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-}
+```
+public PageOutputColor.PageOutputColorOption add(PageOutputColor.IPageOutputColorOptionItem[] items)
+```
+
+
+オプションに IPageOutputColorOptionItem インスタンスの配列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageOutputColorOptionItem\[\]](../../com.aspose.xps.metadata/ipageoutputcoloroptionitem) | 任意の IPageOutputColorOptionItem インスタンスの配列です。 |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageoutputquality/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageoutputquality/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOutputQuality"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のネガティブ設定を説明します。"
+type: docs
+weight: 116
+url: /ja/java/com.aspose.xps.metadata/pageoutputquality/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOutputQuality extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力の負の設定を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageoutputquality
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageOutputQuality(PageOutputQuality.PageOutputQualityOption[] options)](#PageOutputQuality-com.aspose.xps.metadata.PageOutputQuality.PageOutputQualityOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputQuality(PageOutputQuality.PageOutputQualityOption[] options) {#PageOutputQuality-com.aspose.xps.metadata.PageOutputQuality.PageOutputQualityOption...-}
+```
+public PageOutputQuality(PageOutputQuality.PageOutputQualityOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageOutputQualityOption\[\]](../../com.aspose.xps.metadata/pageoutputqualityoption) | 配列または機能オプションです。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageoutputqualityoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageoutputqualityoption/_index.md
@@ -1,0 +1,216 @@
+---
+title: "PageOutputQuality.PageOutputQualityOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageOutputQuality 機能オプションを定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageoutputquality.pageoutputqualityoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageOutputQuality.PageOutputQualityOption extends Option
+```
+
+PageOutputQuality の機能オプションを定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Automatic](#Automatic) | 自動出力の意図を指定します（クライアントが自動的に最適な設定を選択できるようにします）。 |
+| [Draft](#Draft) | ドラフト出力の意図を指定します（ドラフト品質のテキストとグラフィックにバランスが取れています）。 |
+| [Fax](#Fax) | FAX 出力の意図を指定します（標準的なFAX品質にバランスが取れています）。 |
+| [High](#High) | 高品質出力の意図を指定します（高品質のテキストとグラフィックにバランスが取れています）。 |
+| [Normal](#Normal) | 通常出力の意図を指定します（テキストとグラフィックの品質が良好になるようバランスが取れています）。 |
+| [Photographic](#Photographic) | 写真出力の意図を指定します（画像は最高品質であるべきです）。 |
+| [Text](#Text) | テキストのみの出力の意図を指定します（グラフィックは低品質で出力されるか、まったく出力されない可能性があります）。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static PageOutputQuality.PageOutputQualityOption Automatic
+```
+
+
+自動出力の意図を指定します（クライアントが自動的に最適な設定を選択できるようにします）。
+
+### Draft {#Draft}
+```
+public static PageOutputQuality.PageOutputQualityOption Draft
+```
+
+
+ドラフト出力の意図を指定します（ドラフト品質のテキストとグラフィックにバランスが取れています）。
+
+### Fax {#Fax}
+```
+public static PageOutputQuality.PageOutputQualityOption Fax
+```
+
+
+FAX 出力の意図を指定します（標準的なFAX品質にバランスが取れています）。
+
+### High {#High}
+```
+public static PageOutputQuality.PageOutputQualityOption High
+```
+
+
+高品質出力の意図を指定します（高品質のテキストとグラフィックにバランスが取れています）。
+
+### Normal {#Normal}
+```
+public static PageOutputQuality.PageOutputQualityOption Normal
+```
+
+
+通常出力の意図を指定します（テキストとグラフィックの品質が良好になるようバランスが取れています）。
+
+### Photographic {#Photographic}
+```
+public static PageOutputQuality.PageOutputQualityOption Photographic
+```
+
+
+写真出力の意図を指定します（画像は最高品質であるべきです）。
+
+### Text {#Text}
+```
+public static PageOutputQuality.PageOutputQualityOption Text
+```
+
+
+テキストのみの出力の意図を指定します（グラフィックは低品質で出力されるか、まったく出力されない可能性があります）。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagephotoprintingintent/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagephotoprintingintent/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PagePhotoPrintingIntent"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "写真印刷設定の設定を行うための高レベルの意図をドライバーに示します。"
+type: docs
+weight: 117
+url: /ja/java/com.aspose.xps.metadata/pagephotoprintingintent/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PagePhotoPrintingIntent extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ドライバーに対して写真印刷設定の設定を行うための高レベルの意図を示します。これらの設定は、ユーザーが写真を印刷する際に指定できる期待出力品質に関係します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagephotoprintingintent
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PagePhotoPrintingIntent(PagePhotoPrintingIntent.PagePhotoPrintingIntentOption[] options)](#PagePhotoPrintingIntent-com.aspose.xps.metadata.PagePhotoPrintingIntent.PagePhotoPrintingIntentOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PagePhotoPrintingIntent(PagePhotoPrintingIntent.PagePhotoPrintingIntentOption[] options) {#PagePhotoPrintingIntent-com.aspose.xps.metadata.PagePhotoPrintingIntent.PagePhotoPrintingIntentOption...-}
+```
+public PagePhotoPrintingIntent(PagePhotoPrintingIntent.PagePhotoPrintingIntentOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PagePhotoPrintingIntentOption\[\]](../../com.aspose.xps.metadata/pagephotoprintingintentoption) | 配列または機能オプションです。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagephotoprintingintentoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagephotoprintingintentoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PagePhotoPrintingIntent.PagePhotoPrintingIntentOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PagePhotoPrintingIntent 機能オプションを定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagephotoprintingintent.pagephotoprintingintentoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PagePhotoPrintingIntent.PagePhotoPrintingIntentOption extends Option
+```
+
+PagePhotoPrintingIntent の機能オプションを定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | フォト印刷インテントなし（アプリケーションがインテントの解決を指定しないことを許可します）。 |
+| [PhotoBest](#PhotoBest) | 最高品質のフォト印刷（主にマーケティング目的で提供され、デバイスの最高機能を活用します） |
+| [PhotoDraft](#PhotoDraft) | ドラフト品質のフォト印刷（校正目的の高速・低インク量印刷） |
+| [PhotoStandard](#PhotoStandard) | 標準品質のフォト印刷（OEM が推奨する標準的なフォト印刷設定） |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption None
+```
+
+
+フォト印刷インテントなし（アプリケーションがインテントの解決を指定しないことを許可します。PrintTicket 設定は変更すべきではありません）
+
+### PhotoBest {#PhotoBest}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption PhotoBest
+```
+
+
+最高品質のフォト印刷（主にマーケティング目的で提供され、デバイスの最高機能を活用します）
+
+### PhotoDraft {#PhotoDraft}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption PhotoDraft
+```
+
+
+ドラフト品質のフォト印刷（校正目的の高速・低インク量印刷）
+
+### PhotoStandard {#PhotoStandard}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption PhotoStandard
+```
+
+
+標準品質のフォト印刷（OEM が推奨する標準的なフォト印刷設定）
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageposter/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageposter/_index.md
@@ -1,0 +1,181 @@
+---
+title: "PagePoster"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "単一ページの出力を複数の物理メディアシートに記述します。"
+type: docs
+weight: 118
+url: /ja/java/com.aspose.xps.metadata/pageposter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PagePoster extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+単一ページの出力を複数の物理メディアシートに変換する方法を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageposter
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PagePoster()](#PagePoster--) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [addPagesPerSheetOption(int value)](#addPagesPerSheetOption-int-) | PagesPerSheet スコアドプロパティ値を持つオプションを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PagePoster() {#PagePoster--}
+```
+public PagePoster()
+```
+
+
+新しいインスタンスを作成します。
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### addPagesPerSheetOption(int value) {#addPagesPerSheetOption-int-}
+```
+public PagePoster addPagesPerSheetOption(int value)
+```
+
+
+PagesPerSheet のスコア付きプロパティ値を使用してオプションを追加します。論理ページあたりの物理シート数を指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | PagesPerSheet のスコア付きプロパティ値。 |
+
+**Returns:**
+[PagePoster](../../com.aspose.xps.metadata/pageposter) - This feature instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageprintticket/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageprintticket/_index.md
@@ -1,0 +1,181 @@
+---
+title: "PagePrintTicket"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページレベルの印刷チケットをカプセル化するクラスです。"
+type: docs
+weight: 119
+url: /ja/java/com.aspose.xps.metadata/pageprintticket/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicket](../../com.aspose.xps.metadata/printticket)
+```
+public final class PagePrintTicket extends PrintTicket
+```
+
+ページレベルの印刷チケットをカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PagePrintTicket(IPagePrintTicketItem[] items)](#PagePrintTicket-com.aspose.xps.metadata.IPagePrintTicketItem...-) | ページレベルの印刷チケットインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IPagePrintTicketItem[] items)](#add-com.aspose.xps.metadata.IPagePrintTicketItem...-) | この PrintTicket アイテムリストの末尾にアイテムの配列を追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 印刷チケット アイテム名のイテレータを返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | この PrintTicket アイテムリストからアイテムを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PagePrintTicket(IPagePrintTicketItem[] items) {#PagePrintTicket-com.aspose.xps.metadata.IPagePrintTicketItem...-}
+```
+public PagePrintTicket(IPagePrintTicketItem[] items)
+```
+
+
+ページレベルの印刷チケットインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPagePrintTicketItem\[\]](../../com.aspose.xps.metadata/ipageprintticketitem) | 任意の IPagePrintTicketItem インスタンスの配列です。各要素は  Feature 、  ParameterInit 、または  Property  インスタンスでなければなりません。 |
+
+### add(IPagePrintTicketItem[] items) {#add-com.aspose.xps.metadata.IPagePrintTicketItem...-}
+```
+public void add(IPagePrintTicketItem[] items)
+```
+
+
+この PrintTicket アイテムリストの末尾にアイテムの配列を追加します。各要素は  Feature 、  ParameterInit 、または  Property  インスタンスである可能性があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPagePrintTicketItem\[\]](../../com.aspose.xps.metadata/ipageprintticketitem) | 追加するアイテムの配列です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+印刷チケット アイテム名のイテレータを返します。
+
+**Returns:**
+java.util.Iterator<java.lang.String> - リストのイテレータを返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+この PrintTicket アイテムリストからアイテムを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String[] | アイテム名の配列です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageresolution/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageresolution/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageResolution"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "印刷出力のページ解像度を定性的な値、または DPI（ドット毎インチ）として、あるいはその両方で定義します。"
+type: docs
+weight: 120
+url: /ja/java/com.aspose.xps.metadata/pageresolution/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageResolution extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+印刷出力のページ解像度を定性的な値、または DPI（ドット毎インチ）、あるいはその両方で定義します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pageresolution
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageResolution(PageResolution.IPageResolutionItem[] items)](#PageResolution-com.aspose.xps.metadata.PageResolution.IPageResolutionItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageResolution(PageResolution.IPageResolutionItem[] items) {#PageResolution-com.aspose.xps.metadata.PageResolution.IPageResolutionItem...-}
+```
+public PageResolution(PageResolution.IPageResolutionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageResolutionItem\[\]](../../com.aspose.xps.metadata/ipageresolutionitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pageresolutionoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pageresolutionoption/_index.md
@@ -1,0 +1,219 @@
+---
+title: "PageResolution.PageResolutionOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageResolution 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pageresolution.pageresolutionoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageResolution.IPageResolutionItem](../../com.aspose.xps.metadata/ipageresolutionitem)
+```
+public static final class PageResolution.PageResolutionOption extends Option implements PageResolution.IPageResolutionItem
+```
+
+PageResolution の機能オプションを記述します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageResolutionOption(String optionName, PageResolution.IPageResolutionOptionItem[] items)](#PageResolutionOption-java.lang.String-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(PageResolution.IPageResolutionOptionItem[] items)](#add-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-) | IPageResolutionOptionItem インスタンスの配列をオプションに追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setResolutionX(int resolutionX)](#setResolutionX-int-) | ResolutionX のスコア付きプロパティ値を設定します。 |
+| [setResolutionY(int resolutionY)](#setResolutionY-int-) | ResolutionY のスコア付きプロパティ値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageResolutionOption(String optionName, PageResolution.IPageResolutionOptionItem[] items) {#PageResolutionOption-java.lang.String-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-}
+```
+public PageResolutionOption(String optionName, PageResolution.IPageResolutionOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| optionName | java.lang.String | オプション名です。 |
+| items | [IPageResolutionOptionItem\[\]](../../com.aspose.xps.metadata/ipageresolutionoptionitem) | IPageResolutionOptionItem インスタンスの任意の配列です。 |
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(PageResolution.IPageResolutionOptionItem[] items) {#add-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-}
+```
+public PageResolution.PageResolutionOption add(PageResolution.IPageResolutionOptionItem[] items)
+```
+
+
+IPageResolutionOptionItem インスタンスの配列をオプションに追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageResolutionOptionItem\[\]](../../com.aspose.xps.metadata/ipageresolutionoptionitem) | IPageResolutionOptionItem インスタンスの任意の配列です。 |
+
+**Returns:**
+[PageResolutionOption](../../com.aspose.xps.metadata/pageresolutionoption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setResolutionX(int resolutionX) {#setResolutionX-int-}
+```
+public PageResolution.PageResolutionOption setResolutionX(int resolutionX)
+```
+
+
+ResolutionX のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| resolutionX | int | ResolutionX のスコア付きプロパティ値です。 |
+
+**Returns:**
+[PageResolutionOption](../../com.aspose.xps.metadata/pageresolutionoption) - This option instance.
+### setResolutionY(int resolutionY) {#setResolutionY-int-}
+```
+public PageResolution.PageResolutionOption setResolutionY(int resolutionY)
+```
+
+
+ResolutionY のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| resolutionY | int | ResolutionY のスコア付きプロパティ値です。 |
+
+**Returns:**
+[PageResolutionOption](../../com.aspose.xps.metadata/pageresolutionoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescaling/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescaling/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageScaling"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力のスケーリング特性を記述します。"
+type: docs
+weight: 121
+url: /ja/java/com.aspose.xps.metadata/pagescaling/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScaling extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力のスケーリング特性を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescaling
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageScaling(PageScaling.IPageScalingItem[] items)](#PageScaling-com.aspose.xps.metadata.PageScaling.IPageScalingItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScaling(PageScaling.IPageScalingItem[] items) {#PageScaling-com.aspose.xps.metadata.PageScaling.IPageScalingItem...-}
+```
+public PageScaling(PageScaling.IPageScalingItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageScalingItem\[\]](../../com.aspose.xps.metadata/ipagescalingitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescalingoffsetheight/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescalingoffsetheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingOffsetHeight"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタムスケーリングのために ImageableSizeWidth 方向のスケーリングオフセットを指定します。"
+type: docs
+weight: 122
+url: /ja/java/com.aspose.xps.metadata/pagescalingoffsetheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingOffsetHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタムスケーリングのために ImageableSizeWidth 方向のスケーリングオフセットを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingoffsetheight
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageScalingOffsetHeight(int value)](#PageScalingOffsetHeight-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingOffsetHeight(int value) {#PageScalingOffsetHeight-int-}
+```
+public PageScalingOffsetHeight(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescalingoffsetwidth/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescalingoffsetwidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingOffsetWidth"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタムスケーリングのために ImageableSizeWidth 方向のスケーリングオフセットを指定します。"
+type: docs
+weight: 123
+url: /ja/java/com.aspose.xps.metadata/pagescalingoffsetwidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingOffsetWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタムスケーリングのために ImageableSizeWidth 方向のスケーリングオフセットを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingoffsetwidth
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageScalingOffsetWidth(int value)](#PageScalingOffsetWidth-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingOffsetWidth(int value) {#PageScalingOffsetWidth-int-}
+```
+public PageScalingOffsetWidth(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescalingoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescalingoption/_index.md
@@ -1,0 +1,219 @@
+---
+title: "PageScaling.PageScalingOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageScaling 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagescaling.pagescalingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageScaling.IPageScalingItem](../../com.aspose.xps.metadata/ipagescalingitem)
+```
+public static final class PageScaling.PageScalingOption extends Option implements PageScaling.IPageScalingItem
+```
+
+PageScaling の機能オプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Custom](#Custom) | Application Media Size にカスタムスケーリングを適用するように指定します。 |
+| [CustomSquare](#CustomSquare) | Application Media Size にカスタム正方形スケーリングを適用するように指定します。 |
+| [FitApplicationBleedSizeToPageImageableSize](#FitApplicationBleedSizeToPageImageableSize) | アプリケーションのブリードサイズをアスペクト比を保持したまま PageImageableSize にスケーリングするように指定します。 |
+| [FitApplicationContentSizeToPageImageableSize](#FitApplicationContentSizeToPageImageableSize) | アプリケーションのコンテンツサイズをアスペクト比を保持したまま PageImageableSize にスケーリングするように指定します。 |
+| [FitApplicationMediaSizeToPageImageableSize](#FitApplicationMediaSizeToPageImageableSize) | アプリケーションのメディアサイズをアスペクト比を保持したまま PageImageableSize にスケーリングするように指定します。 |
+| [FitApplicationMediaSizeToPageMediaSize](#FitApplicationMediaSizeToPageMediaSize) | アプリケーションのメディアサイズをアスペクト比を保持したまま PageMediaSize にスケーリングするように指定します。 |
+| [None](#None) | スケーリングを適用しないように指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Custom {#Custom}
+```
+public static PageScaling.PageScalingOption Custom
+```
+
+
+Application Media Size にカスタムスケーリングを適用するように指定します。
+
+### CustomSquare {#CustomSquare}
+```
+public static PageScaling.PageScalingOption CustomSquare
+```
+
+
+Application Media Size にカスタム正方形スケーリングを適用するように指定します。
+
+### FitApplicationBleedSizeToPageImageableSize {#FitApplicationBleedSizeToPageImageableSize}
+```
+public static PageScaling.PageScalingOption FitApplicationBleedSizeToPageImageableSize
+```
+
+
+アプリケーションのブリードサイズをアスペクト比を保持したまま PageImageableSize にスケーリングするように指定します。
+
+### FitApplicationContentSizeToPageImageableSize {#FitApplicationContentSizeToPageImageableSize}
+```
+public static PageScaling.PageScalingOption FitApplicationContentSizeToPageImageableSize
+```
+
+
+アプリケーションのコンテンツサイズをアスペクト比を保持したまま PageImageableSize にスケーリングするように指定します。
+
+### FitApplicationMediaSizeToPageImageableSize {#FitApplicationMediaSizeToPageImageableSize}
+```
+public static PageScaling.PageScalingOption FitApplicationMediaSizeToPageImageableSize
+```
+
+
+アプリケーションのメディアサイズをアスペクト比を保持したまま PageImageableSize にスケーリングするように指定します。
+
+### FitApplicationMediaSizeToPageMediaSize {#FitApplicationMediaSizeToPageMediaSize}
+```
+public static PageScaling.PageScalingOption FitApplicationMediaSizeToPageMediaSize
+```
+
+
+アプリケーションのメディアサイズをアスペクト比を保持したまま PageMediaSize にスケーリングするように指定します。
+
+### None {#None}
+```
+public static PageScaling.PageScalingOption None
+```
+
+
+スケーリングを適用しないように指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescalingscale/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescalingscale/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingScale"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタム正方形スケーリングのスケーリング係数を指定します。"
+type: docs
+weight: 124
+url: /ja/java/com.aspose.xps.metadata/pagescalingscale/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingScale extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタム正方形スケーリングのスケーリング係数を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingscale
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageScalingScale(int value)](#PageScalingScale-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingScale(int value) {#PageScalingScale-int-}
+```
+public PageScalingScale(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescalingscaleheight/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescalingscaleheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingScaleHeight"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタムスケーリングのために ImageableSizeHeight 方向の拡大縮小率を指定します。"
+type: docs
+weight: 125
+url: /ja/java/com.aspose.xps.metadata/pagescalingscaleheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingScaleHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタムスケーリングのために ImageableSizeHeight 方向の拡大縮小率を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingscaleheight
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageScalingScaleHeight(int value)](#PageScalingScaleHeight-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingScaleHeight(int value) {#PageScalingScaleHeight-int-}
+```
+public PageScalingScaleHeight(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagescalingscalewidth/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagescalingscalewidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingScaleWidth"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カスタムスケーリングのために ImageableSizeWidth 方向のスケーリング係数を指定します。"
+type: docs
+weight: 126
+url: /ja/java/com.aspose.xps.metadata/pagescalingscalewidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingScaleWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カスタムスケーリングのために ImageableSizeWidth 方向のスケーリング係数を指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingscalewidth
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageScalingScaleWidth(int value)](#PageScalingScaleWidth-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingScaleWidth(int value) {#PageScalingScaleWidth-int-}
+```
+public PageScalingScaleWidth(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofile/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofile/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageSourceColorProfile"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ソースカラープロファイルの特性を定義します。"
+type: docs
+weight: 127
+url: /ja/java/com.aspose.xps.metadata/pagesourcecolorprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageSourceColorProfile extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ソース カラープロファイルの特性を定義します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagesourcecolorprofile
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageSourceColorProfile(PageSourceColorProfile.PageSourceColorProfileOption[] options)](#PageSourceColorProfile-com.aspose.xps.metadata.PageSourceColorProfile.PageSourceColorProfileOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSourceColorProfile(PageSourceColorProfile.PageSourceColorProfileOption[] options) {#PageSourceColorProfile-com.aspose.xps.metadata.PageSourceColorProfile.PageSourceColorProfileOption...-}
+```
+public PageSourceColorProfile(PageSourceColorProfile.PageSourceColorProfileOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageSourceColorProfileOption\[\]](../../com.aspose.xps.metadata/pagesourcecolorprofileoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofileembedded/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofileembedded/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageSourceColorProfileEmbedded"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "埋め込みソースカラープロファイルを指定します。"
+type: docs
+weight: 128
+url: /ja/java/com.aspose.xps.metadata/pagesourcecolorprofileembedded/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageSourceColorProfileEmbedded extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+埋め込みソースカラープロファイルを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageSourceColorProfileEmbedded(String value)](#PageSourceColorProfileEmbedded-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSourceColorProfileEmbedded(String value) {#PageSourceColorProfileEmbedded-java.lang.String-}
+```
+public PageSourceColorProfileEmbedded(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofileoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofileoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "PageSourceColorProfile.PageSourceColorProfileOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageSourceColorProfile 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagesourcecolorprofile.pagesourcecolorprofileoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageSourceColorProfile.PageSourceColorProfileOption extends Option
+```
+
+PageSourceColorProfile の機能オプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [CMYK](#CMYK) | タグ付けされていない CMYK データのカラー管理に使用されるソースプロファイルです。 |
+| [None](#None) | ソースプロファイルがありません。 |
+| [RGB](#RGB) | タグ付けされていない RGB データのカラー管理に使用されるソースプロファイルです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CMYK {#CMYK}
+```
+public static PageSourceColorProfile.PageSourceColorProfileOption CMYK
+```
+
+
+タグ付けされていない CMYK データのカラー管理に使用されるソースプロファイルです。
+
+### None {#None}
+```
+public static PageSourceColorProfile.PageSourceColorProfileOption None
+```
+
+
+ソースプロファイルがありません。
+
+### RGB {#RGB}
+```
+public static PageSourceColorProfile.PageSourceColorProfileOption RGB
+```
+
+
+タグ付けされていない RGB データのカラー管理に使用されるソースプロファイルです。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofileuri/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagesourcecolorprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageSourceColorProfileURI"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "カラープロファイルのソースを指定します。"
+type: docs
+weight: 129
+url: /ja/java/com.aspose.xps.metadata/pagesourcecolorprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageSourceColorProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+カラープロファイルのソースを指定します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageSourceColorProfileURI(String value)](#PageSourceColorProfileURI-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSourceColorProfileURI(String value) {#PageSourceColorProfileURI-java.lang.String-}
+```
+public PageSourceColorProfileURI(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagetruetypefontmode/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagetruetypefontmode/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageTrueTypeFontMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "使用する TrueType フォント処理の方法を記述します。"
+type: docs
+weight: 130
+url: /ja/java/com.aspose.xps.metadata/pagetruetypefontmode/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageTrueTypeFontMode extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+使用する TrueType フォント処理方法を説明します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagetruetypefontmode
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageTrueTypeFontMode(PageTrueTypeFontMode.PageTrueTypeFontModeOption[] options)](#PageTrueTypeFontMode-com.aspose.xps.metadata.PageTrueTypeFontMode.PageTrueTypeFontModeOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageTrueTypeFontMode(PageTrueTypeFontMode.PageTrueTypeFontModeOption[] options) {#PageTrueTypeFontMode-com.aspose.xps.metadata.PageTrueTypeFontMode.PageTrueTypeFontModeOption...-}
+```
+public PageTrueTypeFontMode(PageTrueTypeFontMode.PageTrueTypeFontModeOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PageTrueTypeFontModeOption\[\]](../../com.aspose.xps.metadata/pagetruetypefontmodeoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagetruetypefontmodeoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagetruetypefontmodeoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "PageTrueTypeFontMode.PageTrueTypeFontModeOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageTrueTypeFontMode 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/pagetruetypefontmode.pagetruetypefontmodeoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageTrueTypeFontMode.PageTrueTypeFontModeOption extends Option
+```
+
+PageTrueTypeFontMode の機能オプションを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Automatic](#Automatic) | TrueType フォントの自動処理。 |
+| [DownloadAsNativeTrueTypeFont](#DownloadAsNativeTrueTypeFont) | TrueType フォントはネイティブの TrueType フォントとしてダウンロードされます。 |
+| [DownloadAsOutlineFont](#DownloadAsOutlineFont) | TrueType フォントはアウトラインフォントとしてダウンロードされます。 |
+| [DownloadAsRasterFont](#DownloadAsRasterFont) | TrueType フォントはラスターフォントとしてダウンロードされます。 |
+| [RenderAsBitmap](#RenderAsBitmap) | TrueType フォントはビットマップとしてレンダリングされます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption Automatic
+```
+
+
+TrueType フォントの自動処理。
+
+### DownloadAsNativeTrueTypeFont {#DownloadAsNativeTrueTypeFont}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption DownloadAsNativeTrueTypeFont
+```
+
+
+TrueType フォントはネイティブの TrueType フォントとしてダウンロードされます。
+
+### DownloadAsOutlineFont {#DownloadAsOutlineFont}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption DownloadAsOutlineFont
+```
+
+
+TrueType フォントはアウトラインフォントとしてダウンロードされます。
+
+### DownloadAsRasterFont {#DownloadAsRasterFont}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption DownloadAsRasterFont
+```
+
+
+TrueType フォントはラスターフォントとしてダウンロードされます。
+
+### RenderAsBitmap {#RenderAsBitmap}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption RenderAsBitmap
+```
+
+
+TrueType フォントはビットマップとしてレンダリングされます。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermark/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermark/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageWatermark"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "出力の透かし設定と透かしの特性を記述します。"
+type: docs
+weight: 131
+url: /ja/java/com.aspose.xps.metadata/pagewatermark/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermark extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+出力の透かし設定と透かしの特性を説明します。透かしは物理ページではなく論理ページに適用されます。例えば、DocumentDuplex が有効な場合、各シートの各 NUp ページに透かしが表示されます。DocumentDuplex が有効で、PagesPerSheet = 2 の場合、各シートに 2 つの透かしが付くことになります。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermark
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermark(PageWatermark.IPageWatermarkItem[] items)](#PageWatermark-com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermark(PageWatermark.IPageWatermarkItem[] items) {#PageWatermark-com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem...-}
+```
+public PageWatermark(PageWatermark.IPageWatermarkItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageWatermarkItem\[\]](../../com.aspose.xps.metadata/ipagewatermarkitem) | 機能固有の項目の配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarkoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarkoption/_index.md
@@ -1,0 +1,225 @@
+---
+title: "PageWatermark.PageWatermarkOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PageWatermark の機能オプションを説明します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/pagewatermark.pagewatermarkoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem](../../com.aspose.xps.metadata/ipagewatermarkitem)
+```
+public static final class PageWatermark.PageWatermarkOption extends Option implements PageWatermark.IPageWatermarkItem
+```
+
+PageWatermark の機能オプションについて説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkOption(String optionName, PageWatermark.IPageWatermarkOptionItem[] items)](#PageWatermarkOption-java.lang.String-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-) | 新しいインスタンスを作成します。 |
+| [PageWatermarkOption(PageWatermark.PageWatermarkOption option)](#PageWatermarkOption-com.aspose.xps.metadata.PageWatermark.PageWatermarkOption-) | このオプション インスタンスをクローンします。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Text](#Text) | テキストのみの透かしを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(PageWatermark.IPageWatermarkOptionItem[] items)](#add-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-) | IPageWatermarkOptionItem のインスタンス配列をオプションに追加します。 |
+| [clone()](#clone--) | このオプション インスタンスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkOption(String optionName, PageWatermark.IPageWatermarkOptionItem[] items) {#PageWatermarkOption-java.lang.String-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-}
+```
+public PageWatermarkOption(String optionName, PageWatermark.IPageWatermarkOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| optionName | java.lang.String | オプション名です。 |
+| items | [IPageWatermarkOptionItem\[\]](../../com.aspose.xps.metadata/ipagewatermarkoptionitem) | 任意の IPageWatermarkOptionItem インスタンスの配列です。 |
+
+### PageWatermarkOption(PageWatermark.PageWatermarkOption option) {#PageWatermarkOption-com.aspose.xps.metadata.PageWatermark.PageWatermarkOption-}
+```
+public PageWatermarkOption(PageWatermark.PageWatermarkOption option)
+```
+
+
+このオプション インスタンスをクローンします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| option | [PageWatermarkOption](../../com.aspose.xps.metadata/pagewatermarkoption) | クローン対象のインスタンス。 |
+
+### Text {#Text}
+```
+public static PageWatermark.PageWatermarkOption Text
+```
+
+
+テキストのみの透かしを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(PageWatermark.IPageWatermarkOptionItem[] items) {#add-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-}
+```
+public PageWatermark.PageWatermarkOption add(PageWatermark.IPageWatermarkOptionItem[] items)
+```
+
+
+IPageWatermarkOptionItem のインスタンス配列をオプションに追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPageWatermarkOptionItem\[\]](../../com.aspose.xps.metadata/ipagewatermarkoptionitem) | 任意の IPageWatermarkOptionItem インスタンスの配列です。 |
+
+**Returns:**
+[PageWatermarkOption](../../com.aspose.xps.metadata/pagewatermarkoption) - This options instance.
+### clone() {#clone--}
+```
+public PageWatermark.PageWatermarkOption clone()
+```
+
+
+このオプションインスタンスをクローンします。クローン作成コンストラクタへのショートカットです。
+
+**Returns:**
+[PageWatermarkOption](../../com.aspose.xps.metadata/pagewatermarkoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarkoriginheight/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarkoriginheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkOriginHeight"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしの起点を PageImageableSize の起点に対して相対的に指定します。"
+type: docs
+weight: 132
+url: /ja/java/com.aspose.xps.metadata/pagewatermarkoriginheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkOriginHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしの原点を PageImageableSize の原点に対して指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarkoriginheight
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkOriginHeight(int value)](#PageWatermarkOriginHeight-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkOriginHeight(int value) {#PageWatermarkOriginHeight-int-}
+```
+public PageWatermarkOriginHeight(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarkoriginwidth/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarkoriginwidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkOriginWidth"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしの起点を PageImageableSize の起点に対して相対的に指定します。"
+type: docs
+weight: 133
+url: /ja/java/com.aspose.xps.metadata/pagewatermarkoriginwidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkOriginWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしの起点を PageImageableSize の起点に対して相対的に指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarkoriginwidth
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkOriginWidth(int value)](#PageWatermarkOriginWidth-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkOriginWidth(int value) {#PageWatermarkOriginWidth-int-}
+```
+public PageWatermarkOriginWidth(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarktextangle/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarktextangle/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkTextAngle"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしテキストの角度を PageImageableSizeWidth 方向に対して指定します。"
+type: docs
+weight: 134
+url: /ja/java/com.aspose.xps.metadata/pagewatermarktextangle/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextAngle extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしテキストの角度を PageImageableSizeWidth 方向に対して指定します。角度は反時計回りで測定されます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktextangle
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkTextAngle(int value)](#PageWatermarkTextAngle-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextAngle(int value) {#PageWatermarkTextAngle-int-}
+```
+public PageWatermarkTextAngle(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarktextcolor/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarktextcolor/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageWatermarkTextColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしテキストの sRGB カラーを定義します。"
+type: docs
+weight: 135
+url: /ja/java/com.aspose.xps.metadata/pagewatermarktextcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextColor extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしテキストの sRGB カラーを定義します。形式は ARGB: \#AARRGGBB です。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktextcolor
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkTextColor(String value)](#PageWatermarkTextColor-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextColor(String value) {#PageWatermarkTextColor-java.lang.String-}
+```
+public PageWatermarkTextColor(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarktextfontsize/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarktextfontsize/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkTextFontSize"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしテキストに利用可能なフォントサイズを定義します。"
+type: docs
+weight: 136
+url: /ja/java/com.aspose.xps.metadata/pagewatermarktextfontsize/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextFontSize extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしテキストに使用できるフォントサイズを定義します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktextfontsize
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkTextFontSize(int value)](#PageWatermarkTextFontSize-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextFontSize(int value) {#PageWatermarkTextFontSize-int-}
+```
+public PageWatermarkTextFontSize(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int - 許容される最大値です。
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int - 許容される最小値です。
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarktexttext/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarktexttext/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageWatermarkTextText"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしのテキストを指定します。"
+type: docs
+weight: 137
+url: /ja/java/com.aspose.xps.metadata/pagewatermarktexttext/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextText extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしのテキストを指定します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktexttext
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkTextText(String value)](#PageWatermarkTextText-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextText(String value) {#PageWatermarkTextText-java.lang.String-}
+```
+public PageWatermarkTextText(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/pagewatermarktransparency/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/pagewatermarktransparency/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkTransparency"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "透かしの透明度を指定します。"
+type: docs
+weight: 138
+url: /ja/java/com.aspose.xps.metadata/pagewatermarktransparency/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTransparency extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+透かしの透明度を指定します。完全に不透明な場合は値 0 になります。 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktransparency
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PageWatermarkTransparency(int value)](#PageWatermarkTransparency-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 整数または小数値のパラメーターに対して、許容される最大値を定義します。 |
+| [getMinValue()](#getMinValue--) | 整数または小数値のパラメーターに対して、許容される最小値を定義します。 |
+| [getMultiple()](#getMultiple--) | 整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTransparency(int value) {#PageWatermarkTransparency-int-}
+```
+public PageWatermarkTransparency(int value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最大値を定義します。
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+整数または小数値のパラメーターに対して、許容される最小値を定義します。
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+整数または小数値のパラメーターに対して、パラメーターの値はこの数の倍数である必要があります。
+
+**Returns:**
+int - パラメーターが倍数であるべき数です。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/parameterinit/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/parameterinit/_index.md
@@ -1,0 +1,157 @@
+---
+title: "ParameterInit"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "印刷チケットパラメータ初期化子を実装するクラスです。"
+type: docs
+weight: 139
+url: /ja/java/com.aspose.xps.metadata/parameterinit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public class ParameterInit extends PrintTicketElement implements IPrintTicketItem
+```
+
+印刷チケットパラメータ初期化子を実装するクラスです。共通の PrintTicket パラメータ初期化子を実装するクラスです。すべてのスキーマ定義パラメータ初期化子の基底クラスです。ParameterDef 要素のインスタンスに対する値を定義します。ParameterInit 要素は ParameterRef 要素によって参照される対象です。 https://docs.microsoft.com/en-us/windows/win32/printdocs/parameterinit
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ParameterInit(String name, Value value)](#ParameterInit-java.lang.String-com.aspose.xps.metadata.Value-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParameterInit(String name, Value value) {#ParameterInit-java.lang.String-com.aspose.xps.metadata.Value-}
+```
+public ParameterInit(String name, Value value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | パラメータ名です。 |
+| value | [Value](../../com.aspose.xps.metadata/value) | パラメータの値です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/parameterref/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/parameterref/_index.md
@@ -1,0 +1,156 @@
+---
+title: "ParameterRef"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の PrintTicket パラメータ参照を実装するクラスです。"
+type: docs
+weight: 140
+url: /ja/java/com.aspose.xps.metadata/parameterref/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public class ParameterRef extends PrintTicketElement implements IPrintTicketItem
+```
+
+共通の PrintTicket パラメータ参照を実装するクラスです。ParameterRef 要素は ParameterInit 要素への参照を定義します。ParameterRef 要素を含む ScoredProperty 要素は、明示的に設定された Value 要素を持ちません。その代わりに、ScoredProperty 要素は ParameterRef 要素が参照する ParameterInit 要素から値を取得します。 https://docs.microsoft.com/en-us/windows/win32/printdocs/parameterref
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ParameterRef(String name)](#ParameterRef-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParameterRef(String name) {#ParameterRef-java.lang.String-}
+```
+public ParameterRef(String name)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | パラメータ名です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/preprinted/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/preprinted/_index.md
@@ -1,0 +1,169 @@
+---
+title: "PageMediaType.PrePrinted"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrePrinted のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.preprinted/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.PrePrinted extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+PrePrinted スコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Letterhead](#Letterhead) | レターヘッドの値です。 |
+| [None](#None) | None 値。 |
+| [PrePrintedValue](#PrePrintedValue) | PrePrinted の値です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Letterhead {#Letterhead}
+```
+public static PageMediaType.PrePrinted Letterhead
+```
+
+
+レターヘッドの値です。
+
+### None {#None}
+```
+public static PageMediaType.PrePrinted None
+```
+
+
+None 値。
+
+### PrePrintedValue {#PrePrintedValue}
+```
+public static PageMediaType.PrePrinted PrePrintedValue
+```
+
+
+PrePrinted の値です。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/prepunched/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/prepunched/_index.md
@@ -1,0 +1,160 @@
+---
+title: "PageMediaType.PrePunched"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrePunched のスコア付きプロパティ値の定数を定義します。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.prepunched/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.PrePunched extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+PrePunched スコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | None 値。 |
+| [PrePunchedValue](#PrePunchedValue) | PrePunched 値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static PageMediaType.PrePunched None
+```
+
+
+None 値。
+
+### PrePunchedValue {#PrePunchedValue}
+```
+public static PageMediaType.PrePunched PrePunchedValue
+```
+
+
+PrePunched 値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/presentationdirection/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/presentationdirection/_index.md
@@ -1,0 +1,170 @@
+---
+title: "NUp.PresentationDirection"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "内部の PresentationDirection 機能を説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/nup.presentationdirection/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.NUp.INUpItem](../../com.aspose.xps.metadata/inupitem)
+```
+public static final class NUp.PresentationDirection extends Feature implements NUp.INUpItem
+```
+
+内部 PresentationDirection 機能を説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PresentationDirection(NUp.PresentationDirection.PresentationDirectionOption[] options)](#PresentationDirection-com.aspose.xps.metadata.NUp.PresentationDirection.PresentationDirectionOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PresentationDirection(NUp.PresentationDirection.PresentationDirectionOption[] options) {#PresentationDirection-com.aspose.xps.metadata.NUp.PresentationDirection.PresentationDirectionOption...-}
+```
+public PresentationDirection(NUp.PresentationDirection.PresentationDirectionOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [PresentationDirectionOption\[\]](../../com.aspose.xps.metadata/presentationdirectionoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/presentationdirectionoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/presentationdirectionoption/_index.md
@@ -1,0 +1,225 @@
+---
+title: "NUp.PresentationDirection.PresentationDirectionOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PresentationDirection 機能のオプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/nup.presentationdirection.presentationdirectionoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class NUp.PresentationDirection.PresentationDirectionOption extends Option
+```
+
+PresentationDirection 機能のオプションを説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BottomLeft](#BottomLeft) | 上から下へ、右から左へを指定します。 |
+| [BottomRight](#BottomRight) | 上から下へ、左から右へを指定します。 |
+| [LeftBottom](#LeftBottom) | 右から左へ、上から下へを指定します。 |
+| [LeftTop](#LeftTop) | 右から左へ、下から上へを指定します。 |
+| [RightBottom](#RightBottom) | 左から右へ、上から下へを指定します。 |
+| [RightTop](#RightTop) | 左から右へ、下から上へを指定します。 |
+| [TopLeft](#TopLeft) | 下から上へ、右から左へを指定します。 |
+| [TopRight](#TopRight) | 下から上へ、左から右へを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BottomLeft {#BottomLeft}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption BottomLeft
+```
+
+
+上から下へ、右から左へを指定します。
+
+### BottomRight {#BottomRight}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption BottomRight
+```
+
+
+上から下へ、左から右へを指定します。
+
+### LeftBottom {#LeftBottom}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption LeftBottom
+```
+
+
+右から左へ、上から下へを指定します。
+
+### LeftTop {#LeftTop}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption LeftTop
+```
+
+
+右から左へ、下から上へを指定します。
+
+### RightBottom {#RightBottom}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption RightBottom
+```
+
+
+左から右へ、上から下へを指定します。
+
+### RightTop {#RightTop}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption RightTop
+```
+
+
+左から右へ、下から上へを指定します。
+
+### TopLeft {#TopLeft}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption TopLeft
+```
+
+
+下から上へ、右から左へを指定します。
+
+### TopRight {#TopRight}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption TopRight
+```
+
+
+下から上へ、左から右へを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/printticket/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/printticket/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PrintTicket"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意のスコープの共通 PrintTicket を実装するクラスです。"
+type: docs
+weight: 141
+url: /ja/java/com.aspose.xps.metadata/printticket/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class PrintTicket implements Iterable<String>
+```
+
+任意のスコープの共通 PrintTicket を実装するクラスです。ジョブ、ドキュメント、ページレベルの印刷チケットの基底クラスです。PrintTicket 要素は PrintTicket ドキュメントのルート要素です。PrintTicket 要素はジョブを出力するために必要なすべてのジョブ書式情報を含みます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/printticket
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PrintTicket(IPrintTicketItem[] items)](#PrintTicket-com.aspose.xps.metadata.IPrintTicketItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 印刷チケット アイテム名のイテレータを返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | この PrintTicket アイテムリストからアイテムを削除します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintTicket(IPrintTicketItem[] items) {#PrintTicket-com.aspose.xps.metadata.IPrintTicketItem...-}
+```
+public PrintTicket(IPrintTicketItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IPrintTicketItem\[\]](../../com.aspose.xps.metadata/iprintticketitem) | 任意の IPrintTicketItem インスタンスの配列です。各インスタンスは Feature、ParameterInit、または Property のいずれかでなければなりません。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+印刷チケット アイテム名のイテレータを返します。
+
+**Returns:**
+java.util.Iterator<java.lang.String> - リストのイテレータを返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+この PrintTicket アイテムリストからアイテムを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String[] | アイテム名の配列です。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/printticketelement/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/printticketelement/_index.md
@@ -1,0 +1,156 @@
+---
+title: "PrintTicketElement"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Print Schema 要素になる可能性のあるクラスの基底クラスです。"
+type: docs
+weight: 142
+url: /ja/java/com.aspose.xps.metadata/printticketelement/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public abstract class PrintTicketElement implements IPrintTicketElementChild
+```
+
+Print Schema 要素になる可能性のあるクラスの基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PrintTicketElement(String name)](#PrintTicketElement-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintTicketElement(String name) {#PrintTicketElement-java.lang.String-}
+```
+public PrintTicketElement(String name)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | 要素の名前を、いくつかの XML スキーマ（Microsoft Print Schema Framework など）に従って指定します。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/profile/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/profile/_index.md
@@ -1,0 +1,155 @@
+---
+title: "JobOptimalDestinationColorProfile.Profile"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "利用可能なカラープロファイルを記述します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile.profile/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static final class JobOptimalDestinationColorProfile.Profile
+```
+
+利用可能なカラープロファイルを記述します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [CMYK](#CMYK) | CMYK プロファイル。 |
+| [ICC](#ICC) | ICC プロファイル。 |
+| [RGB](#RGB) | RGB プロファイル。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CMYK {#CMYK}
+```
+public static final JobOptimalDestinationColorProfile.Profile CMYK
+```
+
+
+CMYK プロファイル。
+
+### ICC {#ICC}
+```
+public static final JobOptimalDestinationColorProfile.Profile ICC
+```
+
+
+ICC プロファイル。
+
+### RGB {#RGB}
+```
+public static final JobOptimalDestinationColorProfile.Profile RGB
+```
+
+
+RGB プロファイル。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/property/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/property/_index.md
@@ -1,0 +1,174 @@
+---
+title: "Property"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "印刷チケットプロパティを実装するクラスです。"
+type: docs
+weight: 143
+url: /ja/java/com.aspose.xps.metadata/property/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem), [com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem), [com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem), [com.aspose.xps.metadata.IScoredPropertyItem](../../com.aspose.xps.metadata/iscoredpropertyitem), [com.aspose.xps.metadata.IPropertyItem](../../com.aspose.xps.metadata/ipropertyitem)
+```
+public class Property extends CompositePrintTicketElement implements IPrintTicketItem, IFeatureItem, IOptionItem, IScoredPropertyItem, IPropertyItem
+```
+
+印刷チケットプロパティを実装するクラスです。共通の PrintTicket  Property を実装するクラスです。すべてのスキーマ定義プロパティの基底クラスです。  Property  要素は、デバイス、ジョブの書式設定、またはその他の関連プロパティを宣言し、その名前は name 属性で指定されます。  Value  要素は  Property  に値を割り当てるために使用されます。  Property  は複雑になることがあり、複数のサブプロパティを含む場合があります。サブプロパティも  Property  要素として表されます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/property
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Property(String name, Property property, IPropertyItem[] items)](#Property-java.lang.String-com.aspose.xps.metadata.Property-com.aspose.xps.metadata.IPropertyItem...-) | 新しいインスタンスを作成します。 |
+| [Property(String name, Value value, IPropertyItem[] items)](#Property-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IPropertyItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Property(String name, Property property, IPropertyItem[] items) {#Property-java.lang.String-com.aspose.xps.metadata.Property-com.aspose.xps.metadata.IPropertyItem...-}
+```
+public Property(String name, Property property, IPropertyItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | プロパティ名です。 |
+| property | [Property](../../com.aspose.xps.metadata/property) | 必須の  Property  インスタンスです。 |
+| items | [IPropertyItem\[\]](../../com.aspose.xps.metadata/ipropertyitem) | 任意の  IPropertyItem  インスタンスの配列です。各要素は  Property  または  Value  インスタンスである必要があります。 |
+
+### Property(String name, Value value, IPropertyItem[] items) {#Property-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IPropertyItem...-}
+```
+public Property(String name, Value value, IPropertyItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | プロパティ名です。 |
+| value | [Value](../../com.aspose.xps.metadata/value) | 必須の Value インスタンスです。 |
+| items | [IPropertyItem\[\]](../../com.aspose.xps.metadata/ipropertyitem) | 任意の  IPropertyItem  インスタンスの配列です。各要素は  Property  または  Value  インスタンスである必要があります。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/qnamevalue/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/qnamevalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "QNameValue"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ドキュメント内の QName 値をカプセル化するクラスです。"
+type: docs
+weight: 144
+url: /ja/java/com.aspose.xps.metadata/qnamevalue/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)、[com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class QNameValue extends Value
+```
+
+PrintTicket ドキュメント内の QName 値をカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [QNameValue(String value)](#QNameValue-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [getValueString()](#getValueString--) | 値を文字列として取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### QNameValue(String value) {#QNameValue-java.lang.String-}
+```
+public QNameValue(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | QName の値です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+値を文字列として取得します。
+
+**Returns:**
+java.lang.String - 値を文字列として取得します。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/qualitativeresolution/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/qualitativeresolution/_index.md
@@ -1,0 +1,187 @@
+---
+title: "PageResolution.QualitativeResolution"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "QualitativeResolution のスコア付プロパティ値の定数を定義します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/pageresolution.qualitativeresolution/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem](../../com.aspose.xps.metadata/ipageresolutionoptionitem)
+```
+public static final class PageResolution.QualitativeResolution extends ScoredProperty implements PageResolution.IPageResolutionOptionItem
+```
+
+QualitativeResolution のスコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Default](#Default) | デフォルト値。 |
+| [Draft](#Draft) | ドラフト値。 |
+| [High](#High) | 高い値。 |
+| [Normal](#Normal) | 標準値。 |
+| [Other](#Other) | その他の値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Default {#Default}
+```
+public static PageResolution.QualitativeResolution Default
+```
+
+
+デフォルト値。
+
+### Draft {#Draft}
+```
+public static PageResolution.QualitativeResolution Draft
+```
+
+
+ドラフト値。
+
+### High {#High}
+```
+public static PageResolution.QualitativeResolution High
+```
+
+
+高い値。
+
+### Normal {#Normal}
+```
+public static PageResolution.QualitativeResolution Normal
+```
+
+
+標準値。
+
+### Other {#Other}
+```
+public static PageResolution.QualitativeResolution Other
+```
+
+
+その他の値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/recycled/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/recycled/_index.md
@@ -1,0 +1,160 @@
+---
+title: "PageMediaType.Recycled"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Recycled スコア プロパティ値の定数を定義します。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.xps.metadata/pagemediatype.recycled/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.Recycled extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+Recycled スコア付きプロパティ値の定数を定義します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | None 値。 |
+| [Standard](#Standard) | 標準値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static PageMediaType.Recycled None
+```
+
+
+None 値。
+
+### Standard {#Standard}
+```
+public static PageMediaType.Recycled Standard
+```
+
+
+標準値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/rollcut/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/rollcut/_index.md
@@ -1,0 +1,149 @@
+---
+title: "RollCut"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobRollCutAtEndOfJob と DocumentRollCut 機能クラスの基底クラスです。"
+type: docs
+weight: 145
+url: /ja/java/com.aspose.xps.metadata/rollcut/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class RollCut extends Feature
+```
+
+JobRollCutAtEndOfJob と DocumentRollCut 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/rollcutoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/rollcutoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "RollCut.RollCutOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobRollCutAtEndOfJob と DocumentRollCut 機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/rollcut.rollcutoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class RollCut.RollCutOption extends Option
+```
+
+JobRollCutAtEndOfJob と DocumentRollCut の機能オプションについて説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Banner](#Banner) | バナー用のカット方法を指定します（DocumentRollCut のみ）。 |
+| [CutSheetAtImageEdge](#CutSheetAtImageEdge) | 画像の端でのカットを指定します。 |
+| [CutSheetAtStandardMediaSize](#CutSheetAtStandardMediaSize) | 標準メディアサイズ用のカットを指定します。 |
+| [None](#None) | ジョブのロールカットを行わないことを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Banner {#Banner}
+```
+public static RollCut.RollCutOption Banner
+```
+
+
+バナー用のカット方法を指定します（DocumentRollCut のみ）。
+
+### CutSheetAtImageEdge {#CutSheetAtImageEdge}
+```
+public static RollCut.RollCutOption CutSheetAtImageEdge
+```
+
+
+画像の端でのカットを指定します。
+
+### CutSheetAtStandardMediaSize {#CutSheetAtStandardMediaSize}
+```
+public static RollCut.RollCutOption CutSheetAtStandardMediaSize
+```
+
+
+標準メディアサイズ用のカットを指定します。
+
+### None {#None}
+```
+public static RollCut.RollCutOption None
+```
+
+
+ジョブのロールカットを行わないことを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/scaleoffsetalignment/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/scaleoffsetalignment/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageScaling.ScaleOffsetAlignment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "内部の ScaleOffsetAlignment 機能を説明します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.metadata/pagescaling.scaleoffsetalignment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageScaling.IPageScalingItem](../../com.aspose.xps.metadata/ipagescalingitem)
+```
+public static final class PageScaling.ScaleOffsetAlignment extends Feature implements PageScaling.IPageScalingItem
+```
+
+内部の ScaleOffsetAlignment 機能を記述します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ScaleOffsetAlignment(PageScaling.ScaleOffsetAlignmentOption[] options)](#ScaleOffsetAlignment-com.aspose.xps.metadata.PageScaling.ScaleOffsetAlignmentOption...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ScaleOffsetAlignment(PageScaling.ScaleOffsetAlignmentOption[] options) {#ScaleOffsetAlignment-com.aspose.xps.metadata.PageScaling.ScaleOffsetAlignmentOption...-}
+```
+public ScaleOffsetAlignment(PageScaling.ScaleOffsetAlignmentOption[] options)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ScaleOffsetAlignmentOption\[\]](../../com.aspose.xps.metadata/scaleoffsetalignmentoption) | 機能に固有のオプションの配列です。 |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/scaleoffsetalignmentoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/scaleoffsetalignmentoption/_index.md
@@ -1,0 +1,234 @@
+---
+title: "PageScaling.ScaleOffsetAlignmentOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ScaleOffsetAlignment 機能オプションを説明します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.metadata/pagescaling.scaleoffsetalignmentoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageScaling.ScaleOffsetAlignmentOption extends Option
+```
+
+ScaleOffsetAlignment 機能オプションを説明します。スケーリングされたコンテンツの配置を指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BottomCenter](#BottomCenter) | スケーリングをメディアの下端の中央に合わせて配置するよう指定します。 |
+| [BottomLeft](#BottomLeft) | スケーリングがメディアの左下隅に合わせられることを指定します。 |
+| [BottomRight](#BottomRight) | スケーリングがメディアの右下隅に合わせられることを指定します。 |
+| [Center](#Center) | スケーリングがメディアの中央に配置されることを指定します。 |
+| [LeftCenter](#LeftCenter) | スケーリングがメディアの左端の中央に合わせられることを指定します。 |
+| [RightCenter](#RightCenter) | スケーリングがメディアの右端の中央に合わせられることを指定します。 |
+| [TopCenter](#TopCenter) | スケーリングがメディアの上端の中央に合わせられることを指定します。 |
+| [TopLeft](#TopLeft) | スケーリングがメディアの左上隅に合わせられることを指定します。 |
+| [TopRight](#TopRight) | スケーリングがメディアの右上隅に合わせられることを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BottomCenter {#BottomCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption BottomCenter
+```
+
+
+スケーリングをメディアの下端の中央に合わせて配置するよう指定します。
+
+### BottomLeft {#BottomLeft}
+```
+public static PageScaling.ScaleOffsetAlignmentOption BottomLeft
+```
+
+
+スケーリングがメディアの左下隅に合わせられることを指定します。
+
+### BottomRight {#BottomRight}
+```
+public static PageScaling.ScaleOffsetAlignmentOption BottomRight
+```
+
+
+スケーリングがメディアの右下隅に合わせられることを指定します。
+
+### Center {#Center}
+```
+public static PageScaling.ScaleOffsetAlignmentOption Center
+```
+
+
+スケーリングがメディアの中央に配置されることを指定します。
+
+### LeftCenter {#LeftCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption LeftCenter
+```
+
+
+スケーリングがメディアの左端の中央に合わせられることを指定します。
+
+### RightCenter {#RightCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption RightCenter
+```
+
+
+スケーリングがメディアの右端の中央に合わせられることを指定します。
+
+### TopCenter {#TopCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption TopCenter
+```
+
+
+スケーリングがメディアの上端の中央に合わせられることを指定します。
+
+### TopLeft {#TopLeft}
+```
+public static PageScaling.ScaleOffsetAlignmentOption TopLeft
+```
+
+
+スケーリングがメディアの左上隅に合わせられることを指定します。
+
+### TopRight {#TopRight}
+```
+public static PageScaling.ScaleOffsetAlignmentOption TopRight
+```
+
+
+スケーリングがメディアの右上隅に合わせられることを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/scoredproperty/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/scoredproperty/_index.md
@@ -1,0 +1,173 @@
+---
+title: "ScoredProperty"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の PrintTicket ScoredProperty を実装するクラスです。"
+type: docs
+weight: 146
+url: /ja/java/com.aspose.xps.metadata/scoredproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem), [com.aspose.xps.metadata.IScoredPropertyItem](../../com.aspose.xps.metadata/iscoredpropertyitem)
+```
+public class ScoredProperty extends CompositePrintTicketElement implements IOptionItem, IScoredPropertyItem
+```
+
+共通の PrintTicket ScoredProperty を実装するクラスです。すべてのスキーマ定義されたスコアドプロパティの基底クラスです。ScoredProperty 要素は Option 定義に固有のプロパティを宣言します。このようなプロパティは、要求された Option がデバイスがサポートする Option とどれだけ一致するかを評価する際に比較すべきです。 https://docs.microsoft.com/en-us/windows/win32/printdocs/scoredproperty
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ScoredProperty(String name, ParameterRef parameterRef)](#ScoredProperty-java.lang.String-com.aspose.xps.metadata.ParameterRef-) | 新しいインスタンスを作成します。 |
+| [ScoredProperty(String name, Value value, IScoredPropertyItem[] items)](#ScoredProperty-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IScoredPropertyItem...-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ScoredProperty(String name, ParameterRef parameterRef) {#ScoredProperty-java.lang.String-com.aspose.xps.metadata.ParameterRef-}
+```
+public ScoredProperty(String name, ParameterRef parameterRef)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | プロパティ名です。 |
+| parameterRef | [ParameterRef](../../com.aspose.xps.metadata/parameterref) | ParameterRef のインスタンスです。 |
+
+### ScoredProperty(String name, Value value, IScoredPropertyItem[] items) {#ScoredProperty-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IScoredPropertyItem...-}
+```
+public ScoredProperty(String name, Value value, IScoredPropertyItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | プロパティ名です。 |
+| value | [Value](../../com.aspose.xps.metadata/value) | プロパティ値です。 |
+| items | [IScoredPropertyItem\[\]](../../com.aspose.xps.metadata/iscoredpropertyitem) | IScoredPropertyItem のインスタンスの任意の配列です。各要素は ScoredProperty、Property、または Value のインスタンスでなければなりません。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/selectiontype/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/selectiontype/_index.md
@@ -1,0 +1,157 @@
+---
+title: "SelectionType"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "SelectionType PrintTicket プロパティ用の便利クラスです。"
+type: docs
+weight: 147
+url: /ja/java/com.aspose.xps.metadata/selectiontype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public final class SelectionType extends Property
+```
+
+SelectionType PrintTicket プロパティ用の便利クラスです。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [PickMany](#PickMany) | PickMany 値。 |
+| [PickOne](#PickOne) | PickOne 値。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PickMany {#PickMany}
+```
+public static final SelectionType PickMany
+```
+
+
+PickMany 値。
+
+### PickOne {#PickOne}
+```
+public static final SelectionType PickOne
+```
+
+
+PickOne 値。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/staple/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/staple/_index.md
@@ -1,0 +1,149 @@
+---
+title: "ステープル"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobStapleAllDocuments と DocumentStaple 機能クラスの基底クラスです。"
+type: docs
+weight: 148
+url: /ja/java/com.aspose.xps.metadata/staple/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class Staple extends Feature
+```
+
+JobStapleAllDocuments と DocumentStaple 機能クラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | この機能の項目リストの末尾に項目のリストを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+この機能のアイテムリストの末尾に項目のリストを追加します。各項目は Feature、Option、または Property のインスタンスである必要があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 追加する項目のリスト。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/stapleoption/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/stapleoption/_index.md
@@ -1,0 +1,310 @@
+---
+title: "Staple.StapleOption"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobStapleAllDocuments と DocumentStaple の機能オプションを説明します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.metadata/staple.stapleoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class Staple.StapleOption extends Option
+```
+
+JobStapleAllDocuments と DocumentStaple の機能オプションについて説明します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StapleOption(String optionName, Staple.IStapleOptionItem[] items)](#StapleOption-java.lang.String-com.aspose.xps.metadata.Staple.IStapleOptionItem...-) | 新しいインスタンスを作成します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [None](#None) | 綴じなしを指定します。 |
+| [SaddleStitch](#SaddleStitch) | サドルステッチ綴じを指定します。 |
+| [StapleBottomLeft](#StapleBottomLeft) | 左下隅に1本のホチキス留めを指定します。 |
+| [StapleBottomRight](#StapleBottomRight) | 右下隅に1本のホチキス留めを指定します。 |
+| [StapleDualBottom](#StapleDualBottom) | 下端に沿って2本のホチキス留めを指定します。 |
+| [StapleDualLeft](#StapleDualLeft) | 左端に沿って2本のホチキス留めを指定します。 |
+| [StapleDualRight](#StapleDualRight) | 右端に沿って2本のホチキス留めを指定します。 |
+| [StapleDualTop](#StapleDualTop) | 上端に沿って2本のホチキス留めを指定します |
+| [StapleTopLeft](#StapleTopLeft) | 左上隅に1本のホチキス留めを指定します。 |
+| [StapleTopRight](#StapleTopRight) | 右上隅に1本のホチキス留めを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | このオプションの項目リストの末尾に項目のリストを追加します。 |
+| [add(Staple.IStapleOptionItem[] items)](#add-com.aspose.xps.metadata.Staple.IStapleOptionItem...-) | 機能に IStapleOptionItem インスタンスの配列を追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(int angle)](#setAngle-int-) | Angle のスコア付きプロパティ値を設定します。 |
+| [setSheetCapacity(int sheetCapacity)](#setSheetCapacity-int-) | SheetCapacity のスコア付きプロパティ値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StapleOption(String optionName, Staple.IStapleOptionItem[] items) {#StapleOption-java.lang.String-com.aspose.xps.metadata.Staple.IStapleOptionItem...-}
+```
+public StapleOption(String optionName, Staple.IStapleOptionItem[] items)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| optionName | java.lang.String | オプション名です。 |
+| items | [IStapleOptionItem\[\]](../../com.aspose.xps.metadata/istapleoptionitem) | 任意の IStapleOptionItem インスタンスの配列です。 |
+
+### None {#None}
+```
+public static final Staple.StapleOption None
+```
+
+
+綴じなしを指定します。
+
+### SaddleStitch {#SaddleStitch}
+```
+public static final Staple.StapleOption SaddleStitch
+```
+
+
+サドルステッチ綴じを指定します。
+
+### StapleBottomLeft {#StapleBottomLeft}
+```
+public static final Staple.StapleOption StapleBottomLeft
+```
+
+
+左下隅に1本のホチキス留めを指定します。
+
+### StapleBottomRight {#StapleBottomRight}
+```
+public static final Staple.StapleOption StapleBottomRight
+```
+
+
+右下隅に1本のホチキス留めを指定します。
+
+### StapleDualBottom {#StapleDualBottom}
+```
+public static final Staple.StapleOption StapleDualBottom
+```
+
+
+下端に沿って2本のホチキス留めを指定します。
+
+### StapleDualLeft {#StapleDualLeft}
+```
+public static final Staple.StapleOption StapleDualLeft
+```
+
+
+左端に沿って2本のホチキス留めを指定します。
+
+### StapleDualRight {#StapleDualRight}
+```
+public static final Staple.StapleOption StapleDualRight
+```
+
+
+右端に沿って2本のホチキス留めを指定します。
+
+### StapleDualTop {#StapleDualTop}
+```
+public static final Staple.StapleOption StapleDualTop
+```
+
+
+上端に沿って2本のホチキス留めを指定します
+
+### StapleTopLeft {#StapleTopLeft}
+```
+public static final Staple.StapleOption StapleTopLeft
+```
+
+
+左上隅に1本のホチキス留めを指定します。
+
+### StapleTopRight {#StapleTopRight}
+```
+public static final Staple.StapleOption StapleTopRight
+```
+
+
+右上隅に1本のホチキス留めを指定します。
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+このオプションの項目リストの末尾に項目のリストを追加します。各項目は ScoredProperty または Property のインスタンスでなければなりません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 追加する項目のリスト。 |
+
+### add(Staple.IStapleOptionItem[] items) {#add-com.aspose.xps.metadata.Staple.IStapleOptionItem...-}
+```
+public Staple.StapleOption add(Staple.IStapleOptionItem[] items)
+```
+
+
+機能に IStapleOptionItem インスタンスの配列を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| items | [IStapleOptionItem\[\]](../../com.aspose.xps.metadata/istapleoptionitem) | 任意の IStapleOptionItem インスタンスの配列です。 |
+
+**Returns:**
+[StapleOption](../../com.aspose.xps.metadata/stapleoption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(int angle) {#setAngle-int-}
+```
+public final Staple.StapleOption setAngle(int angle)
+```
+
+
+Angle のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angle | int | Angle のスコア付きプロパティ値です。 |
+
+**Returns:**
+[StapleOption](../../com.aspose.xps.metadata/stapleoption) - This option instance.
+### setSheetCapacity(int sheetCapacity) {#setSheetCapacity-int-}
+```
+public final Staple.StapleOption setSheetCapacity(int sheetCapacity)
+```
+
+
+SheetCapacity のスコア付きプロパティ値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| sheetCapacity | int | SheetCapacity のスコア付きプロパティ値です。 |
+
+**Returns:**
+[StapleOption](../../com.aspose.xps.metadata/stapleoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/stringparameterinit/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/stringparameterinit/_index.md
@@ -1,0 +1,176 @@
+---
+title: "StringParameterInit"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "すべての文字列パラメータ初期化子の基底クラスです。"
+type: docs
+weight: 149
+url: /ja/java/com.aspose.xps.metadata/stringparameterinit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit)
+```
+public abstract class StringParameterInit extends ParameterInit
+```
+
+すべての文字列パラメータ初期化子の基底クラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StringParameterInit(String name, String value)](#StringParameterInit-java.lang.String-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 最短および最長の文字列を定義します。 |
+| [getMinLength()](#getMinLength--) | 文字列値に対して、許容される最短の文字列を定義します。 |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringParameterInit(String name, String value) {#StringParameterInit-java.lang.String-java.lang.String-}
+```
+public StringParameterInit(String name, String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String | パラメータ名。 |
+| value | java.lang.String | パラメータ値。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+最短および最長の文字列を定義します。
+
+**Returns:**
+int - 許容される最長文字列。
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+文字列値に対して、許容される最短の文字列を定義します。
+
+**Returns:**
+int - 許容される最短文字列。
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/stringvalue/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/stringvalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "StringValue"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ドキュメント内の文字列値をカプセル化するクラスです。"
+type: docs
+weight: 150
+url: /ja/java/com.aspose.xps.metadata/stringvalue/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)、[com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class StringValue extends Value
+```
+
+PrintTicket ドキュメント内の文字列値をカプセル化するクラスです。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [StringValue(String value)](#StringValue-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [getValueString()](#getValueString--) | 値を文字列として取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringValue(String value) {#StringValue-java.lang.String-}
+```
+public StringValue(String value)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | 文字列値です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+値を文字列として取得します。
+
+**Returns:**
+java.lang.String - 値を文字列として取得します。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/uriproperty/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/uriproperty/_index.md
@@ -1,0 +1,135 @@
+---
+title: "URIProperty"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "JobURI と DocumentURI プロパティクラスの基底クラスです。"
+type: docs
+weight: 151
+url: /ja/java/com.aspose.xps.metadata/uriproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public class URIProperty extends Property
+```
+
+JobURI と DocumentURI プロパティクラスの基底クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.metadata/value/_index.md
+++ b/japanese/java/com.aspose.xps.metadata/value/_index.md
@@ -1,0 +1,149 @@
+---
+title: "値"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PrintTicket ドキュメント内の Property または ScoredProperty の値をカプセル化する基底クラスです。"
+type: docs
+weight: 152
+url: /ja/java/com.aspose.xps.metadata/value/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IScoredPropertyItem](../../com.aspose.xps.metadata/iscoredpropertyitem), [com.aspose.xps.metadata.IPropertyItem](../../com.aspose.xps.metadata/ipropertyitem)
+```
+public class Value extends PrintTicketElement implements IScoredPropertyItem, IPropertyItem
+```
+
+PrintTicket ドキュメント内の Property または ScoredProperty の値をカプセル化する基底クラスです。Value 要素はリテラルと型を関連付けます。 https://docs.microsoft.com/en-us/windows/win32/printdocs/value
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 要素名を取得します。 |
+| [getValueString()](#getValueString--) | 値を文字列として取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+要素名を取得します。
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+値を文字列として取得します。
+
+**Returns:**
+java.lang.String - 値を文字列として取得します。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.plugins/_index.md
+++ b/japanese/java/com.aspose.xps.plugins/_index.md
@@ -1,0 +1,20 @@
+---
+title: "com.aspose.xps.plugins"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.xps.plugins には XPS プラグインのクラスが含まれています。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.xps.plugins/
+---
+
+この **com.aspose.xps.plugins** には XPS プラグインのクラスが含まれています。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [XpsConverter](../com.aspose.xps.plugins/xpsconverter) | XpsConverter プラグインを表します。 |
+| [XpsConverterOptions](../com.aspose.xps.plugins/xpsconverteroptions) | [XpsConverter](../com.aspose.xps.plugins/xpsconverter) プラグインのオプションの基底クラスを表します。 |
+| [XpsConverterToImageOptions](../com.aspose.xps.plugins/xpsconvertertoimageoptions) | [XpsConverter](../com.aspose.xps.plugins/xpsconverter) プラグインの XPS から画像へのコンバータオプションを表します。 |
+| [XpsConverterToPdfOptions](../com.aspose.xps.plugins/xpsconvertertopdfoptions) | [XpsConverter](../com.aspose.xps.plugins/xpsconverter) プラグインの XPS から PDF へのコンバータオプションを表します。 |

--- a/japanese/java/com.aspose.xps.plugins/xpsconverter/_index.md
+++ b/japanese/java/com.aspose.xps.plugins/xpsconverter/_index.md
@@ -1,0 +1,175 @@
+---
+title: "XpsConverter"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XpsConverter プラグインを表します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.plugins/xpsconverter/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPlugin](../../com.aspose.page.plugins/iplugin)
+```
+public class XpsConverter implements IPlugin
+```
+
+XpsConverter プラグインを表します。
+
+この例は、XPS ドキュメントを PDF ドキュメントに変換する方法を示しています。
+
+// XpsConverter を作成 XpsConverter converter = new XpsConverter(); // XpsConverterToPdfOptions オブジェクトを作成し、出力データタイプをファイルに設定 XpsConverterToPdfOptions opt = new XpsConverterToPdfOptions(); // 入力ファイルパスを追加 opt.addDataSource(new FileDataSource(inputPath)); // 出力ファイルパスを設定 opt.addSaveDataSource(new FileDataSource(outputPath)); // 変換プロセスを開始 ResultContainer results = converter.process(opt);
+
+この例は、XPS ドキュメントをファイル出力の画像に変換する方法を示しています。
+
+// XpsConverter を作成 XpsConverter converter = new XpsConverter(); // JPEG ターゲット画像形式で XpsConverterToImageOptions を作成します。結果画像のデフォルト形式は PNG です。 // また、結果画像のサイズ、解像度、スムージングモード、JPEG 形式の画像品質レベルを設定できます。 XpsConverterToImageOptions opt = new XpsConverterToImageOptions(ImageFormat.Jpeg); // 入力ファイルパスを追加 opt.addDataSource(new FileDataSource(inputPath)); // 入力 XPS ファイルが複数ページの場合、結果は次の名前形式の画像ファイルのセットになります: [\"outputPath\" の拡張子なし][ページ番号は 0 から開始].[\"outputPath\" の拡張子] opt.addSaveDataSource(new FileDataSource(outputPath)); // 変換プロセスを開始 converter.process(opt);
+
+この例は、XPS ドキュメントをバイト配列出力の画像に変換する方法を示しています。
+
+バイト配列出力データソース (byte[][]) では、1 つのバイト配列が 1 ページの画像を含みます。そのため、1 ページ文書の場合、結果は [1][] 配列となり、複数ページ文書の場合、結果は [入力 XPS ドキュメントのページ数][] 配列となります。 // XpsConverter を作成 XpsConverter converter = new XpsConverter(); // JPEG ターゲット画像形式で XpsConverterToImageOptions を作成します。結果画像のデフォルト形式は PNG です。 // また、結果画像のサイズ、解像度、スムージングモード、JPEG 形式の画像品質レベルを設定できます。 XpsConverterToImageOptions opt = new XpsConverterToImageOptions(ImageFormat.Jpeg); // 入力ファイルパスを追加 opt.addDataSource(new FileDataSource(inputPath)); // 入力 XPS ファイルが複数ページの場合、結果は次の名前形式の画像ファイルのセットになります: [\"outputPath\" の拡張子なし][ページ番号は 1 から開始].[\"outputPath\" の拡張子] opt.addSaveDataSource(new ByteArrayDataSource()); // 変換プロセスを開始 converter.process(opt); // 結果のバイト配列を取得 byte[][] imagesBytes = (byte [][]) ((ByteArrayResult)results.ResultCollection[0]).Data;
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsConverter()](#XpsConverter--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [dispose()](#dispose--) | IDisposable の実装。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [process(IPluginOptions options)](#process-com.aspose.page.plugins.IPluginOptions-) | 指定されたパラメータで XpsConverter の処理を開始します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsConverter() {#XpsConverter--}
+```
+public XpsConverter()
+```
+
+
+### dispose() {#dispose--}
+```
+public final void dispose()
+```
+
+
+IDisposable の実装。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### process(IPluginOptions options) {#process-com.aspose.page.plugins.IPluginOptions-}
+```
+public final ResultContainer process(IPluginOptions options)
+```
+
+
+指定されたパラメータで XpsConverter の処理を開始します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [IPluginOptions](../../com.aspose.page.plugins/ipluginoptions) | XpsConverter の指示を含むオプション オブジェクトです。 |
+
+**Returns:**
+[ResultContainer](../../com.aspose.page.plugins/resultcontainer) - An ResultContainer object containing the result of the operation.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.plugins/xpsconverteroptions/_index.md
+++ b/japanese/java/com.aspose.xps.plugins/xpsconverteroptions/_index.md
@@ -1,0 +1,213 @@
+---
+title: "XpsConverterOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグインのオプションの基底クラスを表します。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.plugins/xpsconverteroptions/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPluginOptions](../../com.aspose.page.plugins/ipluginoptions), [com.aspose.page.plugins.IDataContainer](../../com.aspose.page.plugins/idatacontainer), [com.aspose.page.plugins.ISaveInstruction](../../com.aspose.page.plugins/isaveinstruction)
+```
+public class XpsConverterOptions implements IPluginOptions, IDataContainer, ISaveInstruction
+```
+
+プラグイン [XpsConverter](../../com.aspose.xps.plugins/xpsconverter) のオプションの基底クラスを表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | XpsConverter プラグインのデータコレクションに新しいデータ ソースを追加します。 |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | XpsConverterOptions プラグインのデータコレクションに新しいデータ ソースを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | XpsConverterOptions プラグインのデータコレクションを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOperationName()](#getOperationName--) | 操作名を返します。 |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 保存操作結果のために追加されたターゲットのコレクションを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+XpsConverter プラグインのデータコレクションに新しいデータ ソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 追加するデータ ソース。 |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+XpsConverterOptions プラグインのデータコレクションに新しいデータ ソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 保存操作結果のためのデータ ソース（ファイルまたはストリーム）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+XpsConverterOptions プラグインのデータコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOperationName() {#getOperationName--}
+```
+public String getOperationName()
+```
+
+
+操作名を返します。
+
+**Returns:**
+java.lang.String
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+保存操作結果のために追加されたターゲットのコレクションを取得します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.plugins/xpsconvertertoimageoptions/_index.md
+++ b/japanese/java/com.aspose.xps.plugins/xpsconvertertoimageoptions/_index.md
@@ -1,0 +1,391 @@
+---
+title: "XpsConverterToImageOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグイン用の XPS から Image へのコンバータ オプションを表します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.plugins/xpsconvertertoimageoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.plugins.XpsConverterOptions](../../com.aspose.xps.plugins/xpsconverteroptions)
+```
+public class XpsConverterToImageOptions extends XpsConverterOptions
+```
+
+プラグイン [XpsConverter](../../com.aspose.xps.plugins/xpsconverter) 用の XPS から Image へのコンバータ オプションを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsConverterToImageOptions()](#XpsConverterToImageOptions--) | 新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+| [XpsConverterToImageOptions(ImageFormat imageFormat)](#XpsConverterToImageOptions-com.aspose.page.ImageFormat-) | 画像形式を指定して新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+| [XpsConverterToImageOptions(Dimension size)](#XpsConverterToImageOptions-java.awt.Dimension-) | 結果画像のサイズを指定して新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+| [XpsConverterToImageOptions(ImageFormat imageFormat, Dimension size)](#XpsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-) | 画像形式を指定して新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | XpsConverter プラグインのデータコレクションに新しいデータ ソースを追加します。 |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | XpsConverterOptions プラグインのデータコレクションに新しいデータ ソースを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | XpsConverterOptions プラグインのデータコレクションを返します。 |
+| [getImageFormat()](#getImageFormat--) | 画像形式を取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOperationName()](#getOperationName--) | 操作名を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | 変換する XPS ドキュメントのページ番号の配列を取得します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 保存操作結果のために追加されたターゲットのコレクションを取得します。 |
+| [getSize()](#getSize--) | 結果画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | 画像のレンダリングに使用するスムージングモードを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setImageFormat(ImageFormat imageFormat)](#setImageFormat-com.aspose.page.ImageFormat-) | 画像形式を取得します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] pageNumbers)](#setPageNumbers-int---) | 変換する XPS ドキュメントのページ数の配列を設定します。 |
+| [setResolution(int resolution)](#setResolution-int-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 結果画像のサイズを設定します。 |
+| [setSmoothingMode(SmoothingMode smoothingMode)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 画像のレンダリングに使用するスムージングモードを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsConverterToImageOptions() {#XpsConverterToImageOptions--}
+```
+public XpsConverterToImageOptions()
+```
+
+
+新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+### XpsConverterToImageOptions(ImageFormat imageFormat) {#XpsConverterToImageOptions-com.aspose.page.ImageFormat-}
+```
+public XpsConverterToImageOptions(ImageFormat imageFormat)
+```
+
+
+画像形式を指定して新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 結果画像のフォーマット。 |
+
+### XpsConverterToImageOptions(Dimension size) {#XpsConverterToImageOptions-java.awt.Dimension-}
+```
+public XpsConverterToImageOptions(Dimension size)
+```
+
+
+結果画像のサイズを指定して新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 結果画像のサイズ。 |
+
+### XpsConverterToImageOptions(ImageFormat imageFormat, Dimension size) {#XpsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-}
+```
+public XpsConverterToImageOptions(ImageFormat imageFormat, Dimension size)
+```
+
+
+画像形式を指定して新しい [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) オブジェクトのインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 結果画像のフォーマット。 |
+| size | java.awt.Dimension |  |
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+XpsConverter プラグインのデータコレクションに新しいデータ ソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 追加するデータ ソース。 |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+XpsConverterOptions プラグインのデータコレクションに新しいデータ ソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 保存操作結果のためのデータ ソース（ファイルまたはストリーム）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+XpsConverterOptions プラグインのデータコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getImageFormat() {#getImageFormat--}
+```
+public ImageFormat getImageFormat()
+```
+
+
+画像形式を取得します。
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat) - An image format.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+操作名を返します。
+
+**Returns:**
+java.lang.String
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+変換する XPS ドキュメントのページ番号の配列を取得します。
+
+**Returns:**
+int[] - XPS ドキュメントのページ数の配列。
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+int - 画像の解像度。
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+保存操作結果のために追加されたターゲットのコレクションを取得します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+結果画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - 画像のサイズ。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+画像のレンダリングに使用するスムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - A smoothing mode.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setImageFormat(ImageFormat imageFormat) {#setImageFormat-com.aspose.page.ImageFormat-}
+```
+public void setImageFormat(ImageFormat imageFormat)
+```
+
+
+画像形式を取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 結果画像のフォーマット。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] pageNumbers) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] pageNumbers)
+```
+
+
+変換する XPS ドキュメントのページ数の配列を設定します。設定しない場合、すべてのページが変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pageNumbers | int[] | XPS ドキュメントのページ数の配列。 |
+
+### setResolution(int resolution) {#setResolution-int-}
+```
+public void setResolution(int resolution)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 解像度 | int | 結果画像の解像度。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+結果画像のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | 結果画像のサイズ。 |
+
+### setSmoothingMode(SmoothingMode smoothingMode) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode smoothingMode)
+```
+
+
+画像のレンダリングに使用するスムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| smoothingMode | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 平滑化モード。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.plugins/xpsconvertertopdfoptions/_index.md
+++ b/japanese/java/com.aspose.xps.plugins/xpsconvertertopdfoptions/_index.md
@@ -1,0 +1,248 @@
+---
+title: "XpsConverterToPdfOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "プラグインの XPS から PDF へのコンバータオプションを表します。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.plugins/xpsconvertertopdfoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.plugins.XpsConverterOptions](../../com.aspose.xps.plugins/xpsconverteroptions)
+```
+public class XpsConverterToPdfOptions extends XpsConverterOptions
+```
+
+プラグイン [XpsConverter](../../com.aspose.xps.plugins/xpsconverter) の XPS から PDF へのコンバータオプションを表します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsConverterToPdfOptions()](#XpsConverterToPdfOptions--) | 新しい [XpsConverterToPdfOptions](../../com.aspose.xps.plugins/xpsconvertertopdfoptions) オブジェクトのインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | XpsConverter プラグインのデータコレクションに新しいデータ ソースを追加します。 |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | XpsConverterOptions プラグインのデータコレクションに新しいデータ ソースを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | XpsConverterOptions プラグインのデータコレクションを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOperationName()](#getOperationName--) | 操作名を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | 変換する XPS ドキュメントのページ番号の配列を取得します。 |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 保存操作結果のために追加されたターゲットのコレクションを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] pageNumbers)](#setPageNumbers-int---) | 変換する XPS ドキュメントのページ数の配列を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsConverterToPdfOptions() {#XpsConverterToPdfOptions--}
+```
+public XpsConverterToPdfOptions()
+```
+
+
+新しい [XpsConverterToPdfOptions](../../com.aspose.xps.plugins/xpsconvertertopdfoptions) オブジェクトのインスタンスを初期化します。
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+XpsConverter プラグインのデータコレクションに新しいデータ ソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 追加するデータ ソース。 |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+XpsConverterOptions プラグインのデータコレクションに新しいデータ ソースを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 保存操作結果のためのデータ ソース（ファイルまたはストリーム）。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+XpsConverterOptions プラグインのデータコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+操作名を返します。
+
+**Returns:**
+java.lang.String
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+変換する XPS ドキュメントのページ番号の配列を取得します。
+
+**Returns:**
+int[] - XPS ドキュメントのページ数の配列。
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+保存操作結果のために追加されたターゲットのコレクションを取得します。
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] pageNumbers) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] pageNumbers)
+```
+
+
+変換する XPS ドキュメントのページ数の配列を設定します。設定しない場合、すべてのページが変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pageNumbers | int[] | XPS ドキュメントのページ数の配列。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/_index.md
@@ -1,0 +1,42 @@
+---
+title: "com.aspose.xps.rendering"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.xps.rendering パッケージは、XPS ドキュメントを他の形式にレンダリングするための基底クラスを提供します。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.xps.rendering/
+---
+
+**com.aspose.xps.rendering** パッケージは、XPS ドキュメントを他の形式にレンダリングするための基本クラスを提供します。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [BmpSaveOptions](../com.aspose.xps.rendering/bmpsaveoptions) | XPS を BMP として保存するオプションのクラス。 |
+| [ImageSaveOptions](../com.aspose.xps.rendering/imagesaveoptions) | XPS を画像として保存するオプションの基本クラス。 |
+| [JpegSaveOptions](../com.aspose.xps.rendering/jpegsaveoptions) | XPS を JPEG として保存するオプションのクラス。 |
+| [PdfEncryptionDetails](../com.aspose.xps.rendering/pdfencryptiondetails) | PDF 暗号化の詳細が含まれています。 |
+| [PdfSaveOptions](../com.aspose.xps.rendering/pdfsaveoptions) | XPS を PDF として保存するオプションのクラス。 |
+| [PngSaveOptions](../com.aspose.xps.rendering/pngsaveoptions) | XPS を PNG として保存するオプションのクラス。 |
+| [TiffSaveOptions](../com.aspose.xps.rendering/tiffsaveoptions) | XPS を TIFF として保存するオプションのクラス。 |
+
+## インターフェイス
+
+| インターフェイス | 説明 |
+| --- | --- |
+| [IEventBasedModificationOptions](../com.aspose.xps.rendering/ieventbasedmodificationoptions) | ドキュメント保存中のイベントベースの変更処理に関連するオプションを定義します。 |
+| [IPipelineOptions](../com.aspose.xps.rendering/ipipelineoptions) | パイプライン構成に関連する変換オプションを定義します。 |
+| [IXpsTextConversionOptions](../com.aspose.xps.rendering/ixpstextconversionoptions) | XPS を他の形式に変換するためのオプションを定義します。 |
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| --- | --- |
+| [InterpolationMode](../com.aspose.xps.rendering/interpolationmode) | 画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。 |
+| [PdfEncryptionAlgorithm](../com.aspose.xps.rendering/pdfencryptionalgorithm) | 暗号化モード列挙型。 |
+| [PdfImageCompression](../com.aspose.xps.rendering/pdfimagecompression) | PDF ファイル内の画像に適用される圧縮タイプを指定します。 |
+| [PdfTextCompression](../com.aspose.xps.rendering/pdftextcompression) | 画像を除く PDF ファイル内のすべてのコンテンツに適用される圧縮タイプを指定します。 |
+| [SmoothingMode](../com.aspose.xps.rendering/smoothingmode) | 線や曲線、塗りつぶし領域のエッジにスムージング（アンチエイリアス）が適用されるかどうかを指定します。 |
+| [TextRenderingHint](../com.aspose.xps.rendering/textrenderinghint) | テキスト描画の品質を指定します。 |

--- a/japanese/java/com.aspose.xps.rendering/bmpsaveoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/bmpsaveoptions/_index.md
@@ -1,0 +1,484 @@
+---
+title: "BmpSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を BMP として保存するオプションのクラス。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps.rendering/bmpsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class BmpSaveOptions extends ImageSaveOptions
+```
+
+XPS を BMP として保存するオプションのクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [BmpSaveOptions()](#BmpSaveOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBatchSize()](#getBatchSize--) | ノードからノードへ渡すページの一部のサイズを返します。 |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageSize()](#getImageSize--) | 出力画像のサイズ（ピクセル単位）を取得します。 |
+| [getInterpolationMode()](#getInterpolationMode--) | 補間モードを取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | レンダリングするページ数の配列を取得します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | スムージングモードを取得します。 |
+| [getTextRenderingHint()](#getTextRenderingHint--) | テキストレンダリングヒントを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBatchSize(int value)](#setBatchSize-int-) | ノードからノードへ渡すページの一部のサイズを設定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 出力画像のサイズ（ピクセル単位）を設定します。 |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 補間モードを設定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | レンダリングするページ数の配列を設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | スムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | テキストレンダリングヒントを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BmpSaveOptions() {#BmpSaveOptions--}
+```
+public BmpSaveOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+ノードからノードへ渡すページの一部のサイズを返します。
+
+**Returns:**
+int - ノードからノードへ渡すページの一部のサイズ。
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+出力画像のサイズ（ピクセル単位）を取得します。
+
+**Returns:**
+java.awt.Dimension - 出力画像のサイズ（ピクセル単位）。
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+補間モードを取得します。
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+レンダリングするページ数の配列を取得します。
+
+**Returns:**
+int[] - ページ数。
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+float - 画像解像度。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+スムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+テキストレンダリングヒントを取得します。
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+ノードからノードへ渡すページの一部のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | ノード間で渡すページの一部のサイズです。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+出力画像のサイズ（ピクセル単位）を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.Dimension | 出力画像のサイズ（ピクセル単位）です。 |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+補間モードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 補間モードです。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+レンダリングするページ数の配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int[] | ページ数です。 |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 画像の解像度です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+スムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | スムージングモードです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+テキストレンダリングヒントを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | テキスト描画ヒントです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/ieventbasedmodificationoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/ieventbasedmodificationoptions/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IEventBasedModificationOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメント保存中のイベントベースの変更処理に関連するオプションを定義します。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.xps.rendering/ieventbasedmodificationoptions/
+---```
+public interface IEventBasedModificationOptions
+```
+
+Defines options relevant to handling event-based modifications during document saving.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | Returns the collection of event handlers that performs modifications to an XPS page just before it is saved. |
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public abstract List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+Returns the collection of event handlers that performs modifications to an XPS page just before it is saved.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler> - The collection of event handlers that performs modifications to an XPS page just before it is saved.

--- a/japanese/java/com.aspose.xps.rendering/imagesaveoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/imagesaveoptions/_index.md
@@ -1,0 +1,487 @@
+---
+title: "ImageSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を画像として保存するオプションの基本クラス。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps.rendering/imagesaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+
+**All Implemented Interfaces:**
+[com.aspose.page.IMultiPageSaveOptions](../../com.aspose.page/imultipagesaveoptions), [com.aspose.xps.rendering.IPipelineOptions](../../com.aspose.xps.rendering/ipipelineoptions), [com.aspose.xps.rendering.IEventBasedModificationOptions](../../com.aspose.xps.rendering/ieventbasedmodificationoptions)
+```
+public abstract class ImageSaveOptions extends SaveOptions implements IMultiPageSaveOptions, IPipelineOptions, IEventBasedModificationOptions
+```
+
+XPS を画像として保存するオプションの基本クラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [ImageSaveOptions()](#ImageSaveOptions--) | オプションの新しいインスタンスを作成します |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBatchSize()](#getBatchSize--) | ノードからノードへ渡すページの一部のサイズを返します。 |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageSize()](#getImageSize--) | 出力画像のサイズ（ピクセル単位）を取得します。 |
+| [getInterpolationMode()](#getInterpolationMode--) | 補間モードを取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | レンダリングするページ数の配列を取得します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | スムージングモードを取得します。 |
+| [getTextRenderingHint()](#getTextRenderingHint--) | テキストレンダリングヒントを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBatchSize(int value)](#setBatchSize-int-) | ノードからノードへ渡すページの一部のサイズを設定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 出力画像のサイズ（ピクセル単位）を設定します。 |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 補間モードを設定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | レンダリングするページ数の配列を設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | スムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | テキストレンダリングヒントを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions() {#ImageSaveOptions--}
+```
+public ImageSaveOptions()
+```
+
+
+オプションの新しいインスタンスを作成します
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+ノードからノードへ渡すページの一部のサイズを返します。
+
+**Returns:**
+int - ノードからノードへ渡すページの一部のサイズ。
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+出力画像のサイズ（ピクセル単位）を取得します。
+
+**Returns:**
+java.awt.Dimension - 出力画像のサイズ（ピクセル単位）。
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+補間モードを取得します。
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+レンダリングするページ数の配列を取得します。
+
+**Returns:**
+int[] - ページ数。
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+float - 画像解像度。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+スムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+テキストレンダリングヒントを取得します。
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+ノードからノードへ渡すページの一部のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | ノード間で渡すページの一部のサイズです。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+出力画像のサイズ（ピクセル単位）を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.Dimension | 出力画像のサイズ（ピクセル単位）です。 |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+補間モードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 補間モードです。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+レンダリングするページ数の配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int[] | ページ数です。 |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 画像の解像度です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+スムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | スムージングモードです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+テキストレンダリングヒントを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | テキスト描画ヒントです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/interpolationmode/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/interpolationmode/_index.md
@@ -1,0 +1,304 @@
+---
+title: "InterpolationMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.xps.rendering/interpolationmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum InterpolationMode extends Enum<InterpolationMode>
+```
+
+画像が拡大縮小または回転される際に使用されるアルゴリズムを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Bicubic](#Bicubic) | バイキュービック補間を指定します。 |
+| [Bilinear](#Bilinear) | 双一次補間を指定します。 |
+| [Default](#Default) | デフォルトモードを指定します。 |
+| [High](#High) | 高品質補間を指定します。 |
+| [HighQualityBicubic](#HighQualityBicubic) | 高品質のバイキュービック補間を指定します。 |
+| [HighQualityBilinear](#HighQualityBilinear) | 高品質の双一次補間を指定します。 |
+| [Low](#Low) | 低品質補間を指定します。 |
+| [NearestNeighbor](#NearestNeighbor) | 最近傍補間を指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bicubic {#Bicubic}
+```
+public static final InterpolationMode Bicubic
+```
+
+
+バイキュービック補間を指定します。事前フィルタリングは行われません。このモードは画像を元のサイズの25％未満に縮小する場合には適していません。
+
+### Bilinear {#Bilinear}
+```
+public static final InterpolationMode Bilinear
+```
+
+
+双一次補間を指定します。事前フィルタリングは行われません。このモードは画像を元のサイズの50％未満に縮小する場合には適していません。
+
+### Default {#Default}
+```
+public static final InterpolationMode Default
+```
+
+
+デフォルトモードを指定します。
+
+### High {#High}
+```
+public static final InterpolationMode High
+```
+
+
+高品質補間を指定します。
+
+### HighQualityBicubic {#HighQualityBicubic}
+```
+public static final InterpolationMode HighQualityBicubic
+```
+
+
+高品質のバイキュービック補間を指定します。高品質な縮小を実現するために事前フィルタリングが行われます。このモードは最高品質の変換画像を生成します。
+
+### HighQualityBilinear {#HighQualityBilinear}
+```
+public static final InterpolationMode HighQualityBilinear
+```
+
+
+高品質の双一次補間を指定します。高品質な縮小を実現するために事前フィルタリングが行われます。
+
+### Low {#Low}
+```
+public static final InterpolationMode Low
+```
+
+
+低品質補間を指定します。
+
+### NearestNeighbor {#NearestNeighbor}
+```
+public static final InterpolationMode NearestNeighbor
+```
+
+
+最近傍補間を指定します。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static InterpolationMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode)
+### values() {#values--}
+```
+public static InterpolationMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.InterpolationMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/ipipelineoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/ipipelineoptions/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IPipelineOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "パイプライン構成に関連する変換オプションを定義します。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.xps.rendering/ipipelineoptions/
+---```
+public interface IPipelineOptions
+```
+
+Defines conversion options related to pipeline configuration.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getBatchSize()](#getBatchSize--) | Returns the size of a portion of pages to pass from node to node. |
+| [setBatchSize(int value)](#setBatchSize-int-) | Sets the size of a portion of pages to pass from node to node. |
+### getBatchSize() {#getBatchSize--}
+```
+public abstract int getBatchSize()
+```
+
+
+Returns the size of a portion of pages to pass from node to node.
+
+**Returns:**
+int - The size of a portion of pages to pass from node to node.
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public abstract void setBatchSize(int value)
+```
+
+
+Sets the size of a portion of pages to pass from node to node.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | int | The size of a portion of pages to pass from node to node. |
+

--- a/japanese/java/com.aspose.xps.rendering/ixpstextconversionoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/ixpstextconversionoptions/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IXpsTextConversionOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を他の形式に変換するためのオプションを定義します。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.xps.rendering/ixpstextconversionoptions/
+---```
+public interface IXpsTextConversionOptions
+```
+
+Defines options for conversion of XPS to other formats.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [preserveText()](#preserveText--) | In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. |
+| [preserveText(boolean value)](#preserveText-boolean-) | In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. |
+### preserveText() {#preserveText--}
+```
+public abstract boolean preserveText()
+```
+
+
+In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. If this flag is set to true, the text from such XPS elements is converted to graphic shapes. Then the text itself appears transparent on top. This leaves the text of such elements selectable. But the side effect is that the output file may be much larger than the original. If this flag is set to false, the characters that should be displayed as alternate forms are replaced with some other characters that become mapped to the alternate glyph forms. Therefore the text, although still selectable, will be modified and likely become unreadable.
+
+**Returns:**
+boolean - The flag value.
+### preserveText(boolean value) {#preserveText-boolean-}
+```
+public abstract void preserveText(boolean value)
+```
+
+
+In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. If this flag is set to true, the text from such XPS elements is converted to graphic shapes. Then the text itself appears transparent on top. This leaves the text of such elements selectable. But the side effect is that the output file may be much larger than the original. If this flag is set to false, the characters that should be displayed as alternate forms are replaced with some other characters that become mapped to the alternate glyph forms. Therefore the text, although still selectable, will be modified and likely become unreadable.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | boolean | The flag value. |
+

--- a/japanese/java/com.aspose.xps.rendering/jpegsaveoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/jpegsaveoptions/_index.md
@@ -1,0 +1,484 @@
+---
+title: "JpegSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を JPEG として保存するオプションのクラス。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps.rendering/jpegsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class JpegSaveOptions extends ImageSaveOptions
+```
+
+XPS を JPEG として保存するオプションのクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [JpegSaveOptions()](#JpegSaveOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBatchSize()](#getBatchSize--) | ノードからノードへ渡すページの一部のサイズを返します。 |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageSize()](#getImageSize--) | 出力画像のサイズ（ピクセル単位）を取得します。 |
+| [getInterpolationMode()](#getInterpolationMode--) | 補間モードを取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | レンダリングするページ数の配列を取得します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | スムージングモードを取得します。 |
+| [getTextRenderingHint()](#getTextRenderingHint--) | テキストレンダリングヒントを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBatchSize(int value)](#setBatchSize-int-) | ノードからノードへ渡すページの一部のサイズを設定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 出力画像のサイズ（ピクセル単位）を設定します。 |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 補間モードを設定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | レンダリングするページ数の配列を設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | スムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | テキストレンダリングヒントを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JpegSaveOptions() {#JpegSaveOptions--}
+```
+public JpegSaveOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+ノードからノードへ渡すページの一部のサイズを返します。
+
+**Returns:**
+int - ノードからノードへ渡すページの一部のサイズ。
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+出力画像のサイズ（ピクセル単位）を取得します。
+
+**Returns:**
+java.awt.Dimension - 出力画像のサイズ（ピクセル単位）。
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+補間モードを取得します。
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+レンダリングするページ数の配列を取得します。
+
+**Returns:**
+int[] - ページ数。
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+float - 画像解像度。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+スムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+テキストレンダリングヒントを取得します。
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+ノードからノードへ渡すページの一部のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | ノード間で渡すページの一部のサイズです。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+出力画像のサイズ（ピクセル単位）を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.Dimension | 出力画像のサイズ（ピクセル単位）です。 |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+補間モードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 補間モードです。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+レンダリングするページ数の配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int[] | ページ数です。 |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 画像の解像度です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+スムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | スムージングモードです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+テキストレンダリングヒントを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | テキスト描画ヒントです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/pdfencryptionalgorithm/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,250 @@
+---
+title: "PdfEncryptionAlgorithm"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "暗号化モード列挙型。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.xps.rendering/pdfencryptionalgorithm/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PdfEncryptionAlgorithm extends Enum<PdfEncryptionAlgorithm>
+```
+
+暗号化モード列挙。アルゴリズムとキー長を説明します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [RC4_128](#RC4-128) | アルゴリズム、RC4暗号化キー長が128ビットで高度な権限セットを使用; |
+| [RC4_40](#RC4-40) | アルゴリズム、RC4暗号化キー長が40ビット; |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC4_128 {#RC4-128}
+```
+public static final PdfEncryptionAlgorithm RC4_128
+```
+
+
+アルゴリズム、RC4暗号化キー長が128ビットで高度な権限セットを使用;
+
+### RC4_40 {#RC4-40}
+```
+public static final PdfEncryptionAlgorithm RC4_40
+```
+
+
+アルゴリズム、RC4暗号化キー長が40ビット;
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PdfEncryptionAlgorithm valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm)
+### values() {#values--}
+```
+public static PdfEncryptionAlgorithm[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.PdfEncryptionAlgorithm[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/pdfencryptiondetails/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/pdfencryptiondetails/_index.md
@@ -1,0 +1,253 @@
+---
+title: "PdfEncryptionDetails"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PDF 暗号化の詳細が含まれています。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps.rendering/pdfencryptiondetails/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+PDF 暗号化の詳細が含まれています。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int permissions, PdfEncryptionAlgorithm encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-com.aspose.xps.rendering.PdfEncryptionAlgorithm-) | PdfEncryptionDetailsCore クラスの新しいインスタンスを初期化します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | 暗号化モードを返します。 |
+| [getOwnerPassword()](#getOwnerPassword--) | 所有者パスワードを返します。 |
+| [getPermissions()](#getPermissions--) | アクセス許可を返します。 |
+| [getUserPassword()](#getUserPassword--) | ユーザー パスワードを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(PdfEncryptionAlgorithm value)](#setEncryptionAlgorithm-com.aspose.xps.rendering.PdfEncryptionAlgorithm-) | 暗号化モードを設定します。 |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | 所有者パスワードを設定します。 |
+| [setPermissions(int value)](#setPermissions-int-) | アクセス許可を設定します。 |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | ユーザー パスワードを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int permissions, PdfEncryptionAlgorithm encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-com.aspose.xps.rendering.PdfEncryptionAlgorithm-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int permissions, PdfEncryptionAlgorithm encryptionAlgorithm)
+```
+
+
+PdfEncryptionDetailsCore クラスの新しいインスタンスを初期化します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| userPassword | java.lang.String | ユーザー パスワードです。 |
+| ownerPassword | java.lang.String | 所有者パスワードです。 |
+| permissions | int | アクセス許可です。 |
+| encryptionAlgorithm | [PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm) | 暗号化アルゴリズムです。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public PdfEncryptionAlgorithm getEncryptionAlgorithm()
+```
+
+
+暗号化モードを返します。
+
+**Returns:**
+[PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm) - The encryption algorithm.
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+所有者パスワードを返します。
+
+正しい所有者パスワードでドキュメントを開くと（ユーザーパスワードと同じでないと仮定して）、ドキュメントへの完全な（所有者）アクセスが可能になります。この無制限のアクセスには、ドキュメント\\u2019s のパスワードとアクセス許可を変更する機能が含まれます。
+
+**Returns:**
+java.lang.String - 所有者パスワード。
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+アクセス許可を返します。
+
+**Returns:**
+int - 権限。
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+ユーザー パスワードを返します。
+
+正しいユーザーパスワードでドキュメントを開く（またはユーザーパスワードが設定されていないドキュメントを開く）ことで、ドキュメントの暗号化辞書に指定されたユーザーアクセス権限に従って追加の操作を実行できるようになります。
+
+**Returns:**
+java.lang.String - ユーザーパスワード。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(PdfEncryptionAlgorithm value) {#setEncryptionAlgorithm-com.aspose.xps.rendering.PdfEncryptionAlgorithm-}
+```
+public void setEncryptionAlgorithm(PdfEncryptionAlgorithm value)
+```
+
+
+暗号化モードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm) | 暗号化アルゴリズムです。 |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+所有者パスワードを設定します。
+
+正しい所有者パスワードでドキュメントを開くと（ユーザーパスワードと同じでないと仮定して）、ドキュメントへの完全な（所有者）アクセスが可能になります。この無制限のアクセスには、ドキュメント\\u2019s のパスワードとアクセス許可を変更する機能が含まれます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | 所有者パスワードです。 |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+アクセス許可を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | アクセス許可です。 |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+ユーザー パスワードを設定します。
+
+正しいユーザーパスワードでドキュメントを開く（またはユーザーパスワードが設定されていないドキュメントを開く）ことで、ドキュメントの暗号化辞書に指定されたユーザーアクセス権限に従って追加の操作を実行できるようになります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | ユーザー パスワードです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/pdfimagecompression/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/pdfimagecompression/_index.md
@@ -1,0 +1,295 @@
+---
+title: "PdfImageCompression"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PDF ファイル内の画像に適用される圧縮タイプを指定します。"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.xps.rendering/pdfimagecompression/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PdfImageCompression extends Enum<PdfImageCompression>
+```
+
+PDF ファイル内の画像に適用される圧縮タイプを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Auto](#Auto) | 各画像に最適な圧縮を自動的に選択します。 |
+| [Flate](#Flate) | Flate 圧縮。 |
+| [Jpeg](#Jpeg) | JPEG 圧縮。 |
+| [LzwBaselinePredictor](#LzwBaselinePredictor) | 予測子の選択は PNG Paeth 予測子に制限され、処理が高速化されます。 |
+| [LzwOptimizedPredictor](#LzwOptimizedPredictor) | 予測子の選択はより複雑で、画像サイズは小さくなる可能性がありますが、時間がかかります。 |
+| [None](#None) | 生の画像バイトを保存するため、PDF ファイルサイズが大きくなります。 |
+| [Rle](#Rle) | Run Length 圧縮。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Auto {#Auto}
+```
+public static final PdfImageCompression Auto
+```
+
+
+各画像に最適な圧縮を自動的に選択します。
+
+### Flate {#Flate}
+```
+public static final PdfImageCompression Flate
+```
+
+
+Flate 圧縮。
+
+### Jpeg {#Jpeg}
+```
+public static final PdfImageCompression Jpeg
+```
+
+
+JPEG 圧縮。透過はサポートされません。
+
+### LzwBaselinePredictor {#LzwBaselinePredictor}
+```
+public static final PdfImageCompression LzwBaselinePredictor
+```
+
+
+予測子の選択は PNG Paeth 予測子に制限され、処理が高速化されます。実際には驚くほど良好に動作し、LzwOptimizedPredictor よりも優れています。
+
+### LzwOptimizedPredictor {#LzwOptimizedPredictor}
+```
+public static final PdfImageCompression LzwOptimizedPredictor
+```
+
+
+予測子の選択はより複雑で、画像サイズは小さくなる可能性がありますが、時間がかかります。
+
+### None {#None}
+```
+public static final PdfImageCompression None
+```
+
+
+生の画像バイトを保存するため、PDF ファイルサイズが大きくなります。
+
+### Rle {#Rle}
+```
+public static final PdfImageCompression Rle
+```
+
+
+Run Length 圧縮。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PdfImageCompression valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[PdfImageCompression](../../com.aspose.xps.rendering/pdfimagecompression)
+### values() {#values--}
+```
+public static PdfImageCompression[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.PdfImageCompression[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/pdfsaveoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/pdfsaveoptions/_index.md
@@ -1,0 +1,512 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を PDF として保存するオプションのクラス。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps.rendering/pdfsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+
+**All Implemented Interfaces:**
+[com.aspose.page.IMultiPageSaveOptions](../../com.aspose.page/imultipagesaveoptions), [com.aspose.xps.rendering.IXpsTextConversionOptions](../../com.aspose.xps.rendering/ixpstextconversionoptions), [com.aspose.xps.rendering.IPipelineOptions](../../com.aspose.xps.rendering/ipipelineoptions), [com.aspose.xps.rendering.IEventBasedModificationOptions](../../com.aspose.xps.rendering/ieventbasedmodificationoptions)
+```
+public class PdfSaveOptions extends SaveOptions implements IMultiPageSaveOptions, IXpsTextConversionOptions, IPipelineOptions, IEventBasedModificationOptions
+```
+
+XPS を PDF として保存するオプションのクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBatchSize()](#getBatchSize--) | ノードからノードへ渡すページの一部のサイズを返します。 |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getEncryptionDetails()](#getEncryptionDetails--) | 暗号化の詳細を返します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageCompression()](#getImageCompression--) | ドキュメント内のすべての画像に使用される圧縮タイプを返します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getOutlineTreeExpansionLevel()](#getOutlineTreeExpansionLevel--) | PDF ファイルがビューアで開かれたときに、ドキュメントアウトラインを展開するレベルを取得します。1 - 最初のレベルのアウトライン項目のみが表示され、2 - 最初と二番目のレベルのアウトライン項目が表示され、以下同様です。 |
+| [getOutlineTreeHeight()](#getOutlineTreeHeight--) | 保存するドキュメントアウトラインツリーの高さを取得します。0 - アウトラインツリーは変換されず、1 - 最初のレベルのアウトライン項目のみが変換され、以下同様です。 |
+| [getPageNumbers()](#getPageNumbers--) | レンダリングするページ数の配列を取得します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getTextCompression()](#getTextCompression--) | 画像以外のすべてのコンテンツストリームに使用される圧縮タイプを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [preserveText()](#preserveText--) | XPS では、いくつかのテキスト要素がフォント内の文字コードに対応しない代替グリフ形への参照を含む場合があります。 |
+| [preserveText(boolean value)](#preserveText-boolean-) | XPS では、いくつかのテキスト要素がフォント内の文字コードに対応しない代替グリフ形への参照を含む場合があります。 |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBatchSize(int value)](#setBatchSize-int-) | ノードからノードへ渡すページの一部のサイズを設定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.xps.rendering.PdfEncryptionDetails-) | 暗号化の詳細を設定します。 |
+| [setImageCompression(PdfImageCompression value)](#setImageCompression-com.aspose.xps.rendering.PdfImageCompression-) | ドキュメント内のすべての画像に使用される圧縮タイプを設定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setOutlineTreeExpansionLevel(int value)](#setOutlineTreeExpansionLevel-int-) | PDF ファイルがビューアで開かれたときに、ドキュメントアウトラインを展開するレベルを設定します。1 - 最初のレベルのアウトライン項目のみが表示され、2 - 最初と二番目のレベルのアウトライン項目が表示され、以下同様です。 |
+| [setOutlineTreeHeight(int value)](#setOutlineTreeHeight-int-) | 保存するドキュメントアウトラインツリーの高さを設定します。0 - アウトラインツリーは変換されず、1 - 最初のレベルのアウトライン項目のみが変換され、以下同様です。 |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | レンダリングするページ数の配列を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTextCompression(PdfTextCompression value)](#setTextCompression-com.aspose.xps.rendering.PdfTextCompression-) | 画像以外のすべてのコンテンツストリームに使用される圧縮タイプを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+ノードからノードへ渡すページの一部のサイズを返します。
+
+**Returns:**
+int - ノードからノードへ渡すページの一部のサイズ。
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler> - 保存直前に XPS ページに変更を加えるイベントハンドラのコレクションです。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+暗号化の詳細を返します。設定されていない場合、暗号化は行われません。
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.xps.rendering/pdfencryptiondetails) - The encryption details.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageCompression() {#getImageCompression--}
+```
+public PdfImageCompression getImageCompression()
+```
+
+
+ドキュメント内のすべての画像に使用される圧縮タイプを返します。デフォルトは PdfImageCompression.Auto です。
+
+**Returns:**
+[PdfImageCompression](../../com.aspose.xps.rendering/pdfimagecompression) - The compression type.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getOutlineTreeExpansionLevel() {#getOutlineTreeExpansionLevel--}
+```
+public int getOutlineTreeExpansionLevel()
+```
+
+
+PDF ファイルがビューアで開かれたときに、ドキュメントアウトラインを展開するレベルを取得します。1 - 最初のレベルのアウトライン項目のみが表示され、2 - 最初と二番目のレベルのアウトライン項目が表示され、以下同様です。
+
+**Returns:**
+int - アウトラインツリーの展開レベル。
+### getOutlineTreeHeight() {#getOutlineTreeHeight--}
+```
+public int getOutlineTreeHeight()
+```
+
+
+保存するドキュメントのアウトラインツリーの高さを取得します。0 - アウトラインツリーは変換されません、1 - 最初のレベルのアウトライン項目のみが変換され、以下同様です。デフォルトは 10 です。
+
+**Returns:**
+int - アウトラインツリーの高さ。
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+レンダリングするページ数の配列を取得します。
+
+**Returns:**
+int[] - ページ数。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getTextCompression() {#getTextCompression--}
+```
+public PdfTextCompression getTextCompression()
+```
+
+
+画像以外のすべてのコンテンツストリームに使用される圧縮タイプを返します。デフォルトは PdfTextCompression.Flate です。
+
+**Returns:**
+[PdfTextCompression](../../com.aspose.xps.rendering/pdftextcompression) - The compression type.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### preserveText() {#preserveText--}
+```
+public boolean preserveText()
+```
+
+
+XPS では、一部のテキスト要素がフォントの文字コードに対応しない代替グリフ形への参照を含むことがあります。このフラグが true に設定されている場合、該当する XPS 要素のテキストはグラフィックシェイプに変換され、テキスト自体は上に透明に表示されます。これにより、その要素のテキストは選択可能なまま残りますが、出力ファイルが元のファイルよりはるかに大きくなるという副作用があります。このフラグが false に設定されている場合、代替形として表示すべき文字は別の文字に置き換えられ、代替グリフ形にマッピングされます。したがって、テキストは依然として選択可能ですが、変更されて読めなくなる可能性があります。
+
+**Returns:**
+boolean - フラグの値。
+### preserveText(boolean value) {#preserveText-boolean-}
+```
+public void preserveText(boolean value)
+```
+
+
+XPS では、一部のテキスト要素がフォントの文字コードに対応しない代替グリフ形への参照を含むことがあります。このフラグが true に設定されている場合、該当する XPS 要素のテキストはグラフィックシェイプに変換され、テキスト自体は上に透明に表示されます。これにより、その要素のテキストは選択可能なまま残りますが、出力ファイルが元のファイルよりはるかに大きくなるという副作用があります。このフラグが false に設定されている場合、代替形として表示すべき文字は別の文字に置き換えられ、代替グリフ形にマッピングされます。したがって、テキストは依然として選択可能ですが、変更されて読めなくなる可能性があります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+ノードからノードへ渡すページの一部のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | ノード間で渡すページの一部のサイズです。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.xps.rendering.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+暗号化の詳細を設定します。設定されていない場合、暗号化は実行されません。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.xps.rendering/pdfencryptiondetails) | 暗号化の詳細。 |
+
+### setImageCompression(PdfImageCompression value) {#setImageCompression-com.aspose.xps.rendering.PdfImageCompression-}
+```
+public void setImageCompression(PdfImageCompression value)
+```
+
+
+ドキュメント内のすべての画像に使用される圧縮タイプを設定します。デフォルトは PdfImageCompression.Auto です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [PdfImageCompression](../../com.aspose.xps.rendering/pdfimagecompression) | 圧縮タイプ。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setOutlineTreeExpansionLevel(int value) {#setOutlineTreeExpansionLevel-int-}
+```
+public void setOutlineTreeExpansionLevel(int value)
+```
+
+
+PDF ファイルがビューアで開かれたときに、ドキュメントアウトラインを展開するレベルを設定します。1 - 最初のレベルのアウトライン項目のみが表示され、2 - 最初と二番目のレベルのアウトライン項目が表示され、以下同様です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | アウトラインツリーの展開レベル。 |
+
+### setOutlineTreeHeight(int value) {#setOutlineTreeHeight-int-}
+```
+public void setOutlineTreeHeight(int value)
+```
+
+
+保存するドキュメントアウトラインツリーの高さを設定します。0 - アウトラインツリーは変換されず、1 - 最初のレベルのアウトライン項目のみが変換され、以下同様です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | アウトラインツリーの高さ。 |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+レンダリングするページ数の配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int[] | ページ数です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTextCompression(PdfTextCompression value) {#setTextCompression-com.aspose.xps.rendering.PdfTextCompression-}
+```
+public void setTextCompression(PdfTextCompression value)
+```
+
+
+画像以外のすべてのコンテンツストリームに使用される圧縮タイプを設定します。デフォルトは PdfTextCompression.Flate です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [PdfTextCompression](../../com.aspose.xps.rendering/pdftextcompression) | 圧縮タイプ。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/pdftextcompression/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/pdftextcompression/_index.md
@@ -1,0 +1,268 @@
+---
+title: "PdfTextCompression"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "画像を除く PDF ファイル内のすべてのコンテンツに適用される圧縮タイプを指定します。"
+type: docs
+weight: 23
+url: /ja/java/com.aspose.xps.rendering/pdftextcompression/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PdfTextCompression extends Enum<PdfTextCompression>
+```
+
+画像を除く PDF ファイル内のすべてのコンテンツに適用される圧縮タイプを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Flate](#Flate) | Flate 圧縮タイプ |
+| [Lzw](#Lzw) | Lzw 圧縮タイプ |
+| [None](#None) | 圧縮タイプなし |
+| [Rle](#Rle) | Rle 圧縮タイプ |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Flate {#Flate}
+```
+public static final PdfTextCompression Flate
+```
+
+
+Flate 圧縮タイプ
+
+### Lzw {#Lzw}
+```
+public static final PdfTextCompression Lzw
+```
+
+
+Lzw 圧縮タイプ
+
+### None {#None}
+```
+public static final PdfTextCompression None
+```
+
+
+圧縮タイプなし
+
+### Rle {#Rle}
+```
+public static final PdfTextCompression Rle
+```
+
+
+Rle 圧縮タイプ
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PdfTextCompression valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[PdfTextCompression](../../com.aspose.xps.rendering/pdftextcompression)
+### values() {#values--}
+```
+public static PdfTextCompression[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.PdfTextCompression[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/pngsaveoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/pngsaveoptions/_index.md
@@ -1,0 +1,484 @@
+---
+title: "PngSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を PNG として保存するオプションのクラス。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.xps.rendering/pngsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class PngSaveOptions extends ImageSaveOptions
+```
+
+XPS を PNG として保存するオプションのクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [PngSaveOptions()](#PngSaveOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBatchSize()](#getBatchSize--) | ノードからノードへ渡すページの一部のサイズを返します。 |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageSize()](#getImageSize--) | 出力画像のサイズ（ピクセル単位）を取得します。 |
+| [getInterpolationMode()](#getInterpolationMode--) | 補間モードを取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | レンダリングするページ数の配列を取得します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | スムージングモードを取得します。 |
+| [getTextRenderingHint()](#getTextRenderingHint--) | テキストレンダリングヒントを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBatchSize(int value)](#setBatchSize-int-) | ノードからノードへ渡すページの一部のサイズを設定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 出力画像のサイズ（ピクセル単位）を設定します。 |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 補間モードを設定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | レンダリングするページ数の配列を設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | スムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | テキストレンダリングヒントを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PngSaveOptions() {#PngSaveOptions--}
+```
+public PngSaveOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+ノードからノードへ渡すページの一部のサイズを返します。
+
+**Returns:**
+int - ノードからノードへ渡すページの一部のサイズ。
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+出力画像のサイズ（ピクセル単位）を取得します。
+
+**Returns:**
+java.awt.Dimension - 出力画像のサイズ（ピクセル単位）。
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+補間モードを取得します。
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+レンダリングするページ数の配列を取得します。
+
+**Returns:**
+int[] - ページ数。
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+float - 画像解像度。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+スムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+テキストレンダリングヒントを取得します。
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+ノードからノードへ渡すページの一部のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | ノード間で渡すページの一部のサイズです。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+出力画像のサイズ（ピクセル単位）を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.Dimension | 出力画像のサイズ（ピクセル単位）です。 |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+補間モードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 補間モードです。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+レンダリングするページ数の配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int[] | ページ数です。 |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 画像の解像度です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+スムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | スムージングモードです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+テキストレンダリングヒントを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | テキスト描画ヒントです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/smoothingmode/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/smoothingmode/_index.md
@@ -1,0 +1,277 @@
+---
+title: "SmoothingMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "線や曲線、塗りつぶし領域のエッジにスムージングアンチエイリアスが適用されるかどうかを指定します。"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.xps.rendering/smoothingmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum SmoothingMode extends Enum<SmoothingMode>
+```
+
+線や曲線、塗りつぶし領域のエッジにスムージング（アンチエイリアス）が適用されるかどうかを指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AntiAlias](#AntiAlias) | アンチエイリアスレンダリングを指定します。 |
+| [Default](#Default) | アンチエイリアスなしを指定します。 |
+| [HighQuality](#HighQuality) | アンチエイリアスレンダリングを指定します。 |
+| [HighSpeed](#HighSpeed) | アンチエイリアスなしを指定します。 |
+| [None](#None) | アンチエイリアスなしを指定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AntiAlias {#AntiAlias}
+```
+public static final SmoothingMode AntiAlias
+```
+
+
+アンチエイリアスレンダリングを指定します。
+
+### Default {#Default}
+```
+public static final SmoothingMode Default
+```
+
+
+アンチエイリアスなしを指定します。
+
+### HighQuality {#HighQuality}
+```
+public static final SmoothingMode HighQuality
+```
+
+
+アンチエイリアスレンダリングを指定します。
+
+### HighSpeed {#HighSpeed}
+```
+public static final SmoothingMode HighSpeed
+```
+
+
+アンチエイリアスなしを指定します。
+
+### None {#None}
+```
+public static final SmoothingMode None
+```
+
+
+アンチエイリアスなしを指定します。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static SmoothingMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode)
+### values() {#values--}
+```
+public static SmoothingMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.SmoothingMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/textrenderinghint/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/textrenderinghint/_index.md
@@ -1,0 +1,286 @@
+---
+title: "TextRenderingHint"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "テキスト描画の品質を指定します。"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.xps.rendering/textrenderinghint/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TextRenderingHint extends Enum<TextRenderingHint>
+```
+
+テキスト描画の品質を指定します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [AntiAlias](#AntiAlias) | 各文字はヒントなしでアンチエイリアスされたグリフビットマップを使用して描画されます。 |
+| [AntiAliasGridFit](#AntiAliasGridFit) | 各文字はヒントありでアンチエイリアスされたグリフビットマップを使用して描画されます。 |
+| [ClearTypeGridFit](#ClearTypeGridFit) | 各文字はヒントありでグリフのClearTypeビットマップを使用して描画されます。 |
+| [SingleBitPerPixel](#SingleBitPerPixel) | 各文字はグリフビットマップを使用して描画されます。 |
+| [SingleBitPerPixelGridFit](#SingleBitPerPixelGridFit) | 各文字はグリフビットマップを使用して描画されます。 |
+| [SystemDefault](#SystemDefault) | 各文字はシステム既定のレンダリングヒントで、グリフビットマップを使用して描画されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AntiAlias {#AntiAlias}
+```
+public static final TextRenderingHint AntiAlias
+```
+
+
+各文字はヒントなしでアンチエイリアスされたグリフビットマップを使用して描画されます。アンチエイリアスにより品質が向上します。ヒントがオフになっているため、ステム幅の違いが目立つことがあります。
+
+### AntiAliasGridFit {#AntiAliasGridFit}
+```
+public static final TextRenderingHint AntiAliasGridFit
+```
+
+
+各文字はヒントありでアンチエイリアスされたグリフビットマップを使用して描画されます。アンチエイリアスにより品質が大幅に向上しますが、パフォーマンスコストが高くなります。
+
+### ClearTypeGridFit {#ClearTypeGridFit}
+```
+public static final TextRenderingHint ClearTypeGridFit
+```
+
+
+各文字はヒントありでグリフのClearTypeビットマップを使用して描画されます。最高品質の設定です。ClearTypeフォント機能を活用するために使用されます。
+
+### SingleBitPerPixel {#SingleBitPerPixel}
+```
+public static final TextRenderingHint SingleBitPerPixel
+```
+
+
+各文字はグリフビットマップを使用して描画されます。ヒントは使用されません。
+
+### SingleBitPerPixelGridFit {#SingleBitPerPixelGridFit}
+```
+public static final TextRenderingHint SingleBitPerPixelGridFit
+```
+
+
+各文字はグリフビットマップを使用して描画されます。ヒントはステムや曲線上の文字外観を改善するために使用されます。
+
+### SystemDefault {#SystemDefault}
+```
+public static final TextRenderingHint SystemDefault
+```
+
+
+各文字はシステム既定のレンダリングヒントで、グリフビットマップを使用して描画されます。テキストは、ユーザーがシステムで選択したフォントスムージング設定に従って描画されます。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TextRenderingHint valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint)
+### values() {#values--}
+```
+public static TextRenderingHint[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.TextRenderingHint[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps.rendering/tiffsaveoptions/_index.md
+++ b/japanese/java/com.aspose.xps.rendering/tiffsaveoptions/_index.md
@@ -1,0 +1,509 @@
+---
+title: "TiffSaveOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS を TIFF として保存するオプションのクラス。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.xps.rendering/tiffsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class TiffSaveOptions extends ImageSaveOptions
+```
+
+XPS を TIFF として保存するオプションのクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [TiffSaveOptions()](#TiffSaveOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。 |
+| [getBatchSize()](#getBatchSize--) | ノードからノードへ渡すページの一部のサイズを返します。 |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。 |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。 |
+| [getExceptions()](#getExceptions--) | 致命的でないエラーのリストを返します。 |
+| [getImageSize()](#getImageSize--) | 出力画像のサイズ（ピクセル単位）を取得します。 |
+| [getInterpolationMode()](#getInterpolationMode--) | 補間モードを取得します。 |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 画像の圧縮レベルを指定する値を返します。 |
+| [getPageNumbers()](#getPageNumbers--) | レンダリングするページ数の配列を取得します。 |
+| [getResolution()](#getResolution--) | 画像の解像度を取得します。 |
+| [getSize()](#getSize--) | ページまたは画像のサイズを取得します。 |
+| [getSmoothingMode()](#getSmoothingMode--) | スムージングモードを取得します。 |
+| [getTextRenderingHint()](#getTextRenderingHint--) | テキストレンダリングヒントを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 変換中の警告やメッセージの出力を許可するフラグを取得します。 |
+| [isSupressErrors()](#isSupressErrors--) | 変換中にエラーが抑制されるかどうかを示す値を返します。 |
+| [multipage()](#multipage--) | 複数の画像を単一のマルチページ TIFF ファイルに保存するかどうかを定義するフラグを取得します。 |
+| [multipage(boolean value)](#multipage-boolean-) | 複数の画像を単一のマルチページ TIFF ファイルに保存するかどうかを定義するフラグを設定します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。 |
+| [setBatchSize(int value)](#setBatchSize-int-) | ノードからノードへ渡すページの一部のサイズを設定します。 |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 非 TrueType フォントを TTF に保存するかどうかを指定します。 |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 変換中の警告やメッセージの出力を許可するフラグを指定します。 |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 出力画像のサイズ（ピクセル単位）を設定します。 |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 補間モードを設定します。 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 画像の圧縮レベルを指定する値を設定します。 |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | レンダリングするページ数の配列を設定します。 |
+| [setResolution(float value)](#setResolution-float-) | 画像の解像度を設定します。 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | ページまたは画像のサイズを指定します。 |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | スムージングモードを設定します。 |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 変換中にエラーが抑制されるかどうかを示すフラグを指定します。 |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | テキストレンダリングヒントを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TiffSaveOptions() {#TiffSaveOptions--}
+```
+public TiffSaveOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを返します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Returns:**
+java.lang.String[] - フォントフォルダーの配列。
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+ノードからノードへ渡すページの一部のサイズを返します。
+
+**Returns:**
+int - ノードからノードへ渡すページの一部のサイズ。
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+保存直前に XPS ページに対して変更を行うイベントハンドラのコレクションを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+非 TrueType フォントを TTF に保存する必要があるかを示すフラグを取得します。
+
+**Returns:**
+boolean - フラグの値。
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+致命的でないエラーのリストを返します。
+
+**Returns:**
+java.util.List<java.lang.Exception> - 例外リスト
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+出力画像のサイズ（ピクセル単位）を取得します。
+
+**Returns:**
+java.awt.Dimension - 出力画像のサイズ（ピクセル単位）。
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+補間モードを取得します。
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+画像の圧縮レベルを指定する値を返します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Returns:**
+int - 画像の圧縮レベルを指定する値。
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+レンダリングするページ数の配列を取得します。
+
+**Returns:**
+int[] - ページ数。
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+画像の解像度を取得します。
+
+**Returns:**
+float - 画像解像度。
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+ページまたは画像のサイズを取得します。
+
+**Returns:**
+java.awt.Dimension - ページまたは画像のサイズです。
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+スムージングモードを取得します。
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+テキストレンダリングヒントを取得します。
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを取得します。
+
+**Returns:**
+boolean - デバッグ値。
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+変換中にエラーが抑制されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - 真偽値
+### multipage() {#multipage--}
+```
+public boolean multipage()
+```
+
+
+複数の画像を単一のマルチページ TIFF ファイルに保存するかどうかを定義するフラグを取得します。
+
+**Returns:**
+boolean - 複数の画像を単一のマルチページ TIFF ファイルに保存するかどうかを定義するフラグです。
+### multipage(boolean value) {#multipage-boolean-}
+```
+public void multipage(boolean value)
+```
+
+
+複数の画像を単一のマルチページ TIFF ファイルに保存するかどうかを定義するフラグを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | 複数の画像を単一のマルチページ TIFF ファイルに保存するかどうかを定義するフラグです。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+コンバータが入力ドキュメントのフォントを検索すべき追加のフォントフォルダーを指定します。デフォルトのフォルダーは、OS が内部で使用するフォントを検索する標準フォントフォルダーです。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | フォントフォルダーの配列です。 |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+ノードからノードへ渡すページの一部のサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | ノード間で渡すページの一部のサイズです。 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+非TrueTypeフォントをTTFに保存するかどうかを指定します。これにより、PSからPDFへの変換時の生成ドキュメントの容量が大幅に減少し、非TrueTypeフォントで大量のテキストを含むPSファイルを任意の出力形式に変換する速度が向上します。ただし、PostScriptファイルを画像に変換する際にテキストがわずかに垂直方向にずれることがあります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | フラグの値です。 |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+変換中の警告やメッセージの出力を許可するフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| debug | boolean | ブール値です。 |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+出力画像のサイズ（ピクセル単位）を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.Dimension | 出力画像のサイズ（ピクセル単位）です。 |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+補間モードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 補間モードです。 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+画像の圧縮レベルを指定する値を設定します。利用可能な値は 0 から 100 です。指定した数値が小さいほど圧縮率が高くなり、画像の品質は低くなります。0 の場合は最低品質の画像になり、100 の場合は最高品質になります。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | 画像の圧縮レベルを指定する値。 |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+レンダリングするページ数の配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int[] | ページ数です。 |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+画像の解像度を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 画像の解像度です。 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+ページまたは画像のサイズを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| size | java.awt.Dimension | ページまたは画像のサイズです。 |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+スムージングモードを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | スムージングモードです。 |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+変換中にエラーが抑制されるかどうかを示すフラグを指定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| supressErrors | boolean | ブール値です。 |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+テキストレンダリングヒントを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | テキスト描画ヒントです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/_index.md
+++ b/japanese/java/com.aspose.xps/_index.md
@@ -1,0 +1,79 @@
+---
+title: "com.aspose.xps"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "com.aspose.xps は、XPS ドキュメントを扱うすべてのクラスのルートパッケージです。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.xps/
+---
+
+**com.aspose.xps** は、XPS ドキュメントを扱うすべてのクラスのルートパッケージです。
+
+
+## クラス
+
+| クラス | 説明 |
+| --- | --- |
+| [DocumentUtils](../com.aspose.xps/documentutils) | このクラスは、正式な XPS 操作 API を超えるユーティリティを提供します。 |
+| [LoadOptions](../com.aspose.xps/loadoptions) | ドキュメント読み込みオプションの基本クラスです。 |
+| [Size2D](../com.aspose.xps/size2d) | `Size2D` クラスは、次元 (幅 x 高さ) を記述します。 |
+| [Size2D.Float](../com.aspose.xps/size2d.float) | `Float` クラスは、浮動小数点座標で指定された次元を定義します。 |
+| [XpsArcSegment](../com.aspose.xps/xpsarcsegment) | ArcSegment 要素の機能をカプセル化するクラス。 |
+| [XpsArray<T>](../com.aspose.xps/xpsarray) | 共通の XPS モデル配列オブジェクトの機能をカプセル化するクラス。 |
+| [XpsBrush](../com.aspose.xps/xpsbrush) | すべてのブラシ要素の共通機能をカプセル化するクラス。 |
+| [XpsCanvas](../com.aspose.xps/xpscanvas) | Canvas 要素の機能をカプセル化するクラス。 |
+| [XpsColor](../com.aspose.xps/xpscolor) | 共通のカラー機能をカプセル化する基底クラス。 |
+| [XpsContentElement](../com.aspose.xps/xpscontentelement) | XPS コンテンツ要素（Canvas、Path、Glyphs）の機能をカプセル化します。 |
+| [XpsDocument](../com.aspose.xps/xpsdocument) | 任意の XPS 要素に対する操作メソッドを提供する XPS ドキュメントの主要エンティティをカプセル化するクラス。 |
+| [XpsElement](../com.aspose.xps/xpselement) | 共通の XPS 要素機能をカプセル化するクラス。 |
+| [XpsElementLinkTarget](../com.aspose.xps/xpselementlinktarget) | 相対的な名前付きアドレスハイパーリンクターゲットをカプセル化するクラス。 |
+| [XpsExternalLinkTarget](../com.aspose.xps/xpsexternallinktarget) | 外部ハイパーリンクターゲットをカプセル化するクラス。 |
+| [XpsFileResource](../com.aspose.xps/xpsfileresource) | すべてのファイルリソースの共通機能をカプセル化するクラス。 |
+| [XpsFont](../com.aspose.xps/xpsfont) | TrueType フォントリソースをカプセル化するクラス。 |
+| [XpsGlyphs](../com.aspose.xps/xpsglyphs) | Glyphs 要素の機能をカプセル化するクラス。 |
+| [XpsGradientBrush](../com.aspose.xps/xpsgradientbrush) | LinerGradientBrush と RadialGradientBrush 要素の共通機能をカプセル化するクラス。 |
+| [XpsGradientStop](../com.aspose.xps/xpsgradientstop) | GradientStop 要素の機能をカプセル化するクラス。 |
+| [XpsHyperlinkElement](../com.aspose.xps/xpshyperlinkelement) | ハイパーリンクになり得る XPS 要素の共通機能をカプセル化します。 |
+| [XpsHyperlinkTarget](../com.aspose.xps/xpshyperlinktarget) | ハイパーリンクターゲットの基底クラス。 |
+| [XpsIccBasedColor](../com.aspose.xps/xpsiccbasedcolor) | ICC ベースのカラーをカプセル化します。 |
+| [XpsIccProfile](../com.aspose.xps/xpsiccprofile) | ICC プロファイルリソースをカプセル化するクラス。 |
+| [XpsImage](../com.aspose.xps/xpsimage) | 画像リソースをカプセル化するクラス。 |
+| [XpsImageBrush](../com.aspose.xps/xpsimagebrush) | ImageBrush プロパティ要素の機能をカプセル化するクラス。 |
+| [XpsLinearGradientBrush](../com.aspose.xps/xpslineargradientbrush) | LinearGradientBrush プロパティ要素の機能をカプセル化するクラス。 |
+| [XpsLoadOptions](../com.aspose.xps/xpsloadoptions) | XPS ドキュメントの読み込みオプション。 |
+| [XpsMatrix](../com.aspose.xps/xpsmatrix) | MatrixTransform プロパティ要素の機能をカプセル化するクラス。 |
+| [XpsObject](../com.aspose.xps/xpsobject) | 共通の XPS モデルオブジェクト機能をカプセル化するクラス。 |
+| [XpsPage](../com.aspose.xps/xpspage) | FixedPage 要素の機能をカプセル化するクラス。 |
+| [XpsPageLinkTarget](../com.aspose.xps/xpspagelinktarget) | ページハイパーリンクターゲットをカプセル化するクラス。 |
+| [XpsPath](../com.aspose.xps/xpspath) | Path 要素の機能をカプセル化するクラス。 |
+| [XpsPathFigure](../com.aspose.xps/xpspathfigure) | PathFigure 要素の機能をカプセル化するクラス。 |
+| [XpsPathGeometry](../com.aspose.xps/xpspathgeometry) | PathGeometry プロパティ要素の機能をカプセル化するクラス。 |
+| [XpsPathPolySegment](../com.aspose.xps/xpspathpolysegment) | PolyLineSegment、PolyB?zierSegment、PolyQuadraticB?zierSegment 要素の共通機能をカプセル化するクラス。 |
+| [XpsPathSegment](../com.aspose.xps/xpspathsegment) | すべてのパスセグメント要素の共通機能をカプセル化するクラス。 |
+| [XpsPolyBezierSegment](../com.aspose.xps/xpspolybeziersegment) | PolyBezierSegment 要素の機能をカプセル化するクラス。 |
+| [XpsPolyLineSegment](../com.aspose.xps/xpspolylinesegment) | PolyLineSegment 要素の機能をカプセル化するクラス。 |
+| [XpsPolyQuadraticBezierSegment](../com.aspose.xps/xpspolyquadraticbeziersegment) | PolyQuadraticBezierSegment 要素の機能をカプセル化するクラス。 |
+| [XpsRadialGradientBrush](../com.aspose.xps/xpsradialgradientbrush) | RadialGradientBrush プロパティ要素の機能をカプセル化するクラス。 |
+| [XpsRgbColor](../com.aspose.xps/xpsrgbcolor) | 任意の色空間（sRGB または scRGB）の RGB カラーをカプセル化します。 |
+| [XpsSolidColorBrush](../com.aspose.xps/xpssolidcolorbrush) | SolidColorBrush プロパティ要素の機能をカプセル化するクラス。 |
+| [XpsTilingBrush](../com.aspose.xps/xpstilingbrush) | タイルブラシ要素（VisualBrush と ImageBrush）の共通機能をカプセル化するクラス。 |
+| [XpsTransformableBrush](../com.aspose.xps/xpstransformablebrush) | 変形可能なブラシ要素（SolidColorBrush を除くすべて）の共通機能をカプセル化するクラス。 |
+| [XpsVisual](../com.aspose.xps/xpsvisual) | Visual 要素の機能をカプセル化するクラス。 |
+| [XpsVisualBrush](../com.aspose.xps/xpsvisualbrush) | VisualBrush プロパティ要素の機能をカプセル化するクラス。 |
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| --- | --- |
+| [ImageMode](../com.aspose.xps/imagemode) | 画像をボックス内にフィットさせるオプションを一覧表示します。 |
+| [XpsColorInterpolationMode](../com.aspose.xps/xpscolorinterpolationmode) | グラデーションブラシの ColorInterpolationMode プロパティの有効な値。 |
+| [XpsDashCap](../com.aspose.xps/xpsdashcap) | Path 要素の StrokeDashCap プロパティの有効な値。 |
+| [XpsEdgeMode](../com.aspose.xps/xpsedgemode) | Canvas 要素の RenderOptions.EdgeMode プロパティの有効な値。 |
+| [XpsFillRule](../com.aspose.xps/xpsfillrule) | PathGeometry 要素の FillRule プロパティの有効な値。 |
+| [XpsFontStyle](../com.aspose.xps/xpsfontstyle) | フォントスタイルの有効な値。 |
+| [XpsLineCap](../com.aspose.xps/xpslinecap) | Path 要素の StrokeStartLineCap と StrokeEndLineCap プロパティの有効な値。 |
+| [XpsLineJoin](../com.aspose.xps/xpslinejoin) | Path 要素の StrokeLineJoin プロパティの有効な値。 |
+| [XpsSpreadMethod](../com.aspose.xps/xpsspreadmethod) | グラデーションブラシの SpreadMethod プロパティの有効な値。 |
+| [XpsStyleSimulations](../com.aspose.xps/xpsstylesimulations) | Glyphs 要素の StyleSimulations プロパティの有効な値。 |
+| [XpsSweepDirection](../com.aspose.xps/xpssweepdirection) | ArcSegment 要素の SweepDirection プロパティの有効な値。 |
+| [XpsTileMode](../com.aspose.xps/xpstilemode) | タイルブラシの TileMode プロパティの有効な値。 |

--- a/japanese/java/com.aspose.xps/documentutils/_index.md
+++ b/japanese/java/com.aspose.xps/documentutils/_index.md
@@ -1,0 +1,284 @@
+---
+title: "DocumentUtils"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "このクラスは、正式な XPS 操作 API を超えるユーティリティを提供します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps/documentutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentUtils
+```
+
+このクラスは、正式な XPS 操作 API を超えるユーティリティを提供します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [createCircle(Point2D center, float radius)](#createCircle-java.awt.geom.Point2D-float-) | 円を表すパスジオメトリを作成します。 |
+| [createCircularSegment(Point2D center, float radius, float startAngle, float endAngle)](#createCircularSegment-java.awt.geom.Point2D-float-float-float-) | 2 つの角度間の円弧セグメントを表すパスジオメトリを作成します。 |
+| [createEllipse(Point2D center, float radiusX, float radiusY)](#createEllipse-java.awt.geom.Point2D-float-float-) | 楕円を表すパスジオメトリを作成します。 |
+| [createImage(String fileName, Rectangle2D imageBox)](#createImage-java.lang.String-java.awt.geom.Rectangle2D-) | 画像で塗りつぶされた矩形パスを作成します。 |
+| [createImage(String fileName, Rectangle2D imageBox, ImageMode mode)](#createImage-java.lang.String-java.awt.geom.Rectangle2D-com.aspose.xps.ImageMode-) | 画像で塗りつぶされた矩形パスを作成します。 |
+| [createPieSlice(Point2D center, float radius, float startAngle, float endAngle)](#createPieSlice-java.awt.geom.Point2D-float-float-float-) | 2 本の放射線間の円スライスを表すパスジオメトリを作成します。 |
+| [createRectangle(Rectangle2D rectangle)](#createRectangle-java.awt.geom.Rectangle2D-) | 矩形を表すパスジオメトリを作成します。 |
+| [createRegularCircumscribedNGon(int n, Point2D center, float radius)](#createRegularCircumscribedNGon-int-java.awt.geom.Point2D-float-) | 円に外接する正 n 角形を表すパスジオメトリを作成します。 |
+| [createRegularInscribedNGon(int n, Point2D center, float radius)](#createRegularInscribedNGon-int-java.awt.geom.Point2D-float-) | 円に内接する正 n 角形を表すパスジオメトリを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createCircle(Point2D center, float radius) {#createCircle-java.awt.geom.Point2D-float-}
+```
+public XpsPathGeometry createCircle(Point2D center, float radius)
+```
+
+
+円を表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 円の中心点です。 |
+| 半径 | float | 円の半径です。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createCircularSegment(Point2D center, float radius, float startAngle, float endAngle) {#createCircularSegment-java.awt.geom.Point2D-float-float-float-}
+```
+public XpsPathGeometry createCircularSegment(Point2D center, float radius, float startAngle, float endAngle)
+```
+
+
+2 つの角度間の円弧セグメントを表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 円の中心です。 |
+| 半径 | float | 円の半径です。 |
+| startAngle | float | 開始光線の角度（度）。 |
+| endAngle | float | 終了光線の角度（度）。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createEllipse(Point2D center, float radiusX, float radiusY) {#createEllipse-java.awt.geom.Point2D-float-float-}
+```
+public XpsPathGeometry createEllipse(Point2D center, float radiusX, float radiusY)
+```
+
+
+楕円を表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 楕円の中心点です。 |
+| radiusX | float | 楕円の水平半径です。 |
+| radiusY | float | 楕円の垂直半径です。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createImage(String fileName, Rectangle2D imageBox) {#createImage-java.lang.String-java.awt.geom.Rectangle2D-}
+```
+public XpsPath createImage(String fileName, Rectangle2D imageBox)
+```
+
+
+画像で塗りつぶされた矩形パスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fileName | java.lang.String | 画像ファイルの名前です。 |
+| imageBox | java.awt.geom.Rectangle2D | 画像で埋めるイメージボックスです。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - The XPS path.
+### createImage(String fileName, Rectangle2D imageBox, ImageMode mode) {#createImage-java.lang.String-java.awt.geom.Rectangle2D-com.aspose.xps.ImageMode-}
+```
+public XpsPath createImage(String fileName, Rectangle2D imageBox, ImageMode mode)
+```
+
+
+画像で塗りつぶされた矩形パスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fileName | java.lang.String | 画像ファイルの名前です。 |
+| imageBox | java.awt.geom.Rectangle2D | 画像で埋めるイメージボックスです。 |
+| mode | [ImageMode](../../com.aspose.xps/imagemode) | 画像のフィットモードです。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - The XPS path.
+### createPieSlice(Point2D center, float radius, float startAngle, float endAngle) {#createPieSlice-java.awt.geom.Point2D-float-float-float-}
+```
+public XpsPathGeometry createPieSlice(Point2D center, float radius, float startAngle, float endAngle)
+```
+
+
+2 本の放射線間の円スライスを表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 円の中心です。 |
+| 半径 | float | 円の半径です。 |
+| startAngle | float | 開始光線の角度（度）。 |
+| endAngle | float | 終了光線の角度（度）。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createRectangle(Rectangle2D rectangle) {#createRectangle-java.awt.geom.Rectangle2D-}
+```
+public XpsPathGeometry createRectangle(Rectangle2D rectangle)
+```
+
+
+矩形を表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| rectangle | java.awt.geom.Rectangle2D | 矩形です。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createRegularCircumscribedNGon(int n, Point2D center, float radius) {#createRegularCircumscribedNGon-int-java.awt.geom.Point2D-float-}
+```
+public XpsPathGeometry createRegularCircumscribedNGon(int n, Point2D center, float radius)
+```
+
+
+円に外接する正 n 角形を表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| n | int | 頂点の数です。 |
+| center | java.awt.geom.Point2D | 円の中心です。 |
+| 半径 | float | 円の半径です。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createRegularInscribedNGon(int n, Point2D center, float radius) {#createRegularInscribedNGon-int-java.awt.geom.Point2D-float-}
+```
+public XpsPathGeometry createRegularInscribedNGon(int n, Point2D center, float radius)
+```
+
+
+円に内接する正 n 角形を表すパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| n | int | 頂点の数です。 |
+| center | java.awt.geom.Point2D | 円の中心です。 |
+| 半径 | float | 円の半径です。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/float/_index.md
+++ b/japanese/java/com.aspose.xps/float/_index.md
@@ -1,0 +1,254 @@
+---
+title: "Size2D.Float"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Float クラスは、float 座標で指定された寸法を定義します。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps/size2d.float/
+---
+**Inheritance:**
+java.lang.Object, java.awt.geom.Dimension2D, [com.aspose.xps.Size2D](../../com.aspose.xps/size2d)
+
+**All Implemented Interfaces:**
+java.io.Serializable
+```
+public static class Size2D.Float extends Size2D implements Serializable
+```
+
+`Float` クラスは、浮動小数点座標で指定された次元を定義します。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Float()](#Float--) | Size2D インスタンスを作成します。 |
+| [Float(float width, float height)](#Float-float-float-) | Size2D インスタンスを作成します。 |
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [height](#height) | この `Size2D` の高さです。 |
+| [width](#width) | この `Size2D` の幅です。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | \{@inheritDoc\} |
+| [getWidth()](#getWidth--) | \{@inheritDoc\} |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double w, double h)](#setSize-double-double-) | \{@inheritDoc\} |
+| [setSize(float w, float h)](#setSize-float-float-) | この `Size2D` の寸法を指定された `float` 値に設定します。 |
+| [setSize(Dimension2D arg0)](#setSize-java.awt.geom.Dimension2D-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Float() {#Float--}
+```
+public Float()
+```
+
+
+Size2D インスタンスを作成します。
+
+### Float(float width, float height) {#Float-float-float-}
+```
+public Float(float width, float height)
+```
+
+
+Size2D インスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 幅です。 |
+| height | float | 高さです。 |
+
+### height {#height}
+```
+public float height
+```
+
+
+この `Size2D` の高さです。
+
+### width {#width}
+```
+public float width
+```
+
+
+この `Size2D` の幅です。
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double w, double h) {#setSize-double-double-}
+```
+public void setSize(double w, double h)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| w | double |  |
+| h | double |  |
+
+### setSize(float w, float h) {#setSize-float-float-}
+```
+public void setSize(float w, float h)
+```
+
+
+この `Size2D` の寸法を指定された `float` 値に設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| w | float | この `Size2D` の幅です |
+| h | float | この `Size2D` の高さです |
+
+### setSize(Dimension2D arg0) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.awt.geom.Dimension2D |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/imagemode/_index.md
+++ b/japanese/java/com.aspose.xps/imagemode/_index.md
@@ -1,0 +1,259 @@
+---
+title: "ImageMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "画像をボックス内にフィットさせるオプションを一覧表示します。"
+type: docs
+weight: 55
+url: /ja/java/com.aspose.xps/imagemode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum ImageMode extends Enum<ImageMode>
+```
+
+画像をボックス内にフィットさせるオプションを一覧表示します。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [FitToBox](#FitToBox) | 画像はボックスに合わせてフィットします。 |
+| [FitToHeight](#FitToHeight) | 画像は高さに合わせてフィットします。 |
+| [FitToWidth](#FitToWidth) | 画像は幅に合わせてフィットします。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FitToBox {#FitToBox}
+```
+public static final ImageMode FitToBox
+```
+
+
+画像はボックスに合わせてフィットします。
+
+### FitToHeight {#FitToHeight}
+```
+public static final ImageMode FitToHeight
+```
+
+
+画像は高さに合わせてフィットします。
+
+### FitToWidth {#FitToWidth}
+```
+public static final ImageMode FitToWidth
+```
+
+
+画像は幅に合わせてフィットします。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static ImageMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[ImageMode](../../com.aspose.xps/imagemode)
+### values() {#values--}
+```
+public static ImageMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.ImageMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/loadoptions/_index.md
+++ b/japanese/java/com.aspose.xps/loadoptions/_index.md
@@ -1,0 +1,124 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ドキュメント読み込みオプションの基本クラスです。"
+type: docs
+weight: 11
+url: /ja/java/com.aspose.xps/loadoptions/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class LoadOptions
+```
+
+ドキュメント読み込みオプションの基本クラスです。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/matrixorder/_index.md
+++ b/japanese/java/com.aspose.xps/matrixorder/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsMatrix.MatrixOrder"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "行列操作の順序を定義する列挙体。"
+type: docs
+weight: 10
+url: /ja/java/com.aspose.xps/xpsmatrix.matrixorder/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsMatrix.MatrixOrder extends Enum<XpsMatrix.MatrixOrder>
+```
+
+行列操作の順序を定義する列挙体。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Append](#Append) | 追加順序。 |
+| [Prepend](#Prepend) | 前置順序。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Append {#Append}
+```
+public static final XpsMatrix.MatrixOrder Append
+```
+
+
+追加順序。
+
+### Prepend {#Prepend}
+```
+public static final XpsMatrix.MatrixOrder Prepend
+```
+
+
+前置順序。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsMatrix.MatrixOrder valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[MatrixOrder](../../com.aspose.xps/matrixorder)
+### values() {#values--}
+```
+public static XpsMatrix.MatrixOrder[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsMatrix.MatrixOrder[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/size2d/_index.md
+++ b/japanese/java/com.aspose.xps/size2d/_index.md
@@ -1,0 +1,199 @@
+---
+title: "Size2D"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Size2D クラスは幅 x 高さ の寸法を表します。"
+type: docs
+weight: 12
+url: /ja/java/com.aspose.xps/size2d/
+---
+**Inheritance:**
+java.lang.Object, java.awt.geom.Dimension2D
+```
+public abstract class Size2D extends Dimension2D
+```
+
+`Size2D` クラスは、次元 (幅 x 高さ) を記述します。
+
+このクラスは 2D 寸法を保持するすべてのオブジェクトの抽象スーパークラスです。寸法の実際の保存形式はサブクラスに委ねられます。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [Size2D()](#Size2D--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) |  |
+| [getWidth()](#getWidth--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double arg0, double arg1)](#setSize-double-double-) |  |
+| [setSize(Dimension2D arg0)](#setSize-java.awt.geom.Dimension2D-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Size2D() {#Size2D--}
+```
+public Size2D()
+```
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public abstract double getHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getWidth() {#getWidth--}
+```
+public abstract double getWidth()
+```
+
+
+
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double arg0, double arg1) {#setSize-double-double-}
+```
+public abstract void setSize(double arg0, double arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | double |  |
+| arg1 | double |  |
+
+### setSize(Dimension2D arg0) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.awt.geom.Dimension2D |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsarcsegment/_index.md
+++ b/japanese/java/com.aspose.xps/xpsarcsegment/_index.md
@@ -1,0 +1,285 @@
+---
+title: "XpsArcSegment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ArcSegment 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 13
+url: /ja/java/com.aspose.xps/xpsarcsegment/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)、[com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment)
+```
+public class XpsArcSegment extends XpsPathSegment
+```
+
+ArcSegment 要素の機能をカプセル化するクラスです。この要素は楕円弧を記述します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この弧セグメントをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPoint()](#getPoint--) | 楕円弧の終点を返します。 |
+| [getRotationAngle()](#getRotationAngle--) | 楕円が現在の座標系に対してどのように回転しているかを示す値を返します。 |
+| [getSize()](#getSize--) | 楕円弧の x と y の半径を x,y のペアとして返します。 |
+| [getSweepDirection()](#getSweepDirection--) | 弧が描画される方向を指定する値を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [isLargeArc()](#isLargeArc--) | 弧が 180 度以上のスイープで描画されるかどうかを決定する値を返します。 |
+| [isStroked()](#isStroked--) | このパスセグメントのストロークが描画されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLargeArc(boolean value)](#setLargeArc-boolean-) | 円弧が180度以上のスイープで描画されるかどうかを決定する値を設定します。 |
+| [setPoint(Point2D value)](#setPoint-java.awt.geom.Point2D-) | 楕円弧の終点を設定します。 |
+| [setRotationAngle(float value)](#setRotationAngle-float-) | 楕円が現在の座標系に対してどのように回転しているかを示す値を設定します。 |
+| [setSize(Dimension2D value)](#setSize-java.awt.geom.Dimension2D-) | 楕円弧の x および y 半径を x,y のペアとして設定します。 |
+| [setStroked(boolean value)](#setStroked-boolean-) | このパスセグメントのストロークが描画されるかどうかを示す値を設定します。 |
+| [setSweepDirection(XpsSweepDirection value)](#setSweepDirection-com.aspose.xps.XpsSweepDirection-) | 円弧が描画される方向を指定する値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsArcSegment deepClone()
+```
+
+
+この弧セグメントをクローンします。
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - Clone of this arc segment.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPoint() {#getPoint--}
+```
+public Point2D getPoint()
+```
+
+
+楕円弧の終点を返します。
+
+**Returns:**
+java.awt.geom.Point2D - 楕円弧の終点。
+### getRotationAngle() {#getRotationAngle--}
+```
+public float getRotationAngle()
+```
+
+
+楕円が現在の座標系に対してどのように回転しているかを示す値を返します。
+
+**Returns:**
+float - 楕円が現在の座標系に対してどのように回転しているかを示す値。
+### getSize() {#getSize--}
+```
+public Dimension2D getSize()
+```
+
+
+楕円弧の x と y の半径を x,y のペアとして返します。
+
+**Returns:**
+java.awt.geom.Dimension2D - 楕円弧の x および y 半径を x,y のペアとして表します。
+### getSweepDirection() {#getSweepDirection--}
+```
+public XpsSweepDirection getSweepDirection()
+```
+
+
+弧が描画される方向を指定する値を返します。
+
+**Returns:**
+[XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) - The value specifying the direction in which the arc is drawn.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isLargeArc() {#isLargeArc--}
+```
+public boolean isLargeArc()
+```
+
+
+弧が 180 度以上のスイープで描画されるかどうかを決定する値を返します。
+
+**Returns:**
+boolean - 円弧が180度以上のスイープで描画されるかどうかを決定する値。
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - このパスセグメントのストロークが描画されるかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLargeArc(boolean value) {#setLargeArc-boolean-}
+```
+public void setLargeArc(boolean value)
+```
+
+
+円弧が180度以上のスイープで描画されるかどうかを決定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | 円弧が180度以上のスイープで描画されるかどうかを決定する値。 |
+
+### setPoint(Point2D value) {#setPoint-java.awt.geom.Point2D-}
+```
+public void setPoint(Point2D value)
+```
+
+
+楕円弧の終点を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Point2D | 楕円弧の終点。 |
+
+### setRotationAngle(float value) {#setRotationAngle-float-}
+```
+public void setRotationAngle(float value)
+```
+
+
+楕円が現在の座標系に対してどのように回転しているかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 楕円が現在の座標系に対してどのように回転しているかを示す値。 |
+
+### setSize(Dimension2D value) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D value)
+```
+
+
+楕円弧の x および y 半径を x,y のペアとして設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Dimension2D | 楕円弧の x と y の半径（x,y のペア）。 |
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | このパスセグメントのストロークが描画されるかどうかを示す値。 |
+
+### setSweepDirection(XpsSweepDirection value) {#setSweepDirection-com.aspose.xps.XpsSweepDirection-}
+```
+public void setSweepDirection(XpsSweepDirection value)
+```
+
+
+円弧が描画される方向を指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 円弧が描画される方向を指定する値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsarray/_index.md
+++ b/japanese/java/com.aspose.xps/xpsarray/_index.md
@@ -1,0 +1,216 @@
+---
+title: "XpsArray"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の XPS モデル配列オブジェクトの機能をカプセル化するクラス。"
+type: docs
+weight: 14
+url: /ja/java/com.aspose.xps/xpsarray/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public abstract class XpsArray<T> extends XpsObject
+```
+
+共通の XPS モデル配列オブジェクトの機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(T obj)](#add-T-) | 配列に新しいオブジェクトを追加します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i によって配列の要素へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [insert(int index, T obj)](#insert-int-T-) | 指定された位置に新しいオブジェクトを配列に挿入します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(T obj)](#remove-T-) | 配列からオブジェクトを削除します。 |
+| [removeAt(int index)](#removeAt-int-) | 指定された位置で配列からオブジェクトを削除します。 |
+| [size()](#size--) | 要素数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(T obj) {#add-T-}
+```
+public T add(T obj)
+```
+
+
+配列に新しいオブジェクトを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T | 追加するオブジェクト。 |
+
+**Returns:**
+T - 追加されたオブジェクト。
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public T get(int i)
+```
+
+
+インデックス i によって配列の要素へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 要素のインデックス。 |
+
+**Returns:**
+T - インデックス i の位置にある要素。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insert(int index, T obj) {#insert-int-T-}
+```
+public T insert(int index, T obj)
+```
+
+
+指定された位置に新しいオブジェクトを配列に挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | オブジェクトを挿入する位置。 |
+| obj | T | 挿入するオブジェクト。 |
+
+**Returns:**
+T - 挿入されたオブジェクト。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(T obj) {#remove-T-}
+```
+public T remove(T obj)
+```
+
+
+配列からオブジェクトを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T | 削除するオブジェクト。 |
+
+**Returns:**
+T - 削除されたオブジェクト。
+### removeAt(int index) {#removeAt-int-}
+```
+public T removeAt(int index)
+```
+
+
+指定された位置で配列からオブジェクトを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | オブジェクトを削除する位置。 |
+
+**Returns:**
+T - 削除されたオブジェクト。
+### size() {#size--}
+```
+public int size()
+```
+
+
+要素数を返します。
+
+**Returns:**
+int - 要素数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpsbrush/_index.md
@@ -1,0 +1,149 @@
+---
+title: "XpsBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "すべてのブラシ要素の共通機能をカプセル化するクラス。"
+type: docs
+weight: 15
+url: /ja/java/com.aspose.xps/xpsbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public abstract class XpsBrush extends XpsObject
+```
+
+すべてのブラシ要素の共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpscanvas/_index.md
+++ b/japanese/java/com.aspose.xps/xpscanvas/_index.md
@@ -1,0 +1,459 @@
+---
+title: "XpsCanvas"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Canvas 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 16
+url: /ja/java/com.aspose.xps/xpscanvas/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement), [com.aspose.xps.XpsContentElement](../../com.aspose.xps/xpscontentelement)
+```
+public final class XpsCanvas extends XpsContentElement
+```
+
+Canvas要素の機能をカプセル化するクラス。この要素は要素をまとめます。たとえば、GlyphsおよびPath要素をキャンバス内でグループ化し、単位として識別（ハイパーリンク先として）したり、各子要素と先祖要素に合成プロパティ値を適用したりできます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>add(T element)](#-T-add-T-) | このキャンバスの子リストに要素を追加します。 |
+| [<T>insert(int index, T element)](#-T-insert-int-T-) | このキャンバスの子リストの index 位置に要素を挿入します。 |
+| [addCanvas()](#addCanvas--) | このキャンバスの子リストに新しいキャンバスを追加します。 |
+| [addGlyphs(String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | このキャンバスの子リストに新しいグリフを追加します。 |
+| [addPath(XpsPathGeometry data)](#addPath-com.aspose.xps.XpsPathGeometry-) | このキャンバスの子リストに新しいパスを追加します。 |
+| [deepClone()](#deepClone--) | このキャンバスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 要素の描画領域を制限するパスジオメトリを返します。 |
+| [getEdgeMode()](#getEdgeMode--) | キャンバス内のパスのエッジがどのように描画されるかを制御する値を返します。 |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | ハイパーリンクのターゲットオブジェクトを返します。 |
+| [getOpacity()](#getOpacity--) | 要素の均一な透明度を定義する値を返します。 |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [getRenderTransform()](#getRenderTransform--) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [insertCanvas(int index)](#insertCanvas-int-) | このキャンバスの子リストの index 位置に新しいキャンバスを挿入します。 |
+| [insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | このキャンバスの子リストの index 位置に新しいグリフを挿入します。 |
+| [insertPath(int index, XpsPathGeometry data)](#insertPath-int-com.aspose.xps.XpsPathGeometry-) | このキャンバスの子リストの index 位置に新しいパスを挿入します。 |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 要素の描画領域を制限するパスジオメトリを設定します。 |
+| [setEdgeMode(XpsEdgeMode value)](#setEdgeMode-com.aspose.xps.XpsEdgeMode-) | キャンバス内のパスのエッジがどのように描画されるかを制御する値を設定します。 |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | ハイパーリンクのターゲットオブジェクトを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | 要素の均一な透明度を定義する値を設定します。 |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | 要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。 |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>add(T element) {#-T-add-T-}
+```
+public T <T>add(T element)
+```
+
+
+このキャンバスの子リストに要素を追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 要素 | T | 追加する要素です。 |
+
+**Returns:**
+T - 追加された要素。
+### <T>insert(int index, T element) {#-T-insert-int-T-}
+```
+public T <T>insert(int index, T element)
+```
+
+
+このキャンバスの子リストの index 位置に要素を挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素を挿入すべき位置。 |
+| 要素 | T | 挿入する要素。 |
+
+**Returns:**
+T - 挿入された要素。
+### addCanvas() {#addCanvas--}
+```
+public XpsCanvas addCanvas()
+```
+
+
+このキャンバスの子リストに新しいキャンバスを追加します。
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Added canvas.
+### addGlyphs(String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+このキャンバスの子リストに新しいグリフを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 T 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addPath(XpsPathGeometry data) {#addPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath addPath(XpsPathGeometry data)
+```
+
+
+このキャンバスの子リストに新しいパスを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Added path.
+### deepClone() {#deepClone--}
+```
+public XpsCanvas deepClone()
+```
+
+
+このキャンバスをクローンします。
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Clone of this canvas.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+要素の描画領域を制限するパスジオメトリを返します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getEdgeMode() {#getEdgeMode--}
+```
+public XpsEdgeMode getEdgeMode()
+```
+
+
+キャンバス内のパスのエッジがどのように描画されるかを制御する値を返します。
+
+**Returns:**
+[XpsEdgeMode](../../com.aspose.xps/xpsedgemode) - The edge rendering mode.
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+ハイパーリンクのターゲットオブジェクトを返します。
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+要素の均一な透明度を定義する値を返します。
+
+**Returns:**
+float - 要素の均一な透明度を定義する値。
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insertCanvas(int index) {#insertCanvas-int-}
+```
+public XpsCanvas insertCanvas(int index)
+```
+
+
+このキャンバスの子リストの index 位置に新しいキャンバスを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Canvas を挿入すべき位置です。 |
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Inserted canvas.
+### insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+このキャンバスの子リストの index 位置に新しいグリフを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Glyphs を挿入すべき位置です。 |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 T 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### insertPath(int index, XpsPathGeometry data) {#insertPath-int-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath insertPath(int index, XpsPathGeometry data)
+```
+
+
+このキャンバスの子リストの index 位置に新しいパスを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Path を挿入すべき位置です。 |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Inserted path.
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+要素の描画領域を制限するパスジオメトリを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 要素の描画領域を制限するパスジオメトリ。 |
+
+### setEdgeMode(XpsEdgeMode value) {#setEdgeMode-com.aspose.xps.XpsEdgeMode-}
+```
+public void setEdgeMode(XpsEdgeMode value)
+```
+
+
+キャンバス内のパスのエッジがどのように描画されるかを制御する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsEdgeMode](../../com.aspose.xps/xpsedgemode) | エッジ描画モード。 |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+ハイパーリンクのターゲットオブジェクトを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | ハイパーリンクのターゲットオブジェクト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+要素の均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 要素の均一な透明度を定義する値。 |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | マスクを指定するブラシ。 |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | アフィン変換行列。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpscolor/_index.md
+++ b/japanese/java/com.aspose.xps/xpscolor/_index.md
@@ -1,0 +1,135 @@
+---
+title: "XpsColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通のカラー機能をカプセル化する基底クラス。"
+type: docs
+weight: 17
+url: /ja/java/com.aspose.xps/xpscolor/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class XpsColor
+```
+
+共通のカラー機能をカプセル化する基底クラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toColor()](#toColor--) | 任意の色のネイティブ表現を取得するための便利なメソッド。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toColor() {#toColor--}
+```
+public abstract Color toColor()
+```
+
+
+任意の色のネイティブ表現を取得するための便利なメソッド。
+
+**Returns:**
+java.awt.Color - System.Drawing.Color 構造体
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpscolorinterpolationmode/_index.md
+++ b/japanese/java/com.aspose.xps/xpscolorinterpolationmode/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsColorInterpolationMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "グラデーションブラシの ColorInterpolationMode プロパティの有効な値です。"
+type: docs
+weight: 56
+url: /ja/java/com.aspose.xps/xpscolorinterpolationmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsColorInterpolationMode extends Enum<XpsColorInterpolationMode>
+```
+
+グラデーションブラシの ColorInterpolationMode プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [SRgbLinearInterpolation](#SRgbLinearInterpolation) | SRgbLinearInterpolation モード。 |
+| [ScRgbLinearInterpolation](#ScRgbLinearInterpolation) | ScRgbLinearInterpolation モード。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SRgbLinearInterpolation {#SRgbLinearInterpolation}
+```
+public static final XpsColorInterpolationMode SRgbLinearInterpolation
+```
+
+
+SRgbLinearInterpolation モード。
+
+### ScRgbLinearInterpolation {#ScRgbLinearInterpolation}
+```
+public static final XpsColorInterpolationMode ScRgbLinearInterpolation
+```
+
+
+ScRgbLinearInterpolation モード。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsColorInterpolationMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode)
+### values() {#values--}
+```
+public static XpsColorInterpolationMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsColorInterpolationMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpscontentelement/_index.md
+++ b/japanese/java/com.aspose.xps/xpscontentelement/_index.md
@@ -1,0 +1,287 @@
+---
+title: "XpsContentElement"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS コンテンツ要素 Canvas、Path、Glyphs の機能をカプセル化します。"
+type: docs
+weight: 18
+url: /ja/java/com.aspose.xps/xpscontentelement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement)
+```
+public abstract class XpsContentElement extends XpsHyperlinkElement
+```
+
+XPS コンテンツ要素（Canvas、Path、Glyphs）の機能をカプセル化します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 要素の描画領域を制限するパスジオメトリを返します。 |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | ハイパーリンクのターゲットオブジェクトを返します。 |
+| [getOpacity()](#getOpacity--) | 要素の均一な透明度を定義する値を返します。 |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [getRenderTransform()](#getRenderTransform--) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 要素の描画領域を制限するパスジオメトリを設定します。 |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | ハイパーリンクのターゲットオブジェクトを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | 要素の均一な透明度を定義する値を設定します。 |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | 要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。 |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+要素の描画領域を制限するパスジオメトリを返します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+ハイパーリンクのターゲットオブジェクトを返します。
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+要素の均一な透明度を定義する値を返します。
+
+**Returns:**
+float - 要素の均一な透明度を定義する値。
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+要素の描画領域を制限するパスジオメトリを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 要素の描画領域を制限するパスジオメトリ。 |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+ハイパーリンクのターゲットオブジェクトを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | ハイパーリンクのターゲットオブジェクト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+要素の均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 要素の均一な透明度を定義する値。 |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | マスクを指定するブラシ。 |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | アフィン変換行列。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsdashcap/_index.md
+++ b/japanese/java/com.aspose.xps/xpsdashcap/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsDashCap"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Path 要素の StrokeDashCap プロパティの有効な値です。"
+type: docs
+weight: 57
+url: /ja/java/com.aspose.xps/xpsdashcap/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsDashCap extends Enum<XpsDashCap>
+```
+
+Path 要素の StrokeDashCap プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Flat](#Flat) | フラット ダッシュ キャップです。 |
+| [Round](#Round) | ラウンド ダッシュ キャップです。 |
+| [Square](#Square) | スクエア ダッシュ キャップです。 |
+| [Triangle](#Triangle) | トライアングル ダッシュ キャップです。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Flat {#Flat}
+```
+public static final XpsDashCap Flat
+```
+
+
+フラット ダッシュ キャップです。
+
+### Round {#Round}
+```
+public static final XpsDashCap Round
+```
+
+
+ラウンド ダッシュ キャップです。
+
+### Square {#Square}
+```
+public static final XpsDashCap Square
+```
+
+
+スクエア ダッシュ キャップです。
+
+### Triangle {#Triangle}
+```
+public static final XpsDashCap Triangle
+```
+
+
+トライアングル ダッシュ キャップです。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsDashCap valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsDashCap](../../com.aspose.xps/xpsdashcap)
+### values() {#values--}
+```
+public static XpsDashCap[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsDashCap[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsdocument/_index.md
+++ b/japanese/java/com.aspose.xps/xpsdocument/_index.md
@@ -1,0 +1,1938 @@
+---
+title: "XpsDocument"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の XPS 要素に対する操作メソッドを提供する XPS ドキュメントの主要エンティティをカプセル化するクラス。"
+type: docs
+weight: 19
+url: /ja/java/com.aspose.xps/xpsdocument/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.Document](../../com.aspose.page/document)
+
+**All Implemented Interfaces:**
+java.io.Closeable
+```
+public final class XpsDocument extends Document implements Closeable
+```
+
+任意の XPS 要素に対する操作メソッドを提供する XPS ドキュメントの主要エンティティをカプセル化するクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsDocument()](#XpsDocument--) | デフォルトのページサイズで空の XPS ドキュメントを作成します。 |
+| [XpsDocument(String path)](#XpsDocument-java.lang.String-) | 指定されたパスにある既存の XPS ドキュメントを開きます。 |
+| [XpsDocument(InputStream stream, LoadOptions options)](#XpsDocument-java.io.InputStream-com.aspose.xps.LoadOptions-) | ストリームに格納された既存のドキュメントを XPS ドキュメントとしてロードします。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>add(T element)](#-T-add-T-) | コンテンツ要素（Canvas、Path、または Glyphs）を追加します |
+| [<T>insert(int index, T element)](#-T-insert-int-T-) | アクティブページのインデックス位置に要素（Canvas、Path、または Glyphs）を挿入します。 |
+| [<T>remove(T element)](#-T-remove-T-) | アクティブページから要素を削除します。 |
+| [addCanvas()](#addCanvas--) | アクティブページに新しいキャンバスを追加します。 |
+| [addDocument()](#addDocument--) | デフォルトのページサイズで空のドキュメントを追加し、追加されたドキュメントをアクティブとして選択します。 |
+| [addDocument(boolean activate)](#addDocument-boolean-) | デフォルトのページサイズで空のドキュメントを追加します。 |
+| [addDocument(float width, float height)](#addDocument-float-float-) | 最初のページの width と height の寸法で空のドキュメントを追加し、追加されたドキュメントをアクティブとして選択します。 |
+| [addDocument(float width, float height, boolean activate)](#addDocument-float-float-boolean-) | 最初のページの width と height を持つ空のドキュメントを追加します。 |
+| [addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | アクティブなページに新しいグリフを追加します。 |
+| [addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | アクティブなページに新しいグリフを追加します。 |
+| [addOutlineEntry(String description, int outlineLevel, XpsHyperlinkTarget target)](#addOutlineEntry-java.lang.String-int-com.aspose.xps.XpsHyperlinkTarget-) | ドキュメントにアウトラインエントリを追加します。 |
+| [addPage()](#addPage--) | デフォルトのページサイズで空のページをドキュメントに追加します。 |
+| [addPage(boolean activate)](#addPage-boolean-) | デフォルトのページサイズで空のページをドキュメントに追加します。 |
+| [addPage(XpsPage page)](#addPage-com.aspose.xps.XpsPage-) | ページをドキュメントに追加し、追加されたページをアクティブに選択します。 |
+| [addPage(XpsPage page, boolean activate)](#addPage-com.aspose.xps.XpsPage-boolean-) | ページをドキュメントに追加します。 |
+| [addPage(float width, float height)](#addPage-float-float-) | 指定された width と height を持つ空のページをドキュメントに追加します。 |
+| [addPage(float width, float height, boolean activate)](#addPage-float-float-boolean-) | 指定された width と height を持つ空のページをドキュメントに追加します。 |
+| [addPath(XpsPathGeometry data)](#addPath-com.aspose.xps.XpsPathGeometry-) | アクティブなページに新しいパスを追加します。 |
+| [close()](#close--) | インスタンスを破棄します。 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-) | 新しいストロークされた楕円弧セグメントを作成します。 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-) | 新しい楕円弧セグメントを作成します。 |
+| [createCanvas()](#createCanvas--) | 新しいキャンバスを作成します。 |
+| [createColor(XpsIccProfile iccProfile, float[] components)](#createColor-com.aspose.xps.XpsIccProfile-float...-) | ICCベースのカラースペースで新しい色を作成します。 |
+| [createColor(float r, float g, float b)](#createColor-float-float-float-) | scRGB カラースペースで新しい色を作成します。 |
+| [createColor(float a, float r, float g, float b)](#createColor-float-float-float-float-) | scRGB カラースペースで新しい色を作成します。 |
+| [createColor(int r, int g, int b)](#createColor-int-int-int-) | sRGB カラースペースで新しい色を作成します。 |
+| [createColor(int a, int r, int g, int b)](#createColor-int-int-int-int-) | sRGB カラースペースで新しい色を作成します。 |
+| [createColor(Color color)](#createColor-java.awt.Color-) | 新しい色を作成します。 |
+| [createColor(String path, float[] components)](#createColor-java.lang.String-float...-) | ICCベースのカラースペースで新しい色を作成します。 |
+| [createFont(InputStream stream)](#createFont-java.io.InputStream-) | stream から新しい TrueType フォントリソースを作成します。 |
+| [createFont(String fontFamily, XpsFontStyle fontStyle)](#createFont-java.lang.String-com.aspose.xps.XpsFontStyle-) | 新しい TrueType フォントリソースを作成します。 |
+| [createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 新しいグリフを作成します。 |
+| [createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 新しいグリフを作成します。 |
+| [createGradientStop(XpsColor color, float offset)](#createGradientStop-com.aspose.xps.XpsColor-float-) | 新しいグラデーションストップを作成します。 |
+| [createGradientStop(Color color, float offset)](#createGradientStop-java.awt.Color-float-) | 新しいグラデーションストップを作成します。 |
+| [createIccProfile(InputStream stream)](#createIccProfile-java.io.InputStream-) | stream から新しい ICC プロファイルリソースを作成します。 |
+| [createIccProfile(String iccProfilePath)](#createIccProfile-java.lang.String-) | iccProfilePath にある ICC プロファイルファイルから新しい ICC プロファイルリソースを作成します。 |
+| [createImage(InputStream stream)](#createImage-java.io.InputStream-) | stream から新しい画像リソースを作成します。 |
+| [createImage(String imagePath)](#createImage-java.lang.String-) | imagePath にある画像ファイルから新しい画像リソースを作成します。 |
+| [createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 新しいイメージブラシを作成します。 |
+| [createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 新しいイメージブラシを作成します。 |
+| [createLinearGradientBrush(Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-) | 新しい線形グラデーションブラシを作成します。 |
+| [createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-) | 新しい線形グラデーションブラシを作成します。 |
+| [createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)](#createMatrix-float-float-float-float-float-float-) | 新しいアフィン変換行列を作成します。 |
+| [createPath(XpsPathGeometry data)](#createPath-com.aspose.xps.XpsPathGeometry-) | 新しいパスを作成します。 |
+| [createPathFigure(Point2D startPoint)](#createPathFigure-java.awt.geom.Point2D-) | 新しいオープンパス図形を作成します。 |
+| [createPathFigure(Point2D startPoint, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-boolean-) | 新しいパス図形を作成します。 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--) | 新しいオープンパス図形を作成します。 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-) | 新しいパス図形を作成します。 |
+| [createPathGeometry()](#createPathGeometry--) | 新しいパスジオメトリを作成します。 |
+| [createPathGeometry(String abbreviatedGeometry)](#createPathGeometry-java.lang.String-) | 省略形で指定された新しいパスジオメトリを作成します。 |
+| [createPathGeometry(List<XpsPathFigure> pathFigures)](#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--) | 指定されたパス図形のリストで新しいパスジオメトリを作成します。 |
+| [createPolyBezierSegment(Point2D[] points)](#createPolyBezierSegment-java.awt.geom.Point2D---) | ストロークされた立方ベジエ曲線の新しいセットを作成します。 |
+| [createPolyBezierSegment(Point2D[] points, boolean isStroked)](#createPolyBezierSegment-java.awt.geom.Point2D---boolean-) | 立方ベジエ曲線の新しいセットを作成します。 |
+| [createPolyLineSegment(Point2D[] points)](#createPolyLineSegment-java.awt.geom.Point2D---) | 任意の数の個々の頂点を含む新しいストロークされた多角形描画を作成します。 |
+| [createPolyLineSegment(Point2D[] points, boolean isStroked)](#createPolyLineSegment-java.awt.geom.Point2D---boolean-) | 任意の数の個々の頂点を含む新しい多角形描画を作成します。 |
+| [createPolyQuadraticBezierSegment(Point2D[] points)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---) | パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、ストロークされた二次ベジエ曲線の新しいセットを作成します。 |
+| [createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-) | パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、二次ベジエ曲線の新しいセットを作成します。 |
+| [createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 新しい放射状グラデーションブラシを作成します。 |
+| [createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 新しい放射状グラデーションブラシを作成します。 |
+| [createSolidColorBrush(XpsColor color)](#createSolidColorBrush-com.aspose.xps.XpsColor-) | 新しい単色ブラシを作成します。 |
+| [createSolidColorBrush(Color color)](#createSolidColorBrush-java.awt.Color-) | 新しい単色ブラシを作成します。 |
+| [createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)](#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 新しいビジュアルブラシを作成します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveDocument()](#getActiveDocument--) | アクティブなドキュメント番号を返します。 |
+| [getActivePage()](#getActivePage--) | アクティブなドキュメント内のアクティブなページ番号を返します。 |
+| [getClass()](#getClass--) |  |
+| [getDocumentCount()](#getDocumentCount--) | XPS パッケージ内のドキュメント数を返します。 |
+| [getDocumentPrintTicket(int documentIndex)](#getDocumentPrintTicket-int-) | documentIndex でインデックスされたドキュメントの印刷チケットを取得します。 |
+| [getJobPrintTicket()](#getJobPrintTicket--) | ドキュメントのジョブ印刷チケットを返します。 |
+| [getPage()](#getPage--) | アクティブなページの XpsPage インスタンスを返します。 |
+| [getPageCount()](#getPageCount--) | アクティブなドキュメントのページ数を返します。 |
+| [getPagePrintTicket(int documentIndex, int pageIndex)](#getPagePrintTicket-int-int-) | documentIndex でインデックスされたドキュメント内の pageIndex でインデックスされたページの印刷チケットを取得します。 |
+| [getTotalPageCount()](#getTotalPageCount--) | XPS ドキュメント内のすべてのドキュメントの総ページ数を返します。 |
+| [getUtils()](#getUtils--) | 正式な XPS 操作 API を超えるユーティリティを提供するオブジェクトを取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [insertCanvas(int index)](#insertCanvas-int-) | index の位置にアクティブなページへ新しいキャンバスを挿入します。 |
+| [insertDocument(int index)](#insertDocument-int-) | index の位置にデフォルトのページサイズの空のドキュメントを挿入し、挿入されたドキュメントをアクティブに選択します。 |
+| [insertDocument(int index, boolean activate)](#insertDocument-int-boolean-) | index の位置にデフォルトのページサイズの空のドキュメントを挿入します。 |
+| [insertDocument(int index, float width, float height)](#insertDocument-int-float-float-) | index の位置に最初のページの width と height を持つ空のドキュメントを挿入し、挿入されたドキュメントをアクティブに選択します。 |
+| [insertDocument(int index, float width, float height, boolean activate)](#insertDocument-int-float-float-boolean-) | インデックス 位置 に、width と height の最初のページ寸法を持つ空のドキュメントを挿入します。 |
+| [insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)](#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | インデックス 位置 にアクティブページへ新しいグリフを挿入します。 |
+| [insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | インデックス 位置 にアクティブページへ新しいグリフを挿入します。 |
+| [insertPage(int index)](#insertPage-int-) | インデックス 位置 にデフォルトページサイズの空ページをドキュメントに挿入し、挿入されたページをアクティブに選択します。 |
+| [insertPage(int index, boolean activate)](#insertPage-int-boolean-) | インデックス 位置 にデフォルトページサイズの空ページをドキュメントに挿入します。 |
+| [insertPage(int index, XpsPage page)](#insertPage-int-com.aspose.xps.XpsPage-) | インデックス 位置 にページをドキュメントに挿入し、挿入されたページをアクティブに選択します。 |
+| [insertPage(int index, XpsPage page, boolean activate)](#insertPage-int-com.aspose.xps.XpsPage-boolean-) | インデックス 位置 にページをドキュメントに挿入します。 |
+| [insertPage(int index, float width, float height)](#insertPage-int-float-float-) | インデックス 位置 に指定された width と height の空ページをドキュメントに挿入し、挿入されたページをアクティブに選択します。 |
+| [insertPage(int index, float width, float height, boolean activate)](#insertPage-int-float-float-boolean-) | インデックス 位置 に指定された width と height の空ページをドキュメントに挿入します。 |
+| [insertPath(int index, XpsPathGeometry data)](#insertPath-int-com.aspose.xps.XpsPathGeometry-) | インデックス 位置 にアクティブページへ新しいパスを挿入します。 |
+| [isLicensed()](#isLicensed--) | Aspose.Page for Java 製品ライセンスがアクセスされ、有効かどうかを示します。 |
+| [merge(String[] filesForMerge, OutputStream outStream)](#merge-java.lang.String---java.io.OutputStream-) | 複数の XPS ファイルを 1 つの XPS ドキュメントに結合します。 |
+| [merge(String[] filesForMerge, String outXpsFilePath)](#merge-java.lang.String---java.lang.String-) | 複数の XPS ファイルを 1 つの XPS ドキュメントに結合します。 |
+| [mergeToPdf(String outPdfFilePath, String[] filesForMerge, PdfSaveOptions options)](#mergeToPdf-java.lang.String-java.lang.String---com.aspose.xps.rendering.PdfSaveOptions-) | Device インスタンスを使用して XPS ドキュメントを PDF に結合します。 |
+| [mergeToPdf(String[] filesForMerge, OutputStream pdfStream, PdfSaveOptions options)](#mergeToPdf-java.lang.String---java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-) | Device インスタンスを使用して XPS ドキュメントを PDF に結合します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | インデックス 位置 からアクティブページの要素を削除します。 |
+| [removeDocumentAt(int index)](#removeDocumentAt-int-) | インデックス 位置 のドキュメントを削除します。 |
+| [removePage(XpsPage page)](#removePage-com.aspose.xps.XpsPage-) | ドキュメントからページを削除します。 |
+| [removePageAt(int index)](#removePageAt-int-) | インデックス 位置 のドキュメントからページを削除します。 |
+| [save(Device device, SaveOptions options)](#save-com.aspose.page.Device-com.aspose.page.SaveOptions-) | Device インスタンスを使用してドキュメントを保存します。 |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | XPS ドキュメントをストリームに保存します。 |
+| [save(String path)](#save-java.lang.String-) | path にある XPS ファイルに XPS ドキュメントを保存します。 |
+| [saveAsImage(ImageSaveOptions options)](#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-) | ドキュメントを画像ファイルに保存します。出力ディレクトリとファイル名は、入力 XPS ファイルと同じになります。 |
+| [saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)](#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-java.lang.String-java.lang.String-) | 指定されたディレクトリと指定されたファイル名でドキュメントを画像ファイルに保存します。 |
+| [saveAsImageBytes(ImageSaveOptions options)](#saveAsImageBytes-com.aspose.xps.rendering.ImageSaveOptions-) | ドキュメントをビットマップ画像形式でバイト配列として保存します。 |
+| [saveAsPdf(OutputStream stream, PdfSaveOptions options)](#saveAsPdf-java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-) | ドキュメントを PDF 形式で保存します。 |
+| [saveAsPdf(String outPdfFilePath, PdfSaveOptions options)](#saveAsPdf-java.lang.String-com.aspose.xps.rendering.PdfSaveOptions-) | ドキュメントを PDF 形式で保存します。 |
+| [saveAsPs(OutputStream stream, PsSaveOptions options)](#saveAsPs-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | ドキュメントを PS 形式で保存します。 |
+| [saveAsPs(String outPsFilePath, PsSaveOptions options)](#saveAsPs-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | ドキュメントを PostSscript 形式で保存します。 |
+| [selectActiveDocument(int documentNumber)](#selectActiveDocument-int-) | 編集用にアクティブなドキュメントを選択します。 |
+| [selectActivePage(int pageNumber)](#selectActivePage-int-) | 編集用にアクティブなドキュメントページを選択します。 |
+| [setDocumentPrintTicket(int documentIndex, DocumentPrintTicket printTicket)](#setDocumentPrintTicket-int-com.aspose.xps.metadata.DocumentPrintTicket-) | printTicket を documentIndex でインデックス付けされたドキュメントにリンクします。 |
+| [setJobPrintTicket(JobPrintTicket value)](#setJobPrintTicket-com.aspose.xps.metadata.JobPrintTicket-) | ドキュメントのジョブ印刷チケットを設定します。 |
+| [setPagePrintTicket(int documentIndex, int pageIndex, PagePrintTicket printTicket)](#setPagePrintTicket-int-int-com.aspose.xps.metadata.PagePrintTicket-) | printTicket を documentIndex でインデックス付けされたドキュメント内の pageIndex でインデックス付けされたページにリンクします。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsDocument() {#XpsDocument--}
+```
+public XpsDocument()
+```
+
+
+デフォルトのページサイズで空の XPS ドキュメントを作成します。
+
+### XpsDocument(String path) {#XpsDocument-java.lang.String-}
+```
+public XpsDocument(String path)
+```
+
+
+指定されたパスにある既存の XPS ドキュメントを開きます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.lang.String | ドキュメントの場所。 |
+
+### XpsDocument(InputStream stream, LoadOptions options) {#XpsDocument-java.io.InputStream-com.aspose.xps.LoadOptions-}
+```
+public XpsDocument(InputStream stream, LoadOptions options)
+```
+
+
+ストリームに格納された既存のドキュメントを XPS ドキュメントとしてロードします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | ドキュメントストリーム。 |
+| options | [LoadOptions](../../com.aspose.xps/loadoptions) | ドキュメントの読み込みオプション。 |
+
+### <T>add(T element) {#-T-add-T-}
+```
+public T <T>add(T element)
+```
+
+
+コンテンツ要素（Canvas、Path、または Glyphs）を追加します
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 要素 | T | 追加する要素です。 |
+
+**Returns:**
+T - 追加された要素。
+### <T>insert(int index, T element) {#-T-insert-int-T-}
+```
+public T <T>insert(int index, T element)
+```
+
+
+アクティブページのインデックス位置に要素（Canvas、Path、または Glyphs）を挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素を挿入すべき位置。 |
+| 要素 | T | 挿入する要素。 |
+
+**Returns:**
+T - 挿入された要素。
+### <T>remove(T element) {#-T-remove-T-}
+```
+public T <T>remove(T element)
+```
+
+
+アクティブページから要素を削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 要素 | T | 削除する要素。 |
+
+**Returns:**
+T - 削除された要素。
+### addCanvas() {#addCanvas--}
+```
+public XpsCanvas addCanvas()
+```
+
+
+アクティブページに新しいキャンバスを追加します。
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Added canvas.
+### addDocument() {#addDocument--}
+```
+public void addDocument()
+```
+
+
+デフォルトのページサイズで空のドキュメントを追加し、追加されたドキュメントをアクティブとして選択します。
+
+### addDocument(boolean activate) {#addDocument-boolean-}
+```
+public void addDocument(boolean activate)
+```
+
+
+デフォルトのページサイズで空のドキュメントを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| アクティブ化 | boolean | 追加されたドキュメントをアクティブとして選択するかどうかを示すフラグ。 |
+
+### addDocument(float width, float height) {#addDocument-float-float-}
+```
+public void addDocument(float width, float height)
+```
+
+
+最初のページの width と height の寸法で空のドキュメントを追加し、追加されたドキュメントをアクティブとして選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 最初のページの幅。 |
+| height | float | 最初のページの高さ。 |
+
+### addDocument(float width, float height, boolean activate) {#addDocument-float-float-boolean-}
+```
+public void addDocument(float width, float height, boolean activate)
+```
+
+
+最初のページの width と height を持つ空のドキュメントを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 最初のページの幅。 |
+| height | float | 最初のページの高さ。 |
+| アクティブ化 | boolean | 追加されたドキュメントをアクティブとして選択するかどうかを示すフラグ。 |
+
+### addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+アクティブなページに新しいグリフを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | フォントリソース。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+アクティブなページに新しいグリフを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addOutlineEntry(String description, int outlineLevel, XpsHyperlinkTarget target) {#addOutlineEntry-java.lang.String-int-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void addOutlineEntry(String description, int outlineLevel, XpsHyperlinkTarget target)
+```
+
+
+ドキュメントにアウトラインエントリを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 説明 | java.lang.String | エントリの説明。 |
+| outlineLevel | int | アウトラインレベル。 |
+| target | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | エントリターゲット。 |
+
+### addPage() {#addPage--}
+```
+public XpsPage addPage()
+```
+
+
+デフォルトのページサイズで空のページをドキュメントに追加します。
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(boolean activate) {#addPage-boolean-}
+```
+public XpsPage addPage(boolean activate)
+```
+
+
+デフォルトのページサイズで空のページをドキュメントに追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| アクティブ化 | boolean | 追加されたページをアクティブとして選択するかどうかを示すフラグ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(XpsPage page) {#addPage-com.aspose.xps.XpsPage-}
+```
+public XpsPage addPage(XpsPage page)
+```
+
+
+ページをドキュメントに追加し、追加されたページをアクティブに選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 追加されるページ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(XpsPage page, boolean activate) {#addPage-com.aspose.xps.XpsPage-boolean-}
+```
+public XpsPage addPage(XpsPage page, boolean activate)
+```
+
+
+ページをドキュメントに追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 追加されるページ。 |
+| アクティブ化 | boolean | 追加されたページをアクティブとして選択するかどうかを示すフラグ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(float width, float height) {#addPage-float-float-}
+```
+public XpsPage addPage(float width, float height)
+```
+
+
+指定された width と height を持つ空のページをドキュメントに追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 新しいページの幅。 |
+| height | float | 新しいページの高さ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(float width, float height, boolean activate) {#addPage-float-float-boolean-}
+```
+public XpsPage addPage(float width, float height, boolean activate)
+```
+
+
+指定された width と height を持つ空のページをドキュメントに追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| width | float | 新しいページの幅。 |
+| height | float | 新しいページの高さ。 |
+| アクティブ化 | boolean | 追加されたページをアクティブとして選択するかどうかを示すフラグ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPath(XpsPathGeometry data) {#addPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath addPath(XpsPathGeometry data)
+```
+
+
+アクティブなページに新しいパスを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Added path.
+### close() {#close--}
+```
+public void close()
+```
+
+
+インスタンスを破棄します。
+
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)
+```
+
+
+新しいストロークされた楕円弧セグメントを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | java.awt.geom.Point2D | 楕円弧の終点。 |
+| size | java.awt.geom.Dimension2D | 楕円弧の x と y の半径（x,y のペア）。 |
+| rotationAngle | float | 楕円が現在の座標系に対してどのように回転しているかを示します。 |
+| isLargeArc | boolean | 弧が 180 度以上のスイープで描画されるかどうかを決定します。 |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 弧が描画される方向。 |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)
+```
+
+
+新しい楕円弧セグメントを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | java.awt.geom.Point2D | 楕円弧の終点。 |
+| size | java.awt.geom.Dimension2D | 楕円弧の x と y の半径（x,y のペア）。 |
+| rotationAngle | float | 楕円が現在の座標系に対してどのように回転しているかを示します。 |
+| isLargeArc | boolean | 弧が 180 度以上のスイープで描画されるかどうかを決定します。 |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 弧が描画される方向。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createCanvas() {#createCanvas--}
+```
+public XpsCanvas createCanvas()
+```
+
+
+新しいキャンバスを作成します。
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - New canvas.
+### createColor(XpsIccProfile iccProfile, float[] components) {#createColor-com.aspose.xps.XpsIccProfile-float...-}
+```
+public XpsColor createColor(XpsIccProfile iccProfile, float[] components)
+```
+
+
+ICCベースのカラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| iccProfile | [XpsIccProfile](../../com.aspose.xps/xpsiccprofile) | ICC プロファイルリソース。 |
+| components | float[] | 色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float r, float g, float b) {#createColor-float-float-float-}
+```
+public XpsColor createColor(float r, float g, float b)
+```
+
+
+scRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| r | float | 赤色コンポーネント。 |
+| g | float | 緑色コンポーネント。 |
+| b | float | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float a, float r, float g, float b) {#createColor-float-float-float-float-}
+```
+public XpsColor createColor(float a, float r, float g, float b)
+```
+
+
+scRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | float | アルファ色コンポーネント。 |
+| r | float | 赤色コンポーネント。 |
+| g | float | 緑色コンポーネント。 |
+| b | float | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int r, int g, int b) {#createColor-int-int-int-}
+```
+public XpsColor createColor(int r, int g, int b)
+```
+
+
+sRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| r | int | 赤色コンポーネント。 |
+| g | int | 緑色コンポーネント。 |
+| b | int | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int a, int r, int g, int b) {#createColor-int-int-int-int-}
+```
+public XpsColor createColor(int a, int r, int g, int b)
+```
+
+
+sRGB カラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | int | アルファ色コンポーネント。 |
+| r | int | 赤色コンポーネント。 |
+| g | int | 緑色コンポーネント。 |
+| b | int | 青色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(Color color) {#createColor-java.awt.Color-}
+```
+public XpsColor createColor(Color color)
+```
+
+
+新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | java.awt.Color | RGB カラー用のネイティブカラーインスタンスです。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(String path, float[] components) {#createColor-java.lang.String-float...-}
+```
+public XpsColor createColor(String path, float[] components)
+```
+
+
+ICCベースのカラースペースで新しい色を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.lang.String | ICC プロファイルへのパスです。 |
+| components | float[] | 色コンポーネント。 |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createFont(InputStream stream) {#createFont-java.io.InputStream-}
+```
+public XpsFont createFont(InputStream stream)
+```
+
+
+stream から新しい TrueType フォントリソースを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | リソースとして使用する ICC プロファイルを含むストリーム。 |
+
+**Returns:**
+[XpsFont](../../com.aspose.xps/xpsfont) - New TrueType font resource.
+### createFont(String fontFamily, XpsFontStyle fontStyle) {#createFont-java.lang.String-com.aspose.xps.XpsFontStyle-}
+```
+public XpsFont createFont(String fontFamily, XpsFontStyle fontStyle)
+```
+
+
+新しい TrueType フォントリソースを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。組み合わせ可能な値については、 XpsFont  クラス定数（ビットフラグ）を参照してください。 |
+
+**Returns:**
+[XpsFont](../../com.aspose.xps/xpsfont) - New TrueType font resource.
+### createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+新しいグリフを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | フォントリソース。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+新しいグリフを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontRenderingEmSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGradientStop(XpsColor color, float offset) {#createGradientStop-com.aspose.xps.XpsColor-float-}
+```
+public XpsGradientStop createGradientStop(XpsColor color, float offset)
+```
+
+
+新しいグラデーションストップを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | グラデーションストップカラーです。 |
+| オフセット | float | グラデーションのオフセットです。 |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createGradientStop(Color color, float offset) {#createGradientStop-java.awt.Color-float-}
+```
+public XpsGradientStop createGradientStop(Color color, float offset)
+```
+
+
+新しいグラデーションストップを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | java.awt.Color | グラデーションストップカラーです。 |
+| オフセット | float | グラデーションのオフセットです。 |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createIccProfile(InputStream stream) {#createIccProfile-java.io.InputStream-}
+```
+public XpsIccProfile createIccProfile(InputStream stream)
+```
+
+
+stream から新しい ICC プロファイルリソースを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | リソースとして使用する ICC プロファイルを含むストリーム。 |
+
+**Returns:**
+[XpsIccProfile](../../com.aspose.xps/xpsiccprofile) - New ICC profile resource.
+### createIccProfile(String iccProfilePath) {#createIccProfile-java.lang.String-}
+```
+public XpsIccProfile createIccProfile(String iccProfilePath)
+```
+
+
+iccProfilePath にある ICC プロファイルファイルから新しい ICC プロファイルリソースを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| iccProfilePath | java.lang.String | リソースとして使用する ICC プロファイルへのパス。 |
+
+**Returns:**
+[XpsIccProfile](../../com.aspose.xps/xpsiccprofile) - New ICC profile resource.
+### createImage(InputStream stream) {#createImage-java.io.InputStream-}
+```
+public XpsImage createImage(InputStream stream)
+```
+
+
+stream から新しい画像リソースを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.InputStream | リソースとして使用する画像を含むストリーム。 |
+
+**Returns:**
+[XpsImage](../../com.aspose.xps/xpsimage) - New image resource.
+### createImage(String imagePath) {#createImage-java.lang.String-}
+```
+public XpsImage createImage(String imagePath)
+```
+
+
+imagePath にある画像ファイルから新しい画像リソースを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| イメージパス | java.lang.String | リソースとして使用する画像へのパス。 |
+
+**Returns:**
+[XpsImage](../../com.aspose.xps/xpsimage) - New image resource.
+### createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+新しいイメージブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| image | [XpsImage](../../com.aspose.xps/xpsimage) | 画像リソースです。 |
+| ビュー ボックス | java.awt.geom.Rectangle2D | ブラシのソースコンテンツの位置とサイズです。 |
+| ビューポート | java.awt.geom.Rectangle2D | プライムブラシタイルが含まれる座標空間内の領域で、（必要に応じて繰り返し）ブラシが適用される領域を埋めるために適用される領域です。 |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+新しいイメージブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| イメージパス | java.lang.String | ブラシタイルとして使用する画像へのパスです。 |
+| ビュー ボックス | java.awt.geom.Rectangle2D | ブラシのソースコンテンツの位置とサイズです。 |
+| ビューポート | java.awt.geom.Rectangle2D | プライムブラシタイルが含まれる座標空間内の領域で、（必要に応じて繰り返し）ブラシが適用される領域を埋めるために適用される領域です。 |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createLinearGradientBrush(Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(Point2D startPoint, Point2D endPoint)
+```
+
+
+新しい線形グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | 線形グラデーションの開始点です。 |
+| 終了点 | java.awt.geom.Point2D | 線形グラデーションの終了点です。 |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)
+```
+
+
+新しい線形グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| グラデーションストップ | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションストップのリストです。 |
+| 開始点 | java.awt.geom.Point2D | 線形グラデーションの開始点です。 |
+| 終了点 | java.awt.geom.Point2D | 線形グラデーションの終了点です。 |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createMatrix(float m11, float m12, float m21, float m22, float m31, float m32) {#createMatrix-float-float-float-float-float-float-}
+```
+public XpsMatrix createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)
+```
+
+
+新しいアフィン変換行列を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| m11 | float | 要素 11です。 |
+| m12 | float | 要素 12です。 |
+| m21 | float | 要素 21です。 |
+| m22 | float | 要素 22です。 |
+| m31 | float | 要素 31。 |
+| m32 | float | 要素 32。 |
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - New affine transformation matrix.
+### createPath(XpsPathGeometry data) {#createPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath createPath(XpsPathGeometry data)
+```
+
+
+新しいパスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - New path.
+### createPathFigure(Point2D startPoint) {#createPathFigure-java.awt.geom.Point2D-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint)
+```
+
+
+新しいオープンパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, boolean isClosed)
+```
+
+
+新しいパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+| isClosed | boolean | パスが閉じているかどうかを指定します。true に設定すると、ストロークは "closed" と描画され、つまりパス図形の最後のセグメントの最後の点が StartPoint 属性で指定された点と接続されます。false の場合、ストロークは "open" と描画され、最後の点は開始点と接続されません。これは、ストロークを指定する Path 要素でパス図形が使用されている場合にのみ適用されます。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)
+```
+
+
+新しいオープンパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | パスセグメントのリスト。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)
+```
+
+
+新しいパス図形を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 開始点 | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | パスセグメントのリスト。 |
+| isClosed | boolean | パスが閉じているかどうかを指定します。true に設定すると、ストロークは "closed" と描画され、つまりパス図形の最後のセグメントの最後の点が StartPoint 属性で指定された点と接続されます。false の場合、ストロークは "open" と描画され、最後の点は開始点と接続されません。これは、ストロークを指定する Path 要素でパス図形が使用されている場合にのみ適用されます。 |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathGeometry() {#createPathGeometry--}
+```
+public XpsPathGeometry createPathGeometry()
+```
+
+
+新しいパスジオメトリを作成します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(String abbreviatedGeometry) {#createPathGeometry-java.lang.String-}
+```
+public XpsPathGeometry createPathGeometry(String abbreviatedGeometry)
+```
+
+
+省略形で指定された新しいパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| abbreviatedGeometry | java.lang.String | パスジオメトリの省略形。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(List<XpsPathFigure> pathFigures) {#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--}
+```
+public XpsPathGeometry createPathGeometry(List<XpsPathFigure> pathFigures)
+```
+
+
+指定されたパス図形のリストで新しいパスジオメトリを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pathFigures | java.util.List<com.aspose.xps.XpsPathFigure> | パス図形のリスト。 |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPolyBezierSegment(Point2D[] points) {#createPolyBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points)
+```
+
+
+ストロークされた立方ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数のベジエセグメントの制御点。 |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyBezierSegment(Point2D[] points, boolean isStroked) {#createPolyBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+立方ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数のベジエセグメントの制御点。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyLineSegment(Point2D[] points) {#createPolyLineSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points)
+```
+
+
+任意の数の個々の頂点を含む新しいストロークされた多角形描画を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | ポリラインセグメントを定義する複数のセグメントの座標セット。 |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyLineSegment(Point2D[] points, boolean isStroked) {#createPolyLineSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points, boolean isStroked)
+```
+
+
+任意の数の個々の頂点を含む新しい多角形描画を作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | ポリラインセグメントを定義する複数のセグメントの座標セット。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyQuadraticBezierSegment(Point2D[] points) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points)
+```
+
+
+パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、ストロークされた二次ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数の二次ベジエセグメントの制御点。 |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+パス図形の前の点から指定された制御点を使用して頂点のセットを通過する、二次ベジエ曲線の新しいセットを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 複数の二次ベジエセグメントの制御点。 |
+| isStroked | boolean | パスのこのセグメントのストロークが描画されるかどうかを指定します。 |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+新しい放射状グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 放射状グラデーションの中心点（すなわち楕円の中心）。 |
+| gradientOrigin | java.awt.geom.Point2D | 放射状グラデーションの起点。 |
+| radiusX | float | 放射状グラデーションを定義する楕円の x 軸方向の半径です。 |
+| radiusY | float | 放射状グラデーションを定義する楕円の y 軸方向の半径です。 |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+新しい放射状グラデーションブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| グラデーションストップ | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションストップのリストです。 |
+| center | java.awt.geom.Point2D | 放射状グラデーションの中心点（すなわち楕円の中心）。 |
+| gradientOrigin | java.awt.geom.Point2D | 放射状グラデーションの起点。 |
+| radiusX | float | 放射状グラデーションを定義する楕円の x 軸方向の半径です。 |
+| radiusY | float | 放射状グラデーションを定義する楕円の y 軸方向の半径です。 |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createSolidColorBrush(XpsColor color) {#createSolidColorBrush-com.aspose.xps.XpsColor-}
+```
+public XpsSolidColorBrush createSolidColorBrush(XpsColor color)
+```
+
+
+新しい単色ブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | 塗りつぶし要素の色です。 |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createSolidColorBrush(Color color) {#createSolidColorBrush-java.awt.Color-}
+```
+public XpsSolidColorBrush createSolidColorBrush(Color color)
+```
+
+
+新しい単色ブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| color | java.awt.Color | 塗りつぶし要素の色です。 |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport) {#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsVisualBrush createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+新しいビジュアルブラシを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| element | [XpsContentElement](../../com.aspose.xps/xpscontentelement) | Visual プロパティ（ビジュアルブラシ）のための XPS 要素（Canvas、Path、または Glyphs）。 |
+| ビュー ボックス | java.awt.geom.Rectangle2D | ブラシのソースコンテンツの位置とサイズです。 |
+| ビューポート | java.awt.geom.Rectangle2D | プライムブラシタイルが含まれる座標空間内の領域で、（必要に応じて繰り返し）ブラシが適用される領域を埋めるために適用される領域です。 |
+
+**Returns:**
+[XpsVisualBrush](../../com.aspose.xps/xpsvisualbrush) - New visual brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveDocument() {#getActiveDocument--}
+```
+public int getActiveDocument()
+```
+
+
+アクティブなドキュメント番号を返します。
+
+**Returns:**
+int - 整数値。
+### getActivePage() {#getActivePage--}
+```
+public int getActivePage()
+```
+
+
+アクティブなドキュメント内のアクティブなページ番号を返します。
+
+**Returns:**
+int - 整数値。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDocumentCount() {#getDocumentCount--}
+```
+public int getDocumentCount()
+```
+
+
+XPS パッケージ内のドキュメント数を返します。
+
+**Returns:**
+int - XPS パッケージ内のドキュメント数。
+### getDocumentPrintTicket(int documentIndex) {#getDocumentPrintTicket-int-}
+```
+public DocumentPrintTicket getDocumentPrintTicket(int documentIndex)
+```
+
+
+documentIndex でインデックスされたドキュメントの印刷チケットを取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentIndex | int | 返却する印刷チケットを持つドキュメントのインデックス。 |
+
+**Returns:**
+[DocumentPrintTicket](../../com.aspose.xps.metadata/documentprintticket) - Document's print ticket.
+### getJobPrintTicket() {#getJobPrintTicket--}
+```
+public JobPrintTicket getJobPrintTicket()
+```
+
+
+ドキュメントのジョブ印刷チケットを返します。
+
+**Returns:**
+[JobPrintTicket](../../com.aspose.xps.metadata/jobprintticket) - The document's job print ticket.
+### getPage() {#getPage--}
+```
+public XpsPage getPage()
+```
+
+
+アクティブなページの XpsPage インスタンスを返します。
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - The  XpsPage  instance for active page.
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+アクティブなドキュメントのページ数を返します。
+
+**Returns:**
+int - アクティブなドキュメントのページ数です。
+### getPagePrintTicket(int documentIndex, int pageIndex) {#getPagePrintTicket-int-int-}
+```
+public PagePrintTicket getPagePrintTicket(int documentIndex, int pageIndex)
+```
+
+
+documentIndex でインデックスされたドキュメント内の pageIndex でインデックスされたページの印刷チケットを取得します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentIndex | int | ドキュメントのインデックス。 |
+| pageIndex | int | 返却する印刷チケットを持つページのインデックス。 |
+
+**Returns:**
+[PagePrintTicket](../../com.aspose.xps.metadata/pageprintticket) - Page's print ticket.
+### getTotalPageCount() {#getTotalPageCount--}
+```
+public int getTotalPageCount()
+```
+
+
+XPS ドキュメント内のすべてのドキュメントの総ページ数を返します。
+
+**Returns:**
+int - XPS ドキュメント内のすべてのドキュメントの総ページ数です。
+### getUtils() {#getUtils--}
+```
+public DocumentUtils getUtils()
+```
+
+
+正式な XPS 操作 API を超えるユーティリティを提供するオブジェクトを取得します。
+
+**Returns:**
+[DocumentUtils](../../com.aspose.xps/documentutils) - The utilities object.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insertCanvas(int index) {#insertCanvas-int-}
+```
+public XpsCanvas insertCanvas(int index)
+```
+
+
+index の位置にアクティブなページへ新しいキャンバスを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Canvas を挿入すべき位置です。 |
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Inserted canvas.
+### insertDocument(int index) {#insertDocument-int-}
+```
+public void insertDocument(int index)
+```
+
+
+index の位置にデフォルトのページサイズの空のドキュメントを挿入し、挿入されたドキュメントをアクティブに選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ドキュメントを挿入すべき位置。 |
+
+### insertDocument(int index, boolean activate) {#insertDocument-int-boolean-}
+```
+public void insertDocument(int index, boolean activate)
+```
+
+
+index の位置にデフォルトのページサイズの空のドキュメントを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ドキュメントを挿入すべき位置。 |
+| アクティブ化 | boolean | 挿入されたドキュメントをアクティブとして選択するかどうかを示すフラグ。 |
+
+### insertDocument(int index, float width, float height) {#insertDocument-int-float-float-}
+```
+public void insertDocument(int index, float width, float height)
+```
+
+
+index の位置に最初のページの width と height を持つ空のドキュメントを挿入し、挿入されたドキュメントをアクティブに選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ドキュメントを挿入すべき位置。 |
+| width | float | 最初のページの幅。 |
+| height | float | 最初のページの高さ。 |
+
+### insertDocument(int index, float width, float height, boolean activate) {#insertDocument-int-float-float-boolean-}
+```
+public void insertDocument(int index, float width, float height, boolean activate)
+```
+
+
+インデックス 位置 に、width と height の最初のページ寸法を持つ空のドキュメントを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ドキュメントを挿入すべき位置。 |
+| width | float | 最初のページの幅。 |
+| height | float | 最初のページの高さ。 |
+| アクティブ化 | boolean | 挿入されたドキュメントをアクティブとして選択するかどうかを示すフラグ。 |
+
+### insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString) {#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)
+```
+
+
+インデックス 位置 にアクティブページへ新しいグリフを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Glyphs を挿入すべき位置です。 |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | フォントリソース。 |
+| fontSize | float | フォントサイズ。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+インデックス 位置 にアクティブページへ新しいグリフを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Glyphs を挿入すべき位置です。 |
+| fontFamily | java.lang.String | フォントファミリー。 |
+| fontSize | float | フォントサイズ。 |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | フォントスタイル。 |
+| originX | float | グリフの原点 X 座標。 |
+| originY | float | グリフの原点 Y 座標。 |
+| unicodeString | java.lang.String | 印刷される文字列。 |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertPage(int index) {#insertPage-int-}
+```
+public XpsPage insertPage(int index)
+```
+
+
+インデックス 位置 にデフォルトページサイズの空ページをドキュメントに挿入し、挿入されたページをアクティブに選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを挿入すべき位置。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, boolean activate) {#insertPage-int-boolean-}
+```
+public XpsPage insertPage(int index, boolean activate)
+```
+
+
+インデックス 位置 にデフォルトページサイズの空ページをドキュメントに挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを挿入すべき位置。 |
+| アクティブ化 | boolean | 挿入されたページをアクティブとして選択するかどうかを示すフラグ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, XpsPage page) {#insertPage-int-com.aspose.xps.XpsPage-}
+```
+public XpsPage insertPage(int index, XpsPage page)
+```
+
+
+インデックス 位置 にページをドキュメントに挿入し、挿入されたページをアクティブに選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを追加すべき位置。 |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 挿入するページ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, XpsPage page, boolean activate) {#insertPage-int-com.aspose.xps.XpsPage-boolean-}
+```
+public XpsPage insertPage(int index, XpsPage page, boolean activate)
+```
+
+
+インデックス 位置 にページをドキュメントに挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを追加すべき位置。 |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 挿入するページ。 |
+| アクティブ化 | boolean | 挿入されたページをアクティブとして選択するかどうかを示すフラグ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, float width, float height) {#insertPage-int-float-float-}
+```
+public XpsPage insertPage(int index, float width, float height)
+```
+
+
+インデックス 位置 に指定された width と height の空ページをドキュメントに挿入し、挿入されたページをアクティブに選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを挿入すべき位置。 |
+| width | float | 新しいページの幅。 |
+| height | float | 新しいページの高さ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, float width, float height, boolean activate) {#insertPage-int-float-float-boolean-}
+```
+public XpsPage insertPage(int index, float width, float height, boolean activate)
+```
+
+
+インデックス 位置 に指定された width と height の空ページをドキュメントに挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを挿入すべき位置。 |
+| width | float | 新しいページの幅。 |
+| height | float | 新しいページの高さ。 |
+| アクティブ化 | boolean | 挿入されたページをアクティブとして選択するかどうかを示すフラグ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPath(int index, XpsPathGeometry data) {#insertPath-int-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath insertPath(int index, XpsPathGeometry data)
+```
+
+
+インデックス 位置 にアクティブページへ新しいパスを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 新しい Path を挿入すべき位置です。 |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Inserted path.
+### isLicensed() {#isLicensed--}
+```
+public boolean isLicensed()
+```
+
+
+Aspose.Page for Java 製品ライセンスがアクセスされ、有効かどうかを示します。
+
+**Returns:**
+boolean - 真偽値
+### merge(String[] filesForMerge, OutputStream outStream) {#merge-java.lang.String---java.io.OutputStream-}
+```
+public void merge(String[] filesForMerge, OutputStream outStream)
+```
+
+
+複数の XPS ファイルを 1 つの XPS ドキュメントに結合します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | このドキュメントとマージする XPS ファイル。 |
+| outStream | java.io.OutputStream | マージされた XPS ドキュメントを保存する出力ストリーム。 |
+
+### merge(String[] filesForMerge, String outXpsFilePath) {#merge-java.lang.String---java.lang.String-}
+```
+public void merge(String[] filesForMerge, String outXpsFilePath)
+```
+
+
+複数の XPS ファイルを 1 つの XPS ドキュメントに結合します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | このドキュメントとマージする XPS ファイル。 |
+| outXpsFilePath | java.lang.String | 出力 XPS ファイルのパス。 |
+
+### mergeToPdf(String outPdfFilePath, String[] filesForMerge, PdfSaveOptions options) {#mergeToPdf-java.lang.String-java.lang.String---com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void mergeToPdf(String outPdfFilePath, String[] filesForMerge, PdfSaveOptions options)
+```
+
+
+Device インスタンスを使用して XPS ドキュメントを PDF に結合します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 出力 PDF ファイルのパス。 |
+| filesForMerge | java.lang.String[] | このドキュメントを出力デバイスにマージするための XPS ファイル。 |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | ドキュメント保存オプション。 |
+
+### mergeToPdf(String[] filesForMerge, OutputStream pdfStream, PdfSaveOptions options) {#mergeToPdf-java.lang.String---java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void mergeToPdf(String[] filesForMerge, OutputStream pdfStream, PdfSaveOptions options)
+```
+
+
+Device インスタンスを使用して XPS ドキュメントを PDF に結合します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | このドキュメントを出力デバイスにマージするための XPS ファイル。 |
+| pdfStream | java.io.OutputStream | 結果の PDF を書き込む出力ストリーム。 |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | ドキュメント保存オプション。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public XpsContentElement removeAt(int index)
+```
+
+
+インデックス 位置 からアクティブページの要素を削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | 要素を削除すべき位置です。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Removed element.
+### removeDocumentAt(int index) {#removeDocumentAt-int-}
+```
+public void removeDocumentAt(int index)
+```
+
+
+インデックス 位置 のドキュメントを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ドキュメントを削除すべき位置。 |
+
+### removePage(XpsPage page) {#removePage-com.aspose.xps.XpsPage-}
+```
+public XpsPage removePage(XpsPage page)
+```
+
+
+ドキュメントからページを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 削除するページ。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Removed page.
+### removePageAt(int index) {#removePageAt-int-}
+```
+public XpsPage removePageAt(int index)
+```
+
+
+インデックス 位置 のドキュメントからページを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | ページを削除すべき位置。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Removed page.
+### save(Device device, SaveOptions options) {#save-com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public void save(Device device, SaveOptions options)
+```
+
+
+Device インスタンスを使用してドキュメントを保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| device | [Device](../../com.aspose.page/device) | Device のインスタンス。 |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | ドキュメント保存オプション。 |
+
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+XPS ドキュメントをストリームに保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | 保存先となる XPS ドキュメントのストリーム。 |
+
+### save(String path) {#save-java.lang.String-}
+```
+public void save(String path)
+```
+
+
+path にある XPS ファイルに XPS ドキュメントを保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| path | java.lang.String | ドキュメントの場所。 |
+
+### saveAsImage(ImageSaveOptions options) {#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-}
+```
+public void saveAsImage(ImageSaveOptions options)
+```
+
+
+ドキュメントを画像ファイルに保存します。出力ディレクトリとファイル名は入力 XPS ファイルと同じになります。ファイル拡張子は "options" パラメーターの画像形式に対応します。ドキュメントが FileInputStream 以外のストリームで初期化されている場合、画像ファイルはデフォルトのファイル名テンプレートで現在のフォルダーに保存されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions) | ビットマップ画像形式でドキュメントを保存するためのオプション。 |
+
+### saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate) {#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-java.lang.String-java.lang.String-}
+```
+public void saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)
+```
+
+
+指定されたディレクトリとファイル名でドキュメントを画像ファイルに保存します。ファイル拡張子は "options" パラメーターの画像形式に対応します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions) | ビットマップ画像形式でドキュメントを保存するためのオプション。 |
+| outDir | java.lang.String | 画像ファイルが保存される出力ディレクトリ。 |
+| fileNameTemplate | java.lang.String | 画像のファイル名テンプレート（拡張子なし）。入力 XPS ファイルが 1 ページの場合は正確にそのファイル名になります。それ以外の場合は "\_[n]" となり、"n" は 1 から始まるページ番号です。この後にサフィックスが付加されます。ファイル拡張子は "option" パラメーターの画像形式に対応します。 |
+
+### saveAsImageBytes(ImageSaveOptions options) {#saveAsImageBytes-com.aspose.xps.rendering.ImageSaveOptions-}
+```
+public byte[][][] saveAsImageBytes(ImageSaveOptions options)
+```
+
+
+ドキュメントをビットマップ画像形式でバイト配列として保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions) | ビットマップ画像形式でドキュメントを保存するためのオプション。 |
+
+**Returns:**
+byte[][][] - 結果として得られる画像のバイト配列。第1次元は内部ドキュメント用、第2次元は内部ドキュメント内のページ用です。
+### saveAsPdf(OutputStream stream, PdfSaveOptions options) {#saveAsPdf-java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void saveAsPdf(OutputStream stream, PdfSaveOptions options)
+```
+
+
+ドキュメントを PDF 形式で保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | 出力 PDF ファイルを書き込むストリーム。 |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | PDF 形式でドキュメントを保存するためのオプション。 |
+
+### saveAsPdf(String outPdfFilePath, PdfSaveOptions options) {#saveAsPdf-java.lang.String-com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void saveAsPdf(String outPdfFilePath, PdfSaveOptions options)
+```
+
+
+ドキュメントを PDF 形式で保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 出力 PDF ファイルのパス。 |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | PDF 形式でドキュメントを保存するためのオプション。 |
+
+### saveAsPs(OutputStream stream, PsSaveOptions options) {#saveAsPs-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public void saveAsPs(OutputStream stream, PsSaveOptions options)
+```
+
+
+ドキュメントを PS 形式で保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ストリーム | java.io.OutputStream | 出力 PS ファイルを書き込むストリーム。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PS 形式でドキュメントを保存するためのオプション。 |
+
+### saveAsPs(String outPsFilePath, PsSaveOptions options) {#saveAsPs-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public void saveAsPs(String outPsFilePath, PsSaveOptions options)
+```
+
+
+ドキュメントを PostSscript 形式で保存します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 出力 PostScript ファイルのパス。 |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PDF 形式でドキュメントを保存するためのオプション。 |
+
+### selectActiveDocument(int documentNumber) {#selectActiveDocument-int-}
+```
+public void selectActiveDocument(int documentNumber)
+```
+
+
+編集用にアクティブなドキュメントを選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentNumber | int | ドキュメント番号。 |
+
+### selectActivePage(int pageNumber) {#selectActivePage-int-}
+```
+public XpsPage selectActivePage(int pageNumber)
+```
+
+
+編集用にアクティブなドキュメントページを選択します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| pageNumber | int | ページ番号。 |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) -  XpsPage  instance for active page.
+### setDocumentPrintTicket(int documentIndex, DocumentPrintTicket printTicket) {#setDocumentPrintTicket-int-com.aspose.xps.metadata.DocumentPrintTicket-}
+```
+public void setDocumentPrintTicket(int documentIndex, DocumentPrintTicket printTicket)
+```
+
+
+printTicket を documentIndex でインデックス付けされたドキュメントにリンクします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentIndex | int | 印刷チケットをリンクするドキュメントのインデックス。 |
+| printTicket | [DocumentPrintTicket](../../com.aspose.xps.metadata/documentprintticket) | リンクする印刷チケット。 |
+
+### setJobPrintTicket(JobPrintTicket value) {#setJobPrintTicket-com.aspose.xps.metadata.JobPrintTicket-}
+```
+public void setJobPrintTicket(JobPrintTicket value)
+```
+
+
+ドキュメントのジョブ印刷チケットを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [JobPrintTicket](../../com.aspose.xps.metadata/jobprintticket) | ドキュメントのジョブ印刷チケット。 |
+
+### setPagePrintTicket(int documentIndex, int pageIndex, PagePrintTicket printTicket) {#setPagePrintTicket-int-int-com.aspose.xps.metadata.PagePrintTicket-}
+```
+public void setPagePrintTicket(int documentIndex, int pageIndex, PagePrintTicket printTicket)
+```
+
+
+printTicket を documentIndex でインデックス付けされたドキュメント内の pageIndex でインデックス付けされたページにリンクします。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| documentIndex | int | ドキュメントのインデックス。 |
+| pageIndex | int | 印刷チケットをリンクするページのインデックス。 |
+| printTicket | [PagePrintTicket](../../com.aspose.xps.metadata/pageprintticket) | リンクする印刷チケット。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsedgemode/_index.md
+++ b/japanese/java/com.aspose.xps/xpsedgemode/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsEdgeMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Canvas 要素の RenderOptions.EdgeMode プロパティの有効な値。"
+type: docs
+weight: 58
+url: /ja/java/com.aspose.xps/xpsedgemode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsEdgeMode extends Enum<XpsEdgeMode>
+```
+
+Canvas 要素の RenderOptions.EdgeMode プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Aliased](#Aliased) | エッジはエイリアス処理されます。 |
+| [None](#None) | エッジはコンシューマーのデフォルト方式でレンダリングされます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Aliased {#Aliased}
+```
+public static final XpsEdgeMode Aliased
+```
+
+
+エッジはエイリアス処理されます。
+
+### None {#None}
+```
+public static final XpsEdgeMode None
+```
+
+
+エッジはコンシューマーのデフォルト方式でレンダリングされます。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsEdgeMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsEdgeMode](../../com.aspose.xps/xpsedgemode)
+### values() {#values--}
+```
+public static XpsEdgeMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsEdgeMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpselement/_index.md
+++ b/japanese/java/com.aspose.xps/xpselement/_index.md
@@ -1,0 +1,165 @@
+---
+title: "XpsElement"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の XPS 要素機能をカプセル化するクラス。"
+type: docs
+weight: 20
+url: /ja/java/com.aspose.xps/xpselement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class XpsElement extends XpsObject implements Iterable<XpsContentElement>
+```
+
+共通の XPS 要素機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpselementlinktarget/_index.md
+++ b/japanese/java/com.aspose.xps/xpselementlinktarget/_index.md
@@ -1,0 +1,184 @@
+---
+title: "XpsElementLinkTarget"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "相対的な名前付きアドレスハイパーリンクターゲットをカプセル化するクラス。"
+type: docs
+weight: 21
+url: /ja/java/com.aspose.xps/xpselementlinktarget/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget)
+```
+public final class XpsElementLinkTarget extends XpsHyperlinkTarget
+```
+
+相対的な名前付きアドレスハイパーリンクターゲットをカプセル化するクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsElementLinkTarget(XpsPage targetPage)](#XpsElementLinkTarget-com.aspose.xps.XpsPage-) | 新しいインスタンスを作成します。 |
+| [XpsElementLinkTarget(XpsCanvas targetCanvas)](#XpsElementLinkTarget-com.aspose.xps.XpsCanvas-) | 新しいインスタンスを作成します。 |
+| [XpsElementLinkTarget(XpsPath targetPath)](#XpsElementLinkTarget-com.aspose.xps.XpsPath-) | 新しいインスタンスを作成します。 |
+| [XpsElementLinkTarget(XpsGlyphs targetGlyphs)](#XpsElementLinkTarget-com.aspose.xps.XpsGlyphs-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsElementLinkTarget(XpsPage targetPage) {#XpsElementLinkTarget-com.aspose.xps.XpsPage-}
+```
+public XpsElementLinkTarget(XpsPage targetPage)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| targetPage | [XpsPage](../../com.aspose.xps/xpspage) | アクティブな固定ドキュメント内のページ要素です。 |
+
+### XpsElementLinkTarget(XpsCanvas targetCanvas) {#XpsElementLinkTarget-com.aspose.xps.XpsCanvas-}
+```
+public XpsElementLinkTarget(XpsCanvas targetCanvas)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| targetCanvas | [XpsCanvas](../../com.aspose.xps/xpscanvas) | アクティブな固定ドキュメント内のキャンバス要素です。 |
+
+### XpsElementLinkTarget(XpsPath targetPath) {#XpsElementLinkTarget-com.aspose.xps.XpsPath-}
+```
+public XpsElementLinkTarget(XpsPath targetPath)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| targetPath | [XpsPath](../../com.aspose.xps/xpspath) | アクティブな固定ドキュメント内のパス要素です。 |
+
+### XpsElementLinkTarget(XpsGlyphs targetGlyphs) {#XpsElementLinkTarget-com.aspose.xps.XpsGlyphs-}
+```
+public XpsElementLinkTarget(XpsGlyphs targetGlyphs)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| targetGlyphs | [XpsGlyphs](../../com.aspose.xps/xpsglyphs) | アクティブな固定ドキュメント内のグリフ要素です。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsexternallinktarget/_index.md
+++ b/japanese/java/com.aspose.xps/xpsexternallinktarget/_index.md
@@ -1,0 +1,153 @@
+---
+title: "XpsExternalLinkTarget"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "外部ハイパーリンクターゲットをカプセル化するクラス。"
+type: docs
+weight: 22
+url: /ja/java/com.aspose.xps/xpsexternallinktarget/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget)
+```
+public final class XpsExternalLinkTarget extends XpsHyperlinkTarget
+```
+
+外部ハイパーリンクターゲットをカプセル化するクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsExternalLinkTarget(String targetUri)](#XpsExternalLinkTarget-java.lang.String-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getTargetUri()](#getTargetUri--) | target URI を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsExternalLinkTarget(String targetUri) {#XpsExternalLinkTarget-java.lang.String-}
+```
+public XpsExternalLinkTarget(String targetUri)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| targetUri | java.lang.String | 外部の target URI。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTargetUri() {#getTargetUri--}
+```
+public String getTargetUri()
+```
+
+
+target URI を取得します。
+
+**Returns:**
+java.lang.String - target URI。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsfileresource/_index.md
+++ b/japanese/java/com.aspose.xps/xpsfileresource/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsFileResource"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "すべてのファイルリソースの共通機能をカプセル化するクラス。"
+type: docs
+weight: 23
+url: /ja/java/com.aspose.xps/xpsfileresource/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class XpsFileResource
+```
+
+すべてのファイルリソースの共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsfillrule/_index.md
+++ b/japanese/java/com.aspose.xps/xpsfillrule/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsFillRule"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PathGeometry 要素の FillRule プロパティの有効な値。"
+type: docs
+weight: 59
+url: /ja/java/com.aspose.xps/xpsfillrule/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsFillRule extends Enum<XpsFillRule>
+```
+
+PathGeometry 要素の FillRule プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [EvenOdd](#EvenOdd) | この規則は、点から任意の方向に無限遠まで光線を引き、その光線が与えられた形状のセグメントと交差する回数を数えることで、キャンバス上の点の \\u201cinsideness\\u201d を決定します。 |
+| [NonZero](#NonZero) | この規則は、点から任意の方向に無限遠まで光線を引き、形状のセグメントが光線と交差する位置を調べることで、キャンバス上の点の \\u201cinsideness\\u201d を決定します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EvenOdd {#EvenOdd}
+```
+public static final XpsFillRule EvenOdd
+```
+
+
+この規則は、点から任意の方向に無限遠まで光線を引き、その光線が与えられた形状のセグメントと交差する回数を数えることで、キャンバス上の点の \\u201cinsideness\\u201d を決定します。回数が奇数の場合、点は内部にあり、偶数の場合、点は外部にあります。
+
+### NonZero {#NonZero}
+```
+public static final XpsFillRule NonZero
+```
+
+
+この規則は、点から任意の方向に無限遠まで光線を引き、形状のセグメントが光線と交差する位置を調べることで、キャンバス上の点の \\u201cinsideness\\u201d を決定します。カウントを0から開始し、セグメントが左から右へ光線を横切るたびに1を加え、右から左へ横切るたびに1を減算します。交差回数を数えた後、結果が0であれば点はパスの外部にあり、そうでなければ内部にあります。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsFillRule valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsFillRule](../../com.aspose.xps/xpsfillrule)
+### values() {#values--}
+```
+public static XpsFillRule[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsFillRule[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsfont/_index.md
+++ b/japanese/java/com.aspose.xps/xpsfont/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsFont"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "TrueType フォントリソースをカプセル化するクラス。"
+type: docs
+weight: 24
+url: /ja/java/com.aspose.xps/xpsfont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsFileResource](../../com.aspose.xps/xpsfileresource)
+```
+public final class XpsFont extends XpsFileResource
+```
+
+TrueType フォントリソースをカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsfontstyle/_index.md
+++ b/japanese/java/com.aspose.xps/xpsfontstyle/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsFontStyle"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "フォントスタイルの有効な値。"
+type: docs
+weight: 60
+url: /ja/java/com.aspose.xps/xpsfontstyle/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsFontStyle extends Enum<XpsFontStyle>
+```
+
+フォントスタイルの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Bold](#Bold) | 太字テキスト。 |
+| [BoldItalic](#BoldItalic) | 太字イタリックテキスト。 |
+| [Italic](#Italic) | イタリックテキスト。 |
+| [Regular](#Regular) | 標準テキスト。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bold {#Bold}
+```
+public static final XpsFontStyle Bold
+```
+
+
+太字テキスト。
+
+### BoldItalic {#BoldItalic}
+```
+public static final XpsFontStyle BoldItalic
+```
+
+
+太字イタリックテキスト。
+
+### Italic {#Italic}
+```
+public static final XpsFontStyle Italic
+```
+
+
+イタリックテキスト。
+
+### Regular {#Regular}
+```
+public static final XpsFontStyle Regular
+```
+
+
+標準テキスト。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsFontStyle valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsFontStyle](../../com.aspose.xps/xpsfontstyle)
+### values() {#values--}
+```
+public static XpsFontStyle[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsFontStyle[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsglyphs/_index.md
+++ b/japanese/java/com.aspose.xps/xpsglyphs/_index.md
@@ -1,0 +1,509 @@
+---
+title: "XpsGlyphs"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Glyphs 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 25
+url: /ja/java/com.aspose.xps/xpsglyphs/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement), [com.aspose.xps.XpsContentElement](../../com.aspose.xps/xpscontentelement)
+```
+public final class XpsGlyphs extends XpsContentElement
+```
+
+Glyphs 要素の機能をカプセル化するクラスです。この要素は単一フォントからの均一にフォーマットされたテキストのランを表します。正確なレンダリングに必要な情報を提供し、ビューアの検索および選択機能をサポートします。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このグリフをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getBidiLevel()](#getBidiLevel--) | Unicode アルゴリズムの双方向入れ子レベルを指定する値を返します。 |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 要素の描画領域を制限するパスジオメトリを返します。 |
+| [getFill()](#getFill--) | レンダリングされたグリフの形状を塗りつぶすために使用されるブラシを返します。 |
+| [getFont()](#getFont--) | 要素のテキスト組版に使用される TrueType フォントのフォントリソースを返します。 |
+| [getFontRenderingEmSize()](#getFontRenderingEmSize--) | 有効座標空間の単位で浮動小数点数として表された、描画サーフェス単位のフォントサイズを返します。 |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | ハイパーリンクのターゲットオブジェクトを返します。 |
+| [getOpacity()](#getOpacity--) | 要素の均一な透明度を定義する値を返します。 |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [getOriginX()](#getOriginX--) | ラン内の最初のグリフの x 座標を、有効座標空間の単位で返します。 |
+| [getOriginY()](#getOriginY--) | ラン内の最初のグリフの y 座標を、有効座標空間の単位で返します。 |
+| [getRenderTransform()](#getRenderTransform--) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。 |
+| [getStyleSimulations()](#getStyleSimulations--) | スタイルシミュレーションを指定する値を返します。 |
+| [getUnicodeString()](#getUnicodeString--) | Glyphs 要素によってレンダリングされたテキスト文字列を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [isSideways()](#isSideways--) | グリフが横向きに回転していることを示す値を返します。原点は回転していないグリフの上部中央として定義されます。 |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBidiLevel(int value)](#setBidiLevel-int-) | Unicode アルゴリズムの双方向入れ子レベルを指定する値を設定します。 |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 要素の描画領域を制限するパスジオメトリを設定します。 |
+| [setFill(XpsBrush value)](#setFill-com.aspose.xps.XpsBrush-) | レンダリングされたグリフの形状を塗りつぶすために使用されるブラシを設定します。 |
+| [setFontRenderingEmSize(float value)](#setFontRenderingEmSize-float-) | 有効座標空間の単位で浮動小数点数として表された、描画サーフェス単位のフォントサイズを設定します。 |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | ハイパーリンクのターゲットオブジェクトを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | 要素の均一な透明度を定義する値を設定します。 |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | 要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [setOriginX(float value)](#setOriginX-float-) | ラン内の最初のグリフの x 座標を、有効座標空間の単位で設定します。 |
+| [setOriginY(float value)](#setOriginY-float-) | ラン内の最初のグリフの y 座標を、有効座標空間の単位で設定します。 |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。 |
+| [setSideways(boolean value)](#setSideways-boolean-) | グリフが横向きに回転していることを示す値を設定します。原点は回転していないグリフの上部中央として定義されます。 |
+| [setStyleSimulations(XpsStyleSimulations value)](#setStyleSimulations-com.aspose.xps.XpsStyleSimulations-) | スタイルシミュレーションを指定する値を設定します。 |
+| [setUnicodeString(String value)](#setUnicodeString-java.lang.String-) | Glyphs 要素によってレンダリングされたテキスト文字列を設定します。 |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsGlyphs deepClone()
+```
+
+
+このグリフをクローンします。
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Clone of this glyphs.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getBidiLevel() {#getBidiLevel--}
+```
+public int getBidiLevel()
+```
+
+
+Unicode アルゴリズムの双方向入れ子レベルを指定する値を返します。偶数値は左から右へのレイアウトを示し、奇数値は右から左へのレイアウトを示します。右から左へのレイアウトでは、ランの原点が最初のグリフの右側に配置され、正の前進幅（左方向への進みを表す）により、後続のグリフが前のグリフの左側に配置されます。
+
+**Returns:**
+int - Unicode アルゴリズムの双方向入れ子レベルを指定する値。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+要素の描画領域を制限するパスジオメトリを返します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getFill() {#getFill--}
+```
+public XpsBrush getFill()
+```
+
+
+レンダリングされたグリフの形状を塗りつぶすために使用されるブラシを返します。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush used to fill the shape of the rendered glyphs.
+### getFont() {#getFont--}
+```
+public XpsFont getFont()
+```
+
+
+要素のテキスト組版に使用される TrueType フォントのフォントリソースを返します。
+
+**Returns:**
+[XpsFont](../../com.aspose.xps/xpsfont) - The font resource for the TrueType font used to typeset elements text.
+### getFontRenderingEmSize() {#getFontRenderingEmSize--}
+```
+public float getFontRenderingEmSize()
+```
+
+
+有効座標空間の単位で浮動小数点数として表された、描画サーフェス単位のフォントサイズを返します。
+
+**Returns:**
+float - フォントサイズ。
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+ハイパーリンクのターゲットオブジェクトを返します。
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+要素の均一な透明度を定義する値を返します。
+
+**Returns:**
+float - 要素の均一な透明度を定義する値。
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getOriginX() {#getOriginX--}
+```
+public float getOriginX()
+```
+
+
+ラン内の最初のグリフの x 座標を、有効座標空間の単位で返します。
+
+**Returns:**
+float - ラン内の最初のグリフの x 座標（有効座標空間の単位）。
+### getOriginY() {#getOriginY--}
+```
+public float getOriginY()
+```
+
+
+ラン内の最初のグリフの y 座標を、有効座標空間の単位で返します。
+
+**Returns:**
+float - ラン内の最初のグリフの y 座標（有効座標空間の単位）。
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### getStyleSimulations() {#getStyleSimulations--}
+```
+public XpsStyleSimulations getStyleSimulations()
+```
+
+
+スタイルシミュレーションを指定する値を返します。
+
+**Returns:**
+[XpsStyleSimulations](../../com.aspose.xps/xpsstylesimulations) - The value specifying a style simulation.
+### getUnicodeString() {#getUnicodeString--}
+```
+public String getUnicodeString()
+```
+
+
+Glyphs 要素によって描画されたテキスト文字列を返します。テキストは Unicode コードポイントで指定されます。
+
+**Returns:**
+java.lang.String - Glyphs 要素によって描画されたテキスト文字列。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSideways() {#isSideways--}
+```
+public boolean isSideways()
+```
+
+
+グリフが横向きに回転していることを示す値を返します。原点は回転していないグリフの上部中央として定義されます。
+
+**Returns:**
+boolean - グリフが横向きであることを示す値。
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBidiLevel(int value) {#setBidiLevel-int-}
+```
+public void setBidiLevel(int value)
+```
+
+
+Unicode アルゴリズムの双方向入れ子レベルを指定する値を設定します。偶数値は左から右へのレイアウトを意味し、奇数値は右から左へのレイアウトを意味します。右から左へのレイアウトでは、ランの起点が最初のグリフの右側に配置され、正の前進幅（左方向への進みを表す）により、後続のグリフが前のグリフの左側に配置されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | int | Unicode アルゴリズムの双方向入れ子レベルを指定する値。 |
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+要素の描画領域を制限するパスジオメトリを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 要素の描画領域を制限するパスジオメトリ。 |
+
+### setFill(XpsBrush value) {#setFill-com.aspose.xps.XpsBrush-}
+```
+public void setFill(XpsBrush value)
+```
+
+
+レンダリングされたグリフの形状を塗りつぶすために使用されるブラシを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 描画されたグリフの形状を塗りつぶすために使用されるブラシ。 |
+
+### setFontRenderingEmSize(float value) {#setFontRenderingEmSize-float-}
+```
+public void setFontRenderingEmSize(float value)
+```
+
+
+有効座標空間の単位で浮動小数点数として表された、描画サーフェス単位のフォントサイズを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | フォントサイズ。 |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+ハイパーリンクのターゲットオブジェクトを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | ハイパーリンクのターゲットオブジェクト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+要素の均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 要素の均一な透明度を定義する値。 |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | マスクを指定するブラシ。 |
+
+### setOriginX(float value) {#setOriginX-float-}
+```
+public void setOriginX(float value)
+```
+
+
+ラン内の最初のグリフの x 座標を、有効座標空間の単位で設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ラン内の最初のグリフの x 座標（有効座標空間の単位）。 |
+
+### setOriginY(float value) {#setOriginY-float-}
+```
+public void setOriginY(float value)
+```
+
+
+ラン内の最初のグリフの y 座標を、有効座標空間の単位で設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ラン内の最初のグリフの y 座標（有効座標空間の単位）。 |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | アフィン変換行列。 |
+
+### setSideways(boolean value) {#setSideways-boolean-}
+```
+public void setSideways(boolean value)
+```
+
+
+グリフが横向きに回転していることを示す値を設定します。原点は回転していないグリフの上部中央として定義されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | グリフが横向きであることを示す値。 |
+
+### setStyleSimulations(XpsStyleSimulations value) {#setStyleSimulations-com.aspose.xps.XpsStyleSimulations-}
+```
+public void setStyleSimulations(XpsStyleSimulations value)
+```
+
+
+スタイルシミュレーションを指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsStyleSimulations](../../com.aspose.xps/xpsstylesimulations) | スタイルシミュレーションを指定する値。 |
+
+### setUnicodeString(String value) {#setUnicodeString-java.lang.String-}
+```
+public void setUnicodeString(String value)
+```
+
+
+Glyphs 要素によって描画されたテキスト文字列を設定します。テキストは Unicode コードポイントで指定されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | Glyphs 要素によって描画されたテキスト文字列。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsgradientbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpsgradientbrush/_index.md
@@ -1,0 +1,249 @@
+---
+title: "XpsGradientBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "LinerGradientBrush と RadialGradientBrush 要素の共通機能をカプセル化するクラス。"
+type: docs
+weight: 26
+url: /ja/java/com.aspose.xps/xpsgradientbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush)
+```
+public abstract class XpsGradientBrush extends XpsTransformableBrush
+```
+
+LinerGradientBrush と RadialGradientBrush 要素の共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColorInterpolationMode()](#getColorInterpolationMode--) | 色の補間に使用されるガンマ関数を指定する値を返します。 |
+| [getGradientStops()](#getGradientStops--) | グラデーションを構成するグラデーションストップのリストを返します。 |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getSpreadMethod()](#getSpreadMethod--) | ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorInterpolationMode(XpsColorInterpolationMode value)](#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-) | 色の補間に使用されるガンマ関数を指定する値を設定します。 |
+| [setGradientStops(List<XpsGradientStop> value)](#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--) | グラデーションを構成するグラデーションストップのリストを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setSpreadMethod(XpsSpreadMethod value)](#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-) | ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColorInterpolationMode() {#getColorInterpolationMode--}
+```
+public XpsColorInterpolationMode getColorInterpolationMode()
+```
+
+
+色の補間に使用されるガンマ関数を指定する値を返します。ガンマ調整は、指定されている場合、アルファ成分には適用しないでください。
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) - Value specifying the gamma function for color interpolation.
+### getGradientStops() {#getGradientStops--}
+```
+public List<XpsGradientStop> getGradientStops()
+```
+
+
+グラデーションを構成するグラデーションストップのリストを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsGradientStop> - グラデーションを構成するグラデーションストップのリスト。
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getSpreadMethod() {#getSpreadMethod--}
+```
+public XpsSpreadMethod getSpreadMethod()
+```
+
+
+ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を返します。
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) - Value describing how the brush should fill the content area outside of the primary, initial gradient area.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorInterpolationMode(XpsColorInterpolationMode value) {#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-}
+```
+public void setColorInterpolationMode(XpsColorInterpolationMode value)
+```
+
+
+カラー補間のガンマ関数を指定する値を設定します。指定されている場合、ガンマ調整はアルファ成分には適用しないでください。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) | カラー補間のガンマ関数を指定する値。 |
+
+### setGradientStops(List<XpsGradientStop> value) {#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--}
+```
+public void setGradientStops(List<XpsGradientStop> value)
+```
+
+
+グラデーションを構成するグラデーションストップのリストを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションを構成するグラデーションストップのリスト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setSpreadMethod(XpsSpreadMethod value) {#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-}
+```
+public void setSpreadMethod(XpsSpreadMethod value)
+```
+
+
+ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) | 一次的な初期グラデーション領域の外側のコンテンツ領域をブラシがどのように塗りつぶすかを示す値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsgradientstop/_index.md
+++ b/japanese/java/com.aspose.xps/xpsgradientstop/_index.md
@@ -1,0 +1,157 @@
+---
+title: "XpsGradientStop"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "GradientStop 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 27
+url: /ja/java/com.aspose.xps/xpsgradientstop/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public final class XpsGradientStop extends XpsObject
+```
+
+GradientStop 要素の機能をカプセル化するクラス。この要素は LinearGradientBrush と RadialGradientBrush の両方で使用され、グラデーションの描画時に色の進行位置と範囲を定義します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この gradient stop をクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | gradient stop の色を返します。 |
+| [getOffset()](#getOffset--) | gradient offset を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsGradientStop deepClone()
+```
+
+
+この gradient stop をクローンします。
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - Clone of this gradient stop.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public XpsColor getColor()
+```
+
+
+gradient stop の色を返します。
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - The gradient stop color.
+### getOffset() {#getOffset--}
+```
+public float getOffset()
+```
+
+
+gradient offset を返します。offset は、グラデーションの進行に沿って色が指定される点を示します。進行中の gradient offset 間の色は補間されます。
+
+**Returns:**
+float - gradient offset。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpshyperlinkelement/_index.md
+++ b/japanese/java/com.aspose.xps/xpshyperlinkelement/_index.md
@@ -1,0 +1,187 @@
+---
+title: "XpsHyperlinkElement"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ハイパーリンクになり得る XPS 要素の共通機能をカプセル化します。"
+type: docs
+weight: 28
+url: /ja/java/com.aspose.xps/xpshyperlinkelement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement)
+```
+public abstract class XpsHyperlinkElement extends XpsElement
+```
+
+ハイパーリンクになり得る XPS 要素の共通機能をカプセル化します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | ハイパーリンクのターゲットオブジェクトを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | ハイパーリンクのターゲットオブジェクトを設定します。 |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+ハイパーリンクのターゲットオブジェクトを返します。
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+ハイパーリンクのターゲットオブジェクトを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | ハイパーリンクのターゲットオブジェクト。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpshyperlinktarget/_index.md
+++ b/japanese/java/com.aspose.xps/xpshyperlinktarget/_index.md
@@ -1,0 +1,135 @@
+---
+title: "XpsHyperlinkTarget"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ハイパーリンクターゲットの基底クラス。"
+type: docs
+weight: 29
+url: /ja/java/com.aspose.xps/xpshyperlinktarget/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class XpsHyperlinkTarget
+```
+
+ハイパーリンクターゲットの基底クラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsHyperlinkTarget()](#XpsHyperlinkTarget--) |  |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsHyperlinkTarget() {#XpsHyperlinkTarget--}
+```
+public XpsHyperlinkTarget()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsiccbasedcolor/_index.md
+++ b/japanese/java/com.aspose.xps/xpsiccbasedcolor/_index.md
@@ -1,0 +1,146 @@
+---
+title: "XpsIccBasedColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ICC ベースのカラーをカプセル化します。"
+type: docs
+weight: 30
+url: /ja/java/com.aspose.xps/xpsiccbasedcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsColor](../../com.aspose.xps/xpscolor)
+```
+public final class XpsIccBasedColor extends XpsColor
+```
+
+ICC ベースのカラーをカプセル化します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIccProfile()](#getIccProfile--) | 色が基づく ICC プロファイルリソースを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toColor()](#toColor--) | ICC ベースの色の .NET ネイティブ表現を取得するための便利メソッドです。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIccProfile() {#getIccProfile--}
+```
+public XpsIccProfile getIccProfile()
+```
+
+
+色が基づく ICC プロファイルリソースを返します。
+
+**Returns:**
+[XpsIccProfile](../../com.aspose.xps/xpsiccprofile) - The ICC profile resource the color based on.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toColor() {#toColor--}
+```
+public Color toColor()
+```
+
+
+ICC ベースの色の .NET ネイティブ表現を取得するための便利メソッドです。
+
+**Returns:**
+java.awt.Color -  System.Drawing.ColorSystem.Drawing.Color 構造体。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsiccprofile/_index.md
+++ b/japanese/java/com.aspose.xps/xpsiccprofile/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsIccProfile"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ICC プロファイルリソースをカプセル化するクラス。"
+type: docs
+weight: 31
+url: /ja/java/com.aspose.xps/xpsiccprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsFileResource](../../com.aspose.xps/xpsfileresource)
+```
+public final class XpsIccProfile extends XpsFileResource
+```
+
+ICC プロファイルリソースをカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsimage/_index.md
+++ b/japanese/java/com.aspose.xps/xpsimage/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsImage"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "画像リソースをカプセル化するクラス。"
+type: docs
+weight: 32
+url: /ja/java/com.aspose.xps/xpsimage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsFileResource](../../com.aspose.xps/xpsfileresource)
+```
+public final class XpsImage extends XpsFileResource
+```
+
+画像リソースをカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsimagebrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpsimagebrush/_index.md
@@ -1,0 +1,282 @@
+---
+title: "XpsImageBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ImageBrush プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 33
+url: /ja/java/com.aspose.xps/xpsimagebrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsTilingBrush](../../com.aspose.xps/xpstilingbrush)
+```
+public final class XpsImageBrush extends XpsTilingBrush
+```
+
+ImageBrush プロパティ要素の機能をカプセル化するクラス。この要素は画像で領域を塗りつぶすために使用されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この画像ブラシをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getImage()](#getImage--) | ブラシに使用される画像リソースを返します。 |
+| [getImageSource()](#getImageSource--) | 画像リソースの URI を返します。 |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getTileMode()](#getTileMode--) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [getViewbox()](#getViewbox--) | ビュー ポートにマッピングされるブラシのソース コンテンツ領域を返します。 |
+| [getViewport()](#getViewport--) | 最初のブラシタイルの位置とサイズを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setTileMode(XpsTileMode value)](#setTileMode-com.aspose.xps.XpsTileMode-) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [setViewbox(Rectangle2D value)](#setViewbox-java.awt.geom.Rectangle2D-) | ビュー ポートにマッピングされるブラシのソース コンテンツ領域を設定します。 |
+| [setViewport(Rectangle2D value)](#setViewport-java.awt.geom.Rectangle2D-) | 最初のブラシタイルの位置とサイズを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsImageBrush deepClone()
+```
+
+
+この画像ブラシをクローンします。
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - Clone of this image brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getImage() {#getImage--}
+```
+public XpsImage getImage()
+```
+
+
+ブラシに使用される画像リソースを返します。
+
+**Returns:**
+[XpsImage](../../com.aspose.xps/xpsimage) - Image resource used to for the brush.
+### getImageSource() {#getImageSource--}
+```
+public String getImageSource()
+```
+
+
+画像リソースの URI を返します。
+
+**Returns:**
+java.lang.String - 画像リソースの URI。
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getTileMode() {#getTileMode--}
+```
+public XpsTileMode getTileMode()
+```
+
+
+塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を返します。
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode) - Value specifying how tiling is performed in the filled geometry.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### getViewbox() {#getViewbox--}
+```
+public Rectangle2D getViewbox()
+```
+
+
+ビュー ポートにマッピングされるブラシのソース コンテンツ領域を返します。
+
+**Returns:**
+java.awt.geom.Rectangle2D - ビュー ポートにマッピングされるブラシのソース コンテンツ領域。
+### getViewport() {#getViewport--}
+```
+public Rectangle2D getViewport()
+```
+
+
+最初のブラシタイルの位置とサイズを返します。以降のタイルはタイル モードで指定されるように、このタイルを基準に配置されます。
+
+**Returns:**
+java.awt.geom.Rectangle2D - 最初のブラシタイルの位置とサイズ。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setTileMode(XpsTileMode value) {#setTileMode-com.aspose.xps.XpsTileMode-}
+```
+public void setTileMode(XpsTileMode value)
+```
+
+
+塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsTileMode](../../com.aspose.xps/xpstilemode) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### setViewbox(Rectangle2D value) {#setViewbox-java.awt.geom.Rectangle2D-}
+```
+public void setViewbox(Rectangle2D value)
+```
+
+
+ビュー ポートにマッピングされるブラシのソース コンテンツ領域を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Rectangle2D | ビュー ポートにマッピングされるブラシのソース コンテンツ領域。 |
+
+### setViewport(Rectangle2D value) {#setViewport-java.awt.geom.Rectangle2D-}
+```
+public void setViewport(Rectangle2D value)
+```
+
+
+最初のブラシタイルの位置とサイズを設定します。以降のタイルはタイル モードで指定されるように、このタイルを基準に配置されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Rectangle2D | 最初のブラシタイルの位置とサイズ。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpslineargradientbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpslineargradientbrush/_index.md
@@ -1,0 +1,310 @@
+---
+title: "XpsLinearGradientBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "LinearGradientBrush プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 34
+url: /ja/java/com.aspose.xps/xpslineargradientbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsGradientBrush](../../com.aspose.xps/xpsgradientbrush)
+```
+public final class XpsLinearGradientBrush extends XpsGradientBrush
+```
+
+LinearGradientBrush プロパティ要素の機能をカプセル化するクラス。この要素はベクトルに沿った線形グラデーションブラシを指定するために使用されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この線形グラデーションブラシを複製します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColorInterpolationMode()](#getColorInterpolationMode--) | 色の補間に使用されるガンマ関数を指定する値を返します。 |
+| [getEndPoint()](#getEndPoint--) | 線形グラデーションの終点を返します。 |
+| [getGradientStops()](#getGradientStops--) | グラデーションを構成するグラデーションストップのリストを返します。 |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getSpreadMethod()](#getSpreadMethod--) | ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を返します。 |
+| [getStartPoint()](#getStartPoint--) | 線形グラデーションの始点を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorInterpolationMode(XpsColorInterpolationMode value)](#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-) | 色の補間に使用されるガンマ関数を指定する値を設定します。 |
+| [setEndPoint(Point2D value)](#setEndPoint-java.awt.geom.Point2D-) | 線形グラデーションの終点を取得/設定します。 |
+| [setGradientStops(List<XpsGradientStop> value)](#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--) | グラデーションを構成するグラデーションストップのリストを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setSpreadMethod(XpsSpreadMethod value)](#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-) | ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を設定します。 |
+| [setStartPoint(Point2D value)](#setStartPoint-java.awt.geom.Point2D-) | 線形グラデーションの始点を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsLinearGradientBrush deepClone()
+```
+
+
+この線形グラデーションブラシを複製します。
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - Clone of this linear gradient brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColorInterpolationMode() {#getColorInterpolationMode--}
+```
+public XpsColorInterpolationMode getColorInterpolationMode()
+```
+
+
+色の補間に使用されるガンマ関数を指定する値を返します。ガンマ調整は、指定されている場合、アルファ成分には適用しないでください。
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) - Value specifying the gamma function for color interpolation.
+### getEndPoint() {#getEndPoint--}
+```
+public Point2D getEndPoint()
+```
+
+
+線形グラデーションの終点を返します。
+
+**Returns:**
+java.awt.geom.Point2D - 線形グラデーションの終点。
+### getGradientStops() {#getGradientStops--}
+```
+public List<XpsGradientStop> getGradientStops()
+```
+
+
+グラデーションを構成するグラデーションストップのリストを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsGradientStop> - グラデーションを構成するグラデーションストップのリスト。
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getSpreadMethod() {#getSpreadMethod--}
+```
+public XpsSpreadMethod getSpreadMethod()
+```
+
+
+ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を返します。
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) - Value describing how the brush should fill the content area outside of the primary, initial gradient area.
+### getStartPoint() {#getStartPoint--}
+```
+public Point2D getStartPoint()
+```
+
+
+線形グラデーションの始点を返します。
+
+**Returns:**
+java.awt.geom.Point2D - 線形グラデーションの始点。
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorInterpolationMode(XpsColorInterpolationMode value) {#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-}
+```
+public void setColorInterpolationMode(XpsColorInterpolationMode value)
+```
+
+
+カラー補間のガンマ関数を指定する値を設定します。指定されている場合、ガンマ調整はアルファ成分には適用しないでください。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) | カラー補間のガンマ関数を指定する値。 |
+
+### setEndPoint(Point2D value) {#setEndPoint-java.awt.geom.Point2D-}
+```
+public void setEndPoint(Point2D value)
+```
+
+
+線形グラデーションの終点を取得/設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Point2D | 線形グラデーションの終了点です。 |
+
+### setGradientStops(List<XpsGradientStop> value) {#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--}
+```
+public void setGradientStops(List<XpsGradientStop> value)
+```
+
+
+グラデーションを構成するグラデーションストップのリストを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションを構成するグラデーションストップのリスト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setSpreadMethod(XpsSpreadMethod value) {#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-}
+```
+public void setSpreadMethod(XpsSpreadMethod value)
+```
+
+
+ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) | 一次的な初期グラデーション領域の外側のコンテンツ領域をブラシがどのように塗りつぶすかを示す値。 |
+
+### setStartPoint(Point2D value) {#setStartPoint-java.awt.geom.Point2D-}
+```
+public void setStartPoint(Point2D value)
+```
+
+
+線形グラデーションの始点を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Point2D | 線形グラデーションの開始点です。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpslinecap/_index.md
+++ b/japanese/java/com.aspose.xps/xpslinecap/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsLineCap"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Path 要素の StrokeStartLineCap と StrokeEndLineCap プロパティの有効な値です。"
+type: docs
+weight: 61
+url: /ja/java/com.aspose.xps/xpslinecap/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsLineCap extends Enum<XpsLineCap>
+```
+
+Path 要素の StrokeStartLineCap と StrokeEndLineCap プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Flat](#Flat) | フラットなラインキャップ。 |
+| [Round](#Round) | 丸いラインキャップ。 |
+| [Square](#Square) | 四角いラインキャップ。 |
+| [Triangle](#Triangle) | 三角形のラインキャップ。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Flat {#Flat}
+```
+public static final XpsLineCap Flat
+```
+
+
+フラットなラインキャップ。
+
+### Round {#Round}
+```
+public static final XpsLineCap Round
+```
+
+
+丸いラインキャップ。
+
+### Square {#Square}
+```
+public static final XpsLineCap Square
+```
+
+
+四角いラインキャップ。
+
+### Triangle {#Triangle}
+```
+public static final XpsLineCap Triangle
+```
+
+
+三角形のラインキャップ。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsLineCap valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsLineCap](../../com.aspose.xps/xpslinecap)
+### values() {#values--}
+```
+public static XpsLineCap[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsLineCap[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpslinejoin/_index.md
+++ b/japanese/java/com.aspose.xps/xpslinejoin/_index.md
@@ -1,0 +1,259 @@
+---
+title: "XpsLineJoin"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Path 要素の StrokeLineJoin プロパティの有効な値。"
+type: docs
+weight: 62
+url: /ja/java/com.aspose.xps/xpslinejoin/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsLineJoin extends Enum<XpsLineJoin>
+```
+
+Path 要素の StrokeLineJoin プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Bevel](#Bevel) | ベベルライン結合。 |
+| [Miter](#Miter) | ミタライン結合。 |
+| [Round](#Round) | ラウンドライン結合。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bevel {#Bevel}
+```
+public static final XpsLineJoin Bevel
+```
+
+
+ベベルライン結合。
+
+### Miter {#Miter}
+```
+public static final XpsLineJoin Miter
+```
+
+
+ミタライン結合。
+
+### Round {#Round}
+```
+public static final XpsLineJoin Round
+```
+
+
+ラウンドライン結合。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsLineJoin valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsLineJoin](../../com.aspose.xps/xpslinejoin)
+### values() {#values--}
+```
+public static XpsLineJoin[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsLineJoin[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsloadoptions/_index.md
+++ b/japanese/java/com.aspose.xps/xpsloadoptions/_index.md
@@ -1,0 +1,137 @@
+---
+title: "XpsLoadOptions"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "XPS ドキュメントの読み込みオプション。"
+type: docs
+weight: 35
+url: /ja/java/com.aspose.xps/xpsloadoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.LoadOptions](../../com.aspose.xps/loadoptions)
+```
+public class XpsLoadOptions extends LoadOptions
+```
+
+XPS ドキュメントの読み込みオプション。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsLoadOptions()](#XpsLoadOptions--) | 新しいオプションのインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsLoadOptions() {#XpsLoadOptions--}
+```
+public XpsLoadOptions()
+```
+
+
+新しいオプションのインスタンスを作成します。
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsmatrix/_index.md
+++ b/japanese/java/com.aspose.xps/xpsmatrix/_index.md
@@ -1,0 +1,502 @@
+---
+title: "XpsMatrix"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "MatrixTransform プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 36
+url: /ja/java/com.aspose.xps/xpsmatrix/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public final class XpsMatrix extends XpsObject
+```
+
+MatrixTransformプロパティ要素の機能をカプセル化するクラス。この要素は、要素の座標系を操作するために使用される任意のアフィン行列変換を定義します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この変換行列をクローンします。 |
+| [equals(XpsMatrix a, XpsMatrix b)](#equals-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-) | 実際の実装。 |
+| [equals(Object obj)](#equals-java.lang.Object-) | 指定された  object  がこのインスタンスと等しいかどうかを判断します。 |
+| [getClass()](#getClass--) |  |
+| [getM11()](#getM11--) | M11 要素を取得します。 |
+| [getM12()](#getM12--) | M12 要素を取得します。 |
+| [getM21()](#getM21--) | M21 要素を取得します。 |
+| [getM22()](#getM22--) | M22 要素を取得します。 |
+| [getM31()](#getM31--) | M31 要素を取得します。 |
+| [getM32()](#getM32--) | M32 要素を取得します。 |
+| [hashCode()](#hashCode--) | このインスタンスのハッシュコードを返します。 |
+| [isIdentity()](#isIdentity--) | このインスタンスが単位行列かどうかを示す値を取得します。 |
+| [multiply(XpsMatrix matrix)](#multiply-com.aspose.xps.XpsMatrix-) | この行列を、デフォルト（Prepend）順序で指定された  matrix  行列で乗算します。 |
+| [multiply(XpsMatrix matrix, XpsMatrix.MatrixOrder matrixOrder)](#multiply-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix.MatrixOrder-) | この行列を、  matrixOrder  で指定された順序で指定された  matrix  行列で乗算します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(XpsMatrix a, XpsMatrix b)](#op-Equality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-) | 演算子 == を実装します。 |
+| [op_Inequality(XpsMatrix a, XpsMatrix b)](#op-Inequality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-) | 演算子 ! を実装します。 |
+| [reset()](#reset--) | この Matrix を単位行列にリセットします。 |
+| [rotate(float angle)](#rotate-float-) | デフォルト（Prepend）順序で、  angle  の時計回り回転をこの Matrix に適用します。 |
+| [rotate(float angle, XpsMatrix.MatrixOrder matrixOrder)](#rotate-float-com.aspose.xps.XpsMatrix.MatrixOrder-) |   matrixOrder  で指定された順序で、  angle  の時計回り回転をこの Matrix に適用します。 |
+| [rotateAround(float angle, Point2D pivot)](#rotateAround-float-java.awt.geom.Point2D-) | デフォルト（Prepend）順序で、  pivot  を中心に  angle  の時計回り回転をこの Matrix に適用します。 |
+| [rotateAround(float angle, Point2D pivot, XpsMatrix.MatrixOrder matrixOrder)](#rotateAround-float-java.awt.geom.Point2D-com.aspose.xps.XpsMatrix.MatrixOrder-) |   matrixOrder  で指定された順序で、  pivot  を中心に  angle  の時計回り回転をこの Matrix に適用します。 |
+| [scale(float scaleX, float scaleY)](#scale-float-float-) | デフォルト（Prepend）順序で、指定されたスケールベクトル（scaleX と scaleY）をこの Matrix に適用します。 |
+| [scale(float scaleX, float scaleY, XpsMatrix.MatrixOrder matrixOrder)](#scale-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-) |   matrixOrder  で指定された順序で、指定されたスケールベクトル（scaleX と scaleY）をこの Matrix に適用します。 |
+| [skew(double skewX, double skewY)](#skew-double-double-) | 指定されたせん断変換をこの Matrix に適用します。 |
+| [toString()](#toString--) | この  XpsMatrix  インスタンスの文字列表現を返します。 |
+| [transform(Rectangle2D rect)](#transform-java.awt.geom.Rectangle2D-) | この Matrix が表すアフィン変換を指定された矩形に適用します。 |
+| [transformPoint(Point2D point)](#transformPoint-java.awt.geom.Point2D-) | この Matrix が表すアフィン変換を指定された点に適用します。 |
+| [transformPoints(Point2D[] points)](#transformPoints-java.awt.geom.Point2D---) | この Matrix が表すアフィン変換を指定された点の配列に適用します。 |
+| [transformPoints(Point2D[] points, int startIndex, int numberOfPoints)](#transformPoints-java.awt.geom.Point2D---int-int-) | この Matrix が表すアフィン変換を指定された点配列の一部に適用します。 |
+| [translate(float offsetX, float offsetY)](#translate-float-float-) | 指定された平行移動ベクトルをこの Matrix に適用します。 |
+| [translate(float offsetX, float offsetY, XpsMatrix.MatrixOrder matrixOrder)](#translate-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-) |   matrixOrder  で指定された順序で、指定された平行移動ベクトルをこの Matrix に適用します。 |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsMatrix deepClone()
+```
+
+
+この変換行列をクローンします。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - Clone of this transformation matrix.
+### equals(XpsMatrix a, XpsMatrix b) {#equals-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-}
+```
+public static boolean equals(XpsMatrix a, XpsMatrix b)
+```
+
+
+実際の実装。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 最初の行列です。 |
+| b | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 2 番目の行列です。 |
+
+**Returns:**
+boolean - 行列が等しい場合は[true]
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+指定された  object  がこのインスタンスと等しいかどうかを判断します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | java.lang.Object | このインスタンスと比較するオブジェクト。 |
+
+**Returns:**
+boolean - 指定されたオブジェクトがこのインスタンスと等しい場合は true、そうでない場合は false。obj パラメータが null の場合。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getM11() {#getM11--}
+```
+public float getM11()
+```
+
+
+M11 要素を取得します。
+
+**Returns:**
+float - M11 要素。
+### getM12() {#getM12--}
+```
+public float getM12()
+```
+
+
+M12 要素を取得します。
+
+**Returns:**
+float - M12 要素。
+### getM21() {#getM21--}
+```
+public float getM21()
+```
+
+
+M21 要素を取得します。
+
+**Returns:**
+float - M21 要素。
+### getM22() {#getM22--}
+```
+public float getM22()
+```
+
+
+M22 要素を取得します。
+
+**Returns:**
+float - M22 要素。
+### getM31() {#getM31--}
+```
+public float getM31()
+```
+
+
+M31 要素を取得します。
+
+**Returns:**
+float - M31 要素。
+### getM32() {#getM32--}
+```
+public float getM32()
+```
+
+
+M32 要素を取得します。
+
+**Returns:**
+float - M32 要素。
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+このインスタンスのハッシュコードを返します。
+
+**Returns:**
+int - このインスタンスのハッシュコードで、ハッシュアルゴリズムやハッシュテーブルのようなデータ構造での使用に適しています。
+### isIdentity() {#isIdentity--}
+```
+public boolean isIdentity()
+```
+
+
+このインスタンスが単位行列かどうかを示す値を取得します。
+
+値: このインスタンスが単位行列の場合は True、そうでない場合は false。
+
+**Returns:**
+boolean - このインスタンスが単位行列かどうかを示す値。
+### multiply(XpsMatrix matrix) {#multiply-com.aspose.xps.XpsMatrix-}
+```
+public void multiply(XpsMatrix matrix)
+```
+
+
+この行列を、デフォルト（Prepend）順序で指定された  matrix  行列で乗算します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| matrix | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 行列。 |
+
+### multiply(XpsMatrix matrix, XpsMatrix.MatrixOrder matrixOrder) {#multiply-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void multiply(XpsMatrix matrix, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+この行列を、  matrixOrder  で指定された順序で指定された  matrix  行列で乗算します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| matrix | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 行列。 |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 順序。 |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(XpsMatrix a, XpsMatrix b) {#op-Equality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-}
+```
+public static boolean op_Equality(XpsMatrix a, XpsMatrix b)
+```
+
+
+演算子 == を実装します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 最初の行列です。 |
+| b | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 2 番目の行列です。 |
+
+**Returns:**
+boolean - 演算子の結果。
+### op_Inequality(XpsMatrix a, XpsMatrix b) {#op-Inequality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-}
+```
+public static boolean op_Inequality(XpsMatrix a, XpsMatrix b)
+```
+
+
+!= 演算子を実装します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| a | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 最初の行列です。 |
+| b | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 2 番目の行列です。 |
+
+**Returns:**
+boolean - 演算子の結果。
+### reset() {#reset--}
+```
+public void reset()
+```
+
+
+この Matrix を単位行列にリセットします。
+
+### rotate(float angle) {#rotate-float-}
+```
+public void rotate(float angle)
+```
+
+
+デフォルト（Prepend）順序で、  angle  の時計回り回転をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angle | float | 角度。 |
+
+### rotate(float angle, XpsMatrix.MatrixOrder matrixOrder) {#rotate-float-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void rotate(float angle, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+  matrixOrder  で指定された順序で、  angle  の時計回り回転をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angle | float | 角度。 |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 順序。 |
+
+### rotateAround(float angle, Point2D pivot) {#rotateAround-float-java.awt.geom.Point2D-}
+```
+public void rotateAround(float angle, Point2D pivot)
+```
+
+
+デフォルト（Prepend）順序で、  pivot  を中心に  angle  の時計回り回転をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angle | float | 角度。 |
+| ピボット | java.awt.geom.Point2D | ピボット点。 |
+
+### rotateAround(float angle, Point2D pivot, XpsMatrix.MatrixOrder matrixOrder) {#rotateAround-float-java.awt.geom.Point2D-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void rotateAround(float angle, Point2D pivot, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+  matrixOrder  で指定された順序で、  pivot  を中心に  angle  の時計回り回転をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| angle | float | 角度。 |
+| ピボット | java.awt.geom.Point2D | ピボット点。 |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 順序。 |
+
+### scale(float scaleX, float scaleY) {#scale-float-float-}
+```
+public void scale(float scaleX, float scaleY)
+```
+
+
+デフォルト（Prepend）順序で、指定されたスケールベクトル（scaleX と scaleY）をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| scaleX | float | スケール x。 |
+| scaleY | float | スケール y。 |
+
+### scale(float scaleX, float scaleY, XpsMatrix.MatrixOrder matrixOrder) {#scale-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void scale(float scaleX, float scaleY, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+  matrixOrder  で指定された順序で、指定されたスケールベクトル（scaleX と scaleY）をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| scaleX | float | スケール X。 |
+| scaleY | float | スケール Y。 |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 順序。 |
+
+### skew(double skewX, double skewY) {#skew-double-double-}
+```
+public void skew(double skewX, double skewY)
+```
+
+
+指定されたせん断変換をこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| skewX | double | skew xです。 |
+| skewY | double | skew yです。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+この  XpsMatrix  インスタンスの文字列表現を返します。
+
+**Returns:**
+java.lang.String - 文字列表現
+### transform(Rectangle2D rect) {#transform-java.awt.geom.Rectangle2D-}
+```
+public Rectangle2D transform(Rectangle2D rect)
+```
+
+
+この Matrix が表すアフィン変換を指定された矩形に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| rect | java.awt.geom.Rectangle2D | 矩形です。 |
+
+**Returns:**
+java.awt.geom.Rectangle2D - 変換された矩形
+### transformPoint(Point2D point) {#transformPoint-java.awt.geom.Point2D-}
+```
+public Point2D transformPoint(Point2D point)
+```
+
+
+この Matrix が表すアフィン変換を指定された点に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| ポイント | java.awt.geom.Point2D | 点です。 |
+
+**Returns:**
+java.awt.geom.Point2D - 変換された点
+### transformPoints(Point2D[] points) {#transformPoints-java.awt.geom.Point2D---}
+```
+public void transformPoints(Point2D[] points)
+```
+
+
+この Matrix が表すアフィン変換を指定された点の配列に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 点です。 |
+
+### transformPoints(Point2D[] points, int startIndex, int numberOfPoints) {#transformPoints-java.awt.geom.Point2D---int-int-}
+```
+public void transformPoints(Point2D[] points, int startIndex, int numberOfPoints)
+```
+
+
+この Matrix が表すアフィン変換を指定された点配列の一部に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 点です。 |
+| startIndex | int | 開始インデックスです。 |
+| numberOfPoints | int | 点の数です。 |
+
+### translate(float offsetX, float offsetY) {#translate-float-float-}
+```
+public void translate(float offsetX, float offsetY)
+```
+
+
+指定された平行移動ベクトルをこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| offsetX | float | オフセット Xです。 |
+| offsetY | float | オフセット Yです。 |
+
+### translate(float offsetX, float offsetY, XpsMatrix.MatrixOrder matrixOrder) {#translate-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void translate(float offsetX, float offsetY, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+  matrixOrder  で指定された順序で、指定された平行移動ベクトルをこの Matrix に適用します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| offsetX | float | オフセット Xです。 |
+| offsetY | float | オフセット Yです。 |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 順序。 |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsobject/_index.md
+++ b/japanese/java/com.aspose.xps/xpsobject/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsObject"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "共通の XPS モデルオブジェクト機能をカプセル化するクラス。"
+type: docs
+weight: 37
+url: /ja/java/com.aspose.xps/xpsobject/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class XpsObject
+```
+
+共通の XPS モデルオブジェクト機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspage/_index.md
+++ b/japanese/java/com.aspose.xps/xpspage/_index.md
@@ -1,0 +1,248 @@
+---
+title: "XpsPage"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "FixedPage 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 38
+url: /ja/java/com.aspose.xps/xpspage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement)
+```
+public final class XpsPage extends XpsElement
+```
+
+FixedPage 要素の機能をカプセル化するクラス。この要素はページの内容を保持し、FixedPage パートのルート要素です。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このページをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | ページの高さを、実座標空間の単位で実数として返します。 |
+| [getWidth()](#getWidth--) | ページの幅を、実座標空間の単位で実数として返します。 |
+| [getXmlLang()](#getXmlLang--) | 現在の要素およびすべての子要素や子孫要素で使用されるデフォルト言語を指定する値を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | ページの高さを、実座標空間の単位で実数として設定します。 |
+| [setWidth(float value)](#setWidth-float-) | ページの幅を、実座標空間の単位で実数として設定します。 |
+| [setXmlLang(String value)](#setXmlLang-java.lang.String-) | 現在の要素およびすべての子要素や子孫要素で使用されるデフォルト言語を指定する値を設定します。 |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPage deepClone()
+```
+
+
+このページをクローンします。
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Clone of this page.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+ページの高さを、実座標空間の単位で実数として返します。
+
+**Returns:**
+float - ページの高さです。
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+ページの幅を、実座標空間の単位で実数として返します。
+
+**Returns:**
+float - ページの幅です。
+### getXmlLang() {#getXmlLang--}
+```
+public String getXmlLang()
+```
+
+
+現在の要素およびすべての子要素や子孫要素で使用されるデフォルト言語を指定する値を返します。
+
+**Returns:**
+java.lang.String - デフォルト言語を指定する値。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+ページの高さを、実座標空間の単位で実数として設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ページの高さです。 |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+ページの幅を、実座標空間の単位で実数として設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ページの幅です。 |
+
+### setXmlLang(String value) {#setXmlLang-java.lang.String-}
+```
+public void setXmlLang(String value)
+```
+
+
+現在の要素およびすべての子要素や子孫要素で使用されるデフォルト言語を指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.lang.String | デフォルト言語を指定する値。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspagelinktarget/_index.md
+++ b/japanese/java/com.aspose.xps/xpspagelinktarget/_index.md
@@ -1,0 +1,153 @@
+---
+title: "XpsPageLinkTarget"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ページハイパーリンクターゲットをカプセル化するクラス。"
+type: docs
+weight: 39
+url: /ja/java/com.aspose.xps/xpspagelinktarget/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget)
+```
+public final class XpsPageLinkTarget extends XpsHyperlinkTarget
+```
+
+ページハイパーリンクターゲットをカプセル化するクラス。
+## コンストラクタ
+
+| コンストラクタ | 説明 |
+| --- | --- |
+| [XpsPageLinkTarget(int targetPageNumber)](#XpsPageLinkTarget-int-) | 新しいインスタンスを作成します。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getTargetPageNumber()](#getTargetPageNumber--) | 親 XPS 要素が参照するページ番号を取得します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsPageLinkTarget(int targetPageNumber) {#XpsPageLinkTarget-int-}
+```
+public XpsPageLinkTarget(int targetPageNumber)
+```
+
+
+新しいインスタンスを作成します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| targetPageNumber | int | 全体の XPS ドキュメント（固定ドキュメントシーケンス）内の絶対ページ番号。 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTargetPageNumber() {#getTargetPageNumber--}
+```
+public int getTargetPageNumber()
+```
+
+
+親 XPS 要素が参照するページ番号を取得します。
+
+**Returns:**
+int - 親 XPS 要素が参照するページ番号。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspath/_index.md
+++ b/japanese/java/com.aspose.xps/xpspath/_index.md
@@ -1,0 +1,573 @@
+---
+title: "XpsPath"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Path 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 40
+url: /ja/java/com.aspose.xps/xpspath/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement), [com.aspose.xps.XpsContentElement](../../com.aspose.xps/xpscontentelement)
+```
+public final class XpsPath extends XpsContentElement
+```
+
+Path 要素の機能をカプセル化するクラス。この要素は固定ページにベクターグラフィックと画像を追加する唯一の手段です。ページ上にレンダリングされる単一のベクターグラフィックを定義します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | このパスをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i による要素の子へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 要素の描画領域を制限するパスジオメトリを返します。 |
+| [getData()](#getData--) | パスのジオメトリを返します。 |
+| [getFill()](#getFill--) | パスの Data プロパティで指定されたジオメトリを描画するために使用されるブラシを返します。 |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | ハイパーリンクのターゲットオブジェクトを返します。 |
+| [getOpacity()](#getOpacity--) | 要素の均一な透明度を定義する値を返します。 |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [getRenderTransform()](#getRenderTransform--) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。 |
+| [getStroke()](#getStroke--) | ストロークを描画するために使用されるブラシを返します。 |
+| [getStrokeDashArray()](#getStrokeDashArray--) | アウトラインストロークのダッシュとギャップの長さを指定する配列を返します。 |
+| [getStrokeDashCap()](#getStrokeDashCap--) | 各ダッシュの端がどのように描画されるかを指定する値を返します。 |
+| [getStrokeDashOffset()](#getStrokeDashOffset--) | ダッシュ配列パターンを繰り返す開始点を返します。 |
+| [getStrokeEndLineCap()](#getStrokeEndLineCap--) | ストローク内の最後のダッシュの終端形状を定義する値を返します。 |
+| [getStrokeLineJoin()](#getStrokeLineJoin--) | ストローク内の最初のダッシュの開始形状を定義する値を返します。 |
+| [getStrokeMiterLimit()](#getStrokeMiterLimit--) | 最大ミタ長とストローク厚さの半分との比率を返します。 |
+| [getStrokeStartLineCap()](#getStrokeStartLineCap--) | ストローク内の最初のダッシュの開始形状を定義する値を返します。 |
+| [getStrokeThickness()](#getStrokeThickness--) | 有効座標空間の単位でストロークの太さを返します（パスのレンダー変換を含む）。 |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable インターフェイスの実装。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 要素の描画領域を制限するパスジオメトリを設定します。 |
+| [setData(XpsPathGeometry value)](#setData-com.aspose.xps.XpsPathGeometry-) | パスのジオメトリを設定します。 |
+| [setFill(XpsBrush value)](#setFill-com.aspose.xps.XpsBrush-) | パスの Data プロパティで指定されたジオメトリを描画するために使用されるブラシを設定します。 |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | ハイパーリンクのターゲットオブジェクトを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | 要素の均一な透明度を定義する値を設定します。 |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | 要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。 |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。 |
+| [setStroke(XpsBrush value)](#setStroke-com.aspose.xps.XpsBrush-) | ストロークを描画するために使用されるブラシを設定します。 |
+| [setStrokeDashArray(float[] value)](#setStrokeDashArray-float---) | アウトラインストロークのダッシュとギャップの長さを指定する配列を設定します。 |
+| [setStrokeDashCap(XpsDashCap value)](#setStrokeDashCap-com.aspose.xps.XpsDashCap-) | 各ダッシュの端がどのように描画されるかを指定する値を設定します。 |
+| [setStrokeDashOffset(float value)](#setStrokeDashOffset-float-) | ダッシュ配列パターンを繰り返す開始点を設定します。 |
+| [setStrokeEndLineCap(XpsLineCap value)](#setStrokeEndLineCap-com.aspose.xps.XpsLineCap-) | ストローク内の最後のダッシュの終端形状を定義する値を設定します。 |
+| [setStrokeLineJoin(XpsLineJoin value)](#setStrokeLineJoin-com.aspose.xps.XpsLineJoin-) | ストローク内の最初のダッシュの開始形状を定義する値を設定します。 |
+| [setStrokeMiterLimit(float value)](#setStrokeMiterLimit-float-) | 最大ミタ長とストローク厚さの半分との比率を設定します。 |
+| [setStrokeStartLineCap(XpsLineCap value)](#setStrokeStartLineCap-com.aspose.xps.XpsLineCap-) | ストローク内の最初のダッシュの開始形状を定義する値を設定します。 |
+| [setStrokeThickness(float value)](#setStrokeThickness-float-) | 有効座標空間の単位でストロークの太さを設定します（パスのレンダー変換を含む）。 |
+| [size()](#size--) | 子要素の数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPath deepClone()
+```
+
+
+このパスをクローンします。
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Clone this path.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+インデックス i による要素の子へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 子要素のインデックス。 |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+要素の描画領域を制限するパスジオメトリを返します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getData() {#getData--}
+```
+public XpsPathGeometry getData()
+```
+
+
+パスのジオメトリを返します。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The geometry of the path.
+### getFill() {#getFill--}
+```
+public XpsBrush getFill()
+```
+
+
+パスの Data プロパティで指定されたジオメトリを描画するために使用されるブラシを返します。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush used to paint the geometry specified
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+ハイパーリンクのターゲットオブジェクトを返します。
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+要素の均一な透明度を定義する値を返します。
+
+**Returns:**
+float - 要素の均一な透明度を定義する値。
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 属性と同様に要素に適用されるアルファ値のマスクを指定するブラシを返しますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を返します。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### getStroke() {#getStroke--}
+```
+public XpsBrush getStroke()
+```
+
+
+ストロークを描画するために使用されるブラシを返します。
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush used to draw the stroke.
+### getStrokeDashArray() {#getStrokeDashArray--}
+```
+public float[] getStrokeDashArray()
+```
+
+
+アウトラインストロークのダッシュとギャップの長さを指定する配列を返します。
+
+**Returns:**
+float[] - アウトラインストロークのダッシュとギャップの長さを指定する配列。
+### getStrokeDashCap() {#getStrokeDashCap--}
+```
+public XpsDashCap getStrokeDashCap()
+```
+
+
+各ダッシュの端がどのように描画されるかを指定する値を返します。
+
+**Returns:**
+[XpsDashCap](../../com.aspose.xps/xpsdashcap) - The value specifying how the ends of each dash are drawn.
+### getStrokeDashOffset() {#getStrokeDashOffset--}
+```
+public float getStrokeDashOffset()
+```
+
+
+ダッシュ配列パターンを繰り返す開始点を返します。この値が省略された場合、ダッシュ配列はストロークの原点に合わせられます。
+
+**Returns:**
+float - ダッシュ配列パターンを繰り返す開始点です。
+### getStrokeEndLineCap() {#getStrokeEndLineCap--}
+```
+public XpsLineCap getStrokeEndLineCap()
+```
+
+
+ストローク内の最後のダッシュの終端形状を定義する値を返します。
+
+**Returns:**
+[XpsLineCap](../../com.aspose.xps/xpslinecap) - The value defining the shape of the end of the last dash in a stroke.
+### getStrokeLineJoin() {#getStrokeLineJoin--}
+```
+public XpsLineJoin getStrokeLineJoin()
+```
+
+
+ストローク内の最初のダッシュの開始形状を定義する値を返します。
+
+**Returns:**
+[XpsLineJoin](../../com.aspose.xps/xpslinejoin) - The value defining the shape of the beginning of the first dash in a stroke.
+### getStrokeMiterLimit() {#getStrokeMiterLimit--}
+```
+public float getStrokeMiterLimit()
+```
+
+
+最大ミータ長とストロークの厚さの半分との比率を返します。この値は、  StrokeLineJoin  属性が  Miter  を指定している場合にのみ有効です。
+
+**Returns:**
+float - 最大ミータ長とストロークの厚さの半分との比率です。
+### getStrokeStartLineCap() {#getStrokeStartLineCap--}
+```
+public XpsLineCap getStrokeStartLineCap()
+```
+
+
+ストローク内の最初のダッシュの開始形状を定義する値を返します。
+
+**Returns:**
+[XpsLineCap](../../com.aspose.xps/xpslinecap) - The value defining the shape of the beginning of the first dash in a stroke.
+### getStrokeThickness() {#getStrokeThickness--}
+```
+public float getStrokeThickness()
+```
+
+
+ストロークの太さを、実効座標空間の単位で返します（パスのレンダートランスフォームを含む）。ストロークは Path element\\u2019s Data property が指定するジオメトリの境界の上に描画されます。StrokeThickness の半分は Data プロパティが指定するジオメトリの外側に伸び、残りの半分はジオメトリの内部に伸びます。
+
+**Returns:**
+float - ストロークの太さです。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable インターフェイスの実装。
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - リストの列挙子を返します。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+要素の描画領域を制限するパスジオメトリを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 要素の描画領域を制限するパスジオメトリ。 |
+
+### setData(XpsPathGeometry value) {#setData-com.aspose.xps.XpsPathGeometry-}
+```
+public void setData(XpsPathGeometry value)
+```
+
+
+パスのジオメトリを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | パスのジオメトリ。 |
+
+### setFill(XpsBrush value) {#setFill-com.aspose.xps.XpsBrush-}
+```
+public void setFill(XpsBrush value)
+```
+
+
+パスの Data プロパティで指定されたジオメトリを描画するために使用されるブラシを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 指定されたジオメトリを塗装するために使用されるブラシです。 |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+ハイパーリンクのターゲットオブジェクトを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | ハイパーリンクのターゲットオブジェクト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+要素の均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 要素の均一な透明度を定義する値。 |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+要素に適用されるアルファ値のマスクを指定するブラシを設定します。このマスクは Opacity 属性と同様の方法で適用されますが、要素の異なる領域に対して異なるアルファ値を設定できます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | マスクを指定するブラシ。 |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+要素およびすべての子要素（存在する場合）のすべての属性に対して新しい座標系を確立するアフィン変換行列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | アフィン変換行列。 |
+
+### setStroke(XpsBrush value) {#setStroke-com.aspose.xps.XpsBrush-}
+```
+public void setStroke(XpsBrush value)
+```
+
+
+ストロークを描画するために使用されるブラシを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | ストロークを描画するために使用されるブラシです。 |
+
+### setStrokeDashArray(float[] value) {#setStrokeDashArray-float---}
+```
+public void setStrokeDashArray(float[] value)
+```
+
+
+アウトラインストロークのダッシュとギャップの長さを指定する配列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float[] | アウトラインストロークのダッシュとギャップの長さを指定する配列です。 |
+
+### setStrokeDashCap(XpsDashCap value) {#setStrokeDashCap-com.aspose.xps.XpsDashCap-}
+```
+public void setStrokeDashCap(XpsDashCap value)
+```
+
+
+各ダッシュの端がどのように描画されるかを指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsDashCap](../../com.aspose.xps/xpsdashcap) | 各ダッシュの端がどのように描画されるかを指定する値です。 |
+
+### setStrokeDashOffset(float value) {#setStrokeDashOffset-float-}
+```
+public void setStrokeDashOffset(float value)
+```
+
+
+ダッシュ配列パターンを繰り返す開始点を設定します。この値が省略された場合、ダッシュ配列はストロークの原点に合わせられます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ダッシュ配列パターンを繰り返す開始点です。 |
+
+### setStrokeEndLineCap(XpsLineCap value) {#setStrokeEndLineCap-com.aspose.xps.XpsLineCap-}
+```
+public void setStrokeEndLineCap(XpsLineCap value)
+```
+
+
+ストローク内の最後のダッシュの終端形状を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsLineCap](../../com.aspose.xps/xpslinecap) | ストローク内の最後のダッシュの端の形状を定義する値です。 |
+
+### setStrokeLineJoin(XpsLineJoin value) {#setStrokeLineJoin-com.aspose.xps.XpsLineJoin-}
+```
+public void setStrokeLineJoin(XpsLineJoin value)
+```
+
+
+ストローク内の最初のダッシュの開始形状を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsLineJoin](../../com.aspose.xps/xpslinejoin) | ストローク内の最初のダッシュの開始部の形状を定義する値です。 |
+
+### setStrokeMiterLimit(float value) {#setStrokeMiterLimit-float-}
+```
+public void setStrokeMiterLimit(float value)
+```
+
+
+最大ミータ長とストロークの厚さの半分との比率を設定します。この値は、  StrokeLineJoin  属性が  Miter  を指定している場合にのみ有効です。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 最大ミータ長とストロークの厚さの半分との比率です。 |
+
+### setStrokeStartLineCap(XpsLineCap value) {#setStrokeStartLineCap-com.aspose.xps.XpsLineCap-}
+```
+public void setStrokeStartLineCap(XpsLineCap value)
+```
+
+
+ストローク内の最初のダッシュの開始形状を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsLineCap](../../com.aspose.xps/xpslinecap) | ストローク内の最初のダッシュの開始部の形状を定義する値です。 |
+
+### setStrokeThickness(float value) {#setStrokeThickness-float-}
+```
+public void setStrokeThickness(float value)
+```
+
+
+ストロークの太さを、実効座標空間の単位で設定します（パスのレンダートランスフォームを含む）。ストロークは Path element\\u2019s Data property が指定するジオメトリの境界の上に描画されます。StrokeThickness の半分は Data プロパティが指定するジオメトリの外側に伸び、残りの半分はジオメトリの内部に伸びます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ストロークの太さです。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+子要素の数を返します。
+
+**Returns:**
+int - 子要素の数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspathfigure/_index.md
+++ b/japanese/java/com.aspose.xps/xpspathfigure/_index.md
@@ -1,0 +1,313 @@
+---
+title: "XpsPathFigure"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PathFigure 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 41
+url: /ja/java/com.aspose.xps/xpspathfigure/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), com.aspose.xps.XpsArray
+```
+public class XpsPathFigure extends XpsArray<XpsPathSegment>
+```
+
+PathFigure 要素の機能をカプセル化するクラスです。この要素は、1 つ以上の直線または曲線セグメントの集合で構成されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(T obj)](#add-T-) | 配列に新しいオブジェクトを追加します。 |
+| [deepClone()](#deepClone--) | このパスフィギュアをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i によって配列の要素へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getSegments()](#getSegments--) | 子パスセグメントのリストを返します。 |
+| [getStartPoint()](#getStartPoint--) | パスフィギュアの最初のセグメントの開始点を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [insert(int index, T obj)](#insert-int-T-) | 指定された位置に新しいオブジェクトを配列に挿入します。 |
+| [isClosed()](#isClosed--) | パスフィギュアが閉じているかどうかを示す値を返します。 |
+| [isFilled()](#isFilled--) | パスフィギュアが包含するパスジオメトリの面積計算に使用されているかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(T obj)](#remove-T-) | 配列からオブジェクトを削除します。 |
+| [removeAt(int index)](#removeAt-int-) | 指定された位置で配列からオブジェクトを削除します。 |
+| [setClosed(boolean value)](#setClosed-boolean-) | パスフィギュアが閉じているかどうかを示す値を設定します。 |
+| [setFilled(boolean value)](#setFilled-boolean-) | パスフィギュアが包含するパスジオメトリの面積計算に使用されているかどうかを示す値を設定します。 |
+| [setStartPoint(Point2D value)](#setStartPoint-java.awt.geom.Point2D-) | パスフィギュアの最初のセグメントの開始点を設定します。 |
+| [size()](#size--) | 要素数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(T obj) {#add-T-}
+```
+public T add(T obj)
+```
+
+
+配列に新しいオブジェクトを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T | 追加するオブジェクト。 |
+
+**Returns:**
+T - 追加されたオブジェクト。
+### deepClone() {#deepClone--}
+```
+public XpsPathFigure deepClone()
+```
+
+
+このパスフィギュアをクローンします。
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - Clone of this path figure.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public T get(int i)
+```
+
+
+インデックス i によって配列の要素へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 要素のインデックス。 |
+
+**Returns:**
+T - インデックス i の位置にある要素。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSegments() {#getSegments--}
+```
+public List<XpsPathSegment> getSegments()
+```
+
+
+子パスセグメントのリストを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsPathSegment> - 子パスセグメントのリスト。
+### getStartPoint() {#getStartPoint--}
+```
+public Point2D getStartPoint()
+```
+
+
+パスフィギュアの最初のセグメントの開始点を返します。
+
+**Returns:**
+java.awt.geom.Point2D - パスフィギュアの最初のセグメントの開始点。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insert(int index, T obj) {#insert-int-T-}
+```
+public T insert(int index, T obj)
+```
+
+
+指定された位置に新しいオブジェクトを配列に挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | オブジェクトを挿入する位置。 |
+| obj | T | 挿入するオブジェクト。 |
+
+**Returns:**
+T - 挿入されたオブジェクト。
+### isClosed() {#isClosed--}
+```
+public boolean isClosed()
+```
+
+
+パスフィギュアが閉じているかどうかを示す値を返します。
+
+**Returns:**
+boolean - パス図形が閉じているかどうかを示す値。
+### isFilled() {#isFilled--}
+```
+public boolean isFilled()
+```
+
+
+パスフィギュアが包含するパスジオメトリの面積計算に使用されているかどうかを示す値を返します。
+
+**Returns:**
+boolean - パス図形が包含するパスジオメトリの面積計算に使用されているかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(T obj) {#remove-T-}
+```
+public T remove(T obj)
+```
+
+
+配列からオブジェクトを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T | 削除するオブジェクト。 |
+
+**Returns:**
+T - 削除されたオブジェクト。
+### removeAt(int index) {#removeAt-int-}
+```
+public T removeAt(int index)
+```
+
+
+指定された位置で配列からオブジェクトを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | オブジェクトを削除する位置。 |
+
+**Returns:**
+T - 削除されたオブジェクト。
+### setClosed(boolean value) {#setClosed-boolean-}
+```
+public void setClosed(boolean value)
+```
+
+
+パスフィギュアが閉じているかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | パス図形が閉じているかどうかを示す値。 |
+
+### setFilled(boolean value) {#setFilled-boolean-}
+```
+public void setFilled(boolean value)
+```
+
+
+パスフィギュアが包含するパスジオメトリの面積計算に使用されているかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | パス図形が包含するパスジオメトリの面積計算に使用されているかどうかを示す値。 |
+
+### setStartPoint(Point2D value) {#setStartPoint-java.awt.geom.Point2D-}
+```
+public void setStartPoint(Point2D value)
+```
+
+
+パスフィギュアの最初のセグメントの開始点を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Point2D | パス図形の最初のセグメントの開始点。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+要素数を返します。
+
+**Returns:**
+int - 要素数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspathgeometry/_index.md
+++ b/japanese/java/com.aspose.xps/xpspathgeometry/_index.md
@@ -1,0 +1,356 @@
+---
+title: "XpsPathGeometry"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PathGeometry プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 42
+url: /ja/java/com.aspose.xps/xpspathgeometry/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), com.aspose.xps.XpsArray
+
+**All Implemented Interfaces:**
+com.aspose.xps.ITransformableProperty
+```
+public final class XpsPathGeometry extends XpsArray<XpsPathFigure> implements ITransformableProperty
+```
+
+PathGeometry プロパティ要素の機能をカプセル化するクラス。この要素は、Figures 属性または子 PathFigure 要素のいずれかで指定されたパス図形のセットを含みます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [add(T obj)](#add-T-) | 配列に新しいオブジェクトを追加します。 |
+| [addSegment(XpsPathSegment segment)](#addSegment-com.aspose.xps.XpsPathSegment-) | 最後の pah 図形の子セグメントリストにパスセグメントを追加します。 |
+| [deepClone()](#deepClone--) | このパスジオメトリをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | インデックス i によって配列の要素へのアクセスを提供します。 |
+| [getClass()](#getClass--) |  |
+| [getFillRule()](#getFillRule--) | 幾何形状の交差領域がどのように結合されて領域を形成するかを指定する値を返します。 |
+| [getPathFigures()](#getPathFigures--) | 子パス図形のリストを返します。 |
+| [getTransform()](#getTransform--) | パスジオメトリが塗りつぶし、クリッピング、またはストロークに使用される前に、すべての子および子孫要素に適用されるローカル行列変換を確立するアフィン変換行列を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [insert(int index, T obj)](#insert-int-T-) | 指定された位置に新しいオブジェクトを配列に挿入します。 |
+| [insertSegment(int index, XpsPathSegment segment)](#insertSegment-int-com.aspose.xps.XpsPathSegment-) | 最後のパス図形の子セグメントリストの index 位置にパスセグメントを挿入します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(T obj)](#remove-T-) | 配列からオブジェクトを削除します。 |
+| [removeAt(int index)](#removeAt-int-) | 指定された位置で配列からオブジェクトを削除します。 |
+| [removeSegment(XpsPathSegment segment)](#removeSegment-com.aspose.xps.XpsPathSegment-) | 最後のパス図形の子セグメントリストからパスセグメントを削除します。 |
+| [removeSegmentAt(int index)](#removeSegmentAt-int-) | 最後のパス図形の子セグメントリストの index 位置からパスセグメントを削除します。 |
+| [setFillRule(XpsFillRule value)](#setFillRule-com.aspose.xps.XpsFillRule-) | 幾何形状の交差領域がどのように結合されて領域を形成するかを指定する値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | パスジオメトリが塗りつぶし、クリッピング、またはストロークに使用される前に、すべての子および子孫要素に適用されるローカル行列変換を確立するアフィン変換行列を設定します。 |
+| [size()](#size--) | 要素数を返します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(T obj) {#add-T-}
+```
+public T add(T obj)
+```
+
+
+配列に新しいオブジェクトを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T | 追加するオブジェクト。 |
+
+**Returns:**
+T - 追加されたオブジェクト。
+### addSegment(XpsPathSegment segment) {#addSegment-com.aspose.xps.XpsPathSegment-}
+```
+public XpsPathSegment addSegment(XpsPathSegment segment)
+```
+
+
+最後の pah 図形の子セグメントリストにパスセグメントを追加します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| segment | [XpsPathSegment](../../com.aspose.xps/xpspathsegment) | 追加されるパスセグメント。 |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Added path segment.
+### deepClone() {#deepClone--}
+```
+public XpsPathGeometry deepClone()
+```
+
+
+このパスジオメトリをクローンします。
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - Clone of this path geometry.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public T get(int i)
+```
+
+
+インデックス i によって配列の要素へのアクセスを提供します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| i | int | 要素のインデックス。 |
+
+**Returns:**
+T - インデックス i の位置にある要素。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFillRule() {#getFillRule--}
+```
+public XpsFillRule getFillRule()
+```
+
+
+幾何形状の交差領域がどのように結合されて領域を形成するかを指定する値を返します。
+
+**Returns:**
+[XpsFillRule](../../com.aspose.xps/xpsfillrule) - The value specifying how the intersecting areas of geometric shapes are combined to form a region.
+### getPathFigures() {#getPathFigures--}
+```
+public List<XpsPathFigure> getPathFigures()
+```
+
+
+子パス図形のリストを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsPathFigure> - 子パス図形のリスト。
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+パスジオメトリが塗りつぶし、クリッピング、またはストロークに使用される前に、すべての子および子孫要素に適用されるローカル行列変換を確立するアフィン変換行列を返します。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insert(int index, T obj) {#insert-int-T-}
+```
+public T insert(int index, T obj)
+```
+
+
+指定された位置に新しいオブジェクトを配列に挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | オブジェクトを挿入する位置。 |
+| obj | T | 挿入するオブジェクト。 |
+
+**Returns:**
+T - 挿入されたオブジェクト。
+### insertSegment(int index, XpsPathSegment segment) {#insertSegment-int-com.aspose.xps.XpsPathSegment-}
+```
+public XpsPathSegment insertSegment(int index, XpsPathSegment segment)
+```
+
+
+最後のパス図形の子セグメントリストの index 位置にパスセグメントを挿入します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | セグメントを挿入すべき位置。 |
+| segment | [XpsPathSegment](../../com.aspose.xps/xpspathsegment) | 挿入されるパスセグメント。 |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Inserted path segment.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(T obj) {#remove-T-}
+```
+public T remove(T obj)
+```
+
+
+配列からオブジェクトを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| obj | T | 削除するオブジェクト。 |
+
+**Returns:**
+T - 削除されたオブジェクト。
+### removeAt(int index) {#removeAt-int-}
+```
+public T removeAt(int index)
+```
+
+
+指定された位置で配列からオブジェクトを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | オブジェクトを削除する位置。 |
+
+**Returns:**
+T - 削除されたオブジェクト。
+### removeSegment(XpsPathSegment segment) {#removeSegment-com.aspose.xps.XpsPathSegment-}
+```
+public XpsPathSegment removeSegment(XpsPathSegment segment)
+```
+
+
+最後のパス図形の子セグメントリストからパスセグメントを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| segment | [XpsPathSegment](../../com.aspose.xps/xpspathsegment) | 削除されるパスセグメント。 |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Removed path segment.
+### removeSegmentAt(int index) {#removeSegmentAt-int-}
+```
+public XpsPathSegment removeSegmentAt(int index)
+```
+
+
+最後のパス図形の子セグメントリストの index 位置からパスセグメントを削除します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| インデックス | int | パスセグメントを削除すべき位置。 |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Removed path segment.
+### setFillRule(XpsFillRule value) {#setFillRule-com.aspose.xps.XpsFillRule-}
+```
+public void setFillRule(XpsFillRule value)
+```
+
+
+幾何形状の交差領域がどのように結合されて領域を形成するかを指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsFillRule](../../com.aspose.xps/xpsfillrule) | 幾何形状の交差領域がどのように結合されて領域を形成するかを指定する値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+パスジオメトリが塗りつぶし、クリッピング、またはストロークに使用される前に、すべての子および子孫要素に適用されるローカル行列変換を確立するアフィン変換行列を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | アフィン変換行列。 |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+要素数を返します。
+
+**Returns:**
+int - 要素数。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspathpolysegment/_index.md
+++ b/japanese/java/com.aspose.xps/xpspathpolysegment/_index.md
@@ -1,0 +1,149 @@
+---
+title: "XpsPathPolySegment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PolyLineSegment、PolyBzierSegment、PolyQuadraticBzierSegment 要素の共通機能をカプセル化するクラス。"
+type: docs
+weight: 43
+url: /ja/java/com.aspose.xps/xpspathpolysegment/
+---
+**Inheritance:**
+java.lang.Object、[com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)、[com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment)
+```
+public abstract class XpsPathPolySegment extends XpsPathSegment
+```
+
+PolyLineSegment、PolyB?zierSegment、PolyQuadraticB?zierSegment 要素の共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | このパスセグメントのストロークが描画されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | このパスセグメントのストロークが描画されるかどうかを示す値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - このパスセグメントのストロークが描画されるかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | このパスセグメントのストロークが描画されるかどうかを示す値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspathsegment/_index.md
+++ b/japanese/java/com.aspose.xps/xpspathsegment/_index.md
@@ -1,0 +1,149 @@
+---
+title: "XpsPathSegment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "すべてのパスセグメント要素の共通機能をカプセル化するクラス。"
+type: docs
+weight: 44
+url: /ja/java/com.aspose.xps/xpspathsegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public abstract class XpsPathSegment extends XpsObject
+```
+
+すべてのパスセグメント要素の共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | このパスセグメントのストロークが描画されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | このパスセグメントのストロークが描画されるかどうかを示す値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - このパスセグメントのストロークが描画されるかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | このパスセグメントのストロークが描画されるかどうかを示す値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspolybeziersegment/_index.md
+++ b/japanese/java/com.aspose.xps/xpspolybeziersegment/_index.md
@@ -1,0 +1,160 @@
+---
+title: "XpsPolyBezierSegment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PolyBezierSegment 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 45
+url: /ja/java/com.aspose.xps/xpspolybeziersegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment), [com.aspose.xps.XpsPathPolySegment](../../com.aspose.xps/xpspathpolysegment)
+```
+public class XpsPolyBezierSegment extends XpsPathPolySegment
+```
+
+PolyBezierSegment 要素の機能をカプセル化するクラス。この要素は一連の三次ベジエ曲線を記述します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この三次ベジエ曲線のセットをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | このパスセグメントのストロークが描画されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | このパスセグメントのストロークが描画されるかどうかを示す値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPolyBezierSegment deepClone()
+```
+
+
+この三次ベジエ曲線のセットをクローンします。
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - Clone of this set of cubic B?zier curves.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - このパスセグメントのストロークが描画されるかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | このパスセグメントのストロークが描画されるかどうかを示す値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspolylinesegment/_index.md
+++ b/japanese/java/com.aspose.xps/xpspolylinesegment/_index.md
@@ -1,0 +1,160 @@
+---
+title: "XpsPolyLineSegment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PolyLineSegment 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 46
+url: /ja/java/com.aspose.xps/xpspolylinesegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment), [com.aspose.xps.XpsPathPolySegment](../../com.aspose.xps/xpspathpolysegment)
+```
+public class XpsPolyLineSegment extends XpsPathPolySegment
+```
+
+PolyLineSegment 要素の機能をカプセル化するクラスです。この要素は、任意の数の個別の頂点を含む多角形の描画を表します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この多角形をクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | このパスセグメントのストロークが描画されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | このパスセグメントのストロークが描画されるかどうかを示す値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPolyLineSegment deepClone()
+```
+
+
+この多角形をクローンします。
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - Clone of this polygon.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - このパスセグメントのストロークが描画されるかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | このパスセグメントのストロークが描画されるかどうかを示す値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpspolyquadraticbeziersegment/_index.md
+++ b/japanese/java/com.aspose.xps/xpspolyquadraticbeziersegment/_index.md
@@ -1,0 +1,160 @@
+---
+title: "XpsPolyQuadraticBezierSegment"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "PolyQuadraticBezierSegment 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 47
+url: /ja/java/com.aspose.xps/xpspolyquadraticbeziersegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment), [com.aspose.xps.XpsPathPolySegment](../../com.aspose.xps/xpspathpolysegment)
+```
+public class XpsPolyQuadraticBezierSegment extends XpsPathPolySegment
+```
+
+PolyQuadraticBezierSegment 要素の機能をカプセル化するクラス。この要素は、パス図形の前の点から一連の頂点を通り、指定された制御点を使用して二次 B?zier 曲線のセットを記述します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この二次 B?zier 曲線のセットを複製します。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | このパスセグメントのストロークが描画されるかどうかを示す値を返します。 |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | このパスセグメントのストロークが描画されるかどうかを示す値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPolyQuadraticBezierSegment deepClone()
+```
+
+
+この二次 B?zier 曲線のセットを複製します。
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - Clone of this set of quadratic B?zier curves.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を返します。
+
+**Returns:**
+boolean - このパスセグメントのストロークが描画されるかどうかを示す値。
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+このパスセグメントのストロークが描画されるかどうかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | boolean | このパスセグメントのストロークが描画されるかどうかを示す値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsradialgradientbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpsradialgradientbrush/_index.md
@@ -1,0 +1,360 @@
+---
+title: "XpsRadialGradientBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "RadialGradientBrush プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 48
+url: /ja/java/com.aspose.xps/xpsradialgradientbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsGradientBrush](../../com.aspose.xps/xpsgradientbrush)
+```
+public final class XpsRadialGradientBrush extends XpsGradientBrush
+```
+
+RadialGradientBrush プロパティ要素機能をカプセル化するクラス。この要素は放射状グラデーションブラシを指定するために使用されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この放射状グラデーションブラシをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenter()](#getCenter--) | 放射状グラデーションの中心点を返します（すなわち、楕円の中心）。 |
+| [getClass()](#getClass--) |  |
+| [getColorInterpolationMode()](#getColorInterpolationMode--) | 色の補間に使用されるガンマ関数を指定する値を返します。 |
+| [getGradientOrigin()](#getGradientOrigin--) | 放射状グラデーションの原点を返します。 |
+| [getGradientStops()](#getGradientStops--) | グラデーションを構成するグラデーションストップのリストを返します。 |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getRadiusX()](#getRadiusX--) | 放射状グラデーションを定義する楕円の x 軸方向の半径を返します。 |
+| [getRadiusY()](#getRadiusY--) | 放射状グラデーションを定義する楕円の y 軸方向の半径を返します。 |
+| [getSpreadMethod()](#getSpreadMethod--) | ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCenter(Point2D value)](#setCenter-java.awt.geom.Point2D-) | 放射状グラデーションの中心点を設定します（すなわち、楕円の中心）。 |
+| [setColorInterpolationMode(XpsColorInterpolationMode value)](#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-) | 色の補間に使用されるガンマ関数を指定する値を設定します。 |
+| [setGradientOrigin(Point2D value)](#setGradientOrigin-java.awt.geom.Point2D-) | 放射状グラデーションの原点を設定します。 |
+| [setGradientStops(List<XpsGradientStop> value)](#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--) | グラデーションを構成するグラデーションストップのリストを設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setRadiusX(float value)](#setRadiusX-float-) | 放射状グラデーションを定義する楕円の x 軸方向の半径を設定します。 |
+| [setRadiusY(float value)](#setRadiusY-float-) | 放射状グラデーションを定義する楕円の y 軸方向の半径を設定します。 |
+| [setSpreadMethod(XpsSpreadMethod value)](#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-) | ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsRadialGradientBrush deepClone()
+```
+
+
+この放射状グラデーションブラシをクローンします。
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - Clone of this radial gradient brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenter() {#getCenter--}
+```
+public Point2D getCenter()
+```
+
+
+放射状グラデーションの中心点を返します（すなわち、楕円の中心）。
+
+**Returns:**
+java.awt.geom.Point2D - 放射状グラデーションの中心点。
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColorInterpolationMode() {#getColorInterpolationMode--}
+```
+public XpsColorInterpolationMode getColorInterpolationMode()
+```
+
+
+色の補間に使用されるガンマ関数を指定する値を返します。ガンマ調整は、指定されている場合、アルファ成分には適用しないでください。
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) - Value specifying the gamma function for color interpolation.
+### getGradientOrigin() {#getGradientOrigin--}
+```
+public Point2D getGradientOrigin()
+```
+
+
+放射状グラデーションの原点を返します。
+
+**Returns:**
+java.awt.geom.Point2D - 放射状グラデーションの原点。
+### getGradientStops() {#getGradientStops--}
+```
+public List<XpsGradientStop> getGradientStops()
+```
+
+
+グラデーションを構成するグラデーションストップのリストを返します。
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsGradientStop> - グラデーションを構成するグラデーションストップのリスト。
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getRadiusX() {#getRadiusX--}
+```
+public float getRadiusX()
+```
+
+
+放射状グラデーションを定義する楕円の x 軸方向の半径を返します。
+
+**Returns:**
+float - 放射状グラデーションを定義する楕円の x 軸方向の半径。
+### getRadiusY() {#getRadiusY--}
+```
+public float getRadiusY()
+```
+
+
+放射状グラデーションを定義する楕円の y 軸方向の半径を返します。
+
+**Returns:**
+float - 放射状グラデーションを定義する楕円の y 軸方向の半径。
+### getSpreadMethod() {#getSpreadMethod--}
+```
+public XpsSpreadMethod getSpreadMethod()
+```
+
+
+ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を返します。
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) - Value describing how the brush should fill the content area outside of the primary, initial gradient area.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCenter(Point2D value) {#setCenter-java.awt.geom.Point2D-}
+```
+public void setCenter(Point2D value)
+```
+
+
+放射状グラデーションの中心点を設定します（すなわち、楕円の中心）。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Point2D | 放射状グラデーションの中心点。 |
+
+### setColorInterpolationMode(XpsColorInterpolationMode value) {#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-}
+```
+public void setColorInterpolationMode(XpsColorInterpolationMode value)
+```
+
+
+カラー補間のガンマ関数を指定する値を設定します。指定されている場合、ガンマ調整はアルファ成分には適用しないでください。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) | カラー補間のガンマ関数を指定する値。 |
+
+### setGradientOrigin(Point2D value) {#setGradientOrigin-java.awt.geom.Point2D-}
+```
+public void setGradientOrigin(Point2D value)
+```
+
+
+放射状グラデーションの原点を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Point2D | 放射状グラデーションの起点。 |
+
+### setGradientStops(List<XpsGradientStop> value) {#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--}
+```
+public void setGradientStops(List<XpsGradientStop> value)
+```
+
+
+グラデーションを構成するグラデーションストップのリストを設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.util.List<com.aspose.xps.XpsGradientStop> | グラデーションを構成するグラデーションストップのリスト。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setRadiusX(float value) {#setRadiusX-float-}
+```
+public void setRadiusX(float value)
+```
+
+
+放射状グラデーションを定義する楕円の x 軸方向の半径を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 放射状グラデーションを定義する楕円の x 軸方向の半径です。 |
+
+### setRadiusY(float value) {#setRadiusY-float-}
+```
+public void setRadiusY(float value)
+```
+
+
+放射状グラデーションを定義する楕円の y 軸方向の半径を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | 放射状グラデーションを定義する楕円の y 軸方向の半径です。 |
+
+### setSpreadMethod(XpsSpreadMethod value) {#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-}
+```
+public void setSpreadMethod(XpsSpreadMethod value)
+```
+
+
+ブラシが主要な初期グラデーション領域の外側のコンテンツ領域をどのように塗りつぶすかを示す値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) | 一次的な初期グラデーション領域の外側のコンテンツ領域をブラシがどのように塗りつぶすかを示す値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsrgbcolor/_index.md
+++ b/japanese/java/com.aspose.xps/xpsrgbcolor/_index.md
@@ -1,0 +1,135 @@
+---
+title: "XpsRgbColor"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "任意の色空間 sRGB または scRGB の RGB カラーをカプセル化します。"
+type: docs
+weight: 49
+url: /ja/java/com.aspose.xps/xpsrgbcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsColor](../../com.aspose.xps/xpscolor)
+```
+public final class XpsRgbColor extends XpsColor
+```
+
+任意の色空間（sRGB または scRGB）の RGB カラーをカプセル化します。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toColor()](#toColor--) | .NET のネイティブ表現の RGB カラーを取得するための便利メソッド。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toColor() {#toColor--}
+```
+public Color toColor()
+```
+
+
+.NET のネイティブ表現の RGB カラーを取得するための便利メソッド。
+
+**Returns:**
+java.awt.Color -  System.Drawing.ColorSystem.Drawing.Color 構造体。
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpssolidcolorbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpssolidcolorbrush/_index.md
@@ -1,0 +1,185 @@
+---
+title: "XpsSolidColorBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "SolidColorBrush プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 50
+url: /ja/java/com.aspose.xps/xpssolidcolorbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush)
+```
+public final class XpsSolidColorBrush extends XpsBrush
+```
+
+SolidColorBrush プロパティ要素の機能をカプセル化するクラス。この要素は定義された幾何領域を単色で塗りつぶすために使用されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この単色ブラシをクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | 塗りつぶし要素の色を返します。 |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(XpsColor value)](#setColor-com.aspose.xps.XpsColor-) | 塗りつぶし要素の色を設定します。 |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsSolidColorBrush deepClone()
+```
+
+
+この単色ブラシをクローンします。
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - Clone of this solid color brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public XpsColor getColor()
+```
+
+
+塗りつぶし要素の色を返します。
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - The color for filled elements.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(XpsColor value) {#setColor-com.aspose.xps.XpsColor-}
+```
+public void setColor(XpsColor value)
+```
+
+
+塗りつぶし要素の色を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsColor](../../com.aspose.xps/xpscolor) | 塗りつぶし要素の色です。 |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsspreadmethod/_index.md
+++ b/japanese/java/com.aspose.xps/xpsspreadmethod/_index.md
@@ -1,0 +1,259 @@
+---
+title: "XpsSpreadMethod"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "グラデーションブラシの SpreadMethod プロパティの有効な値。"
+type: docs
+weight: 63
+url: /ja/java/com.aspose.xps/xpsspreadmethod/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsSpreadMethod extends Enum<XpsSpreadMethod>
+```
+
+グラデーションブラシの SpreadMethod プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Pad](#Pad) | この方法では、最初の色と最後の色が、開始時と終了時の残りの塗りつぶし領域を埋めるために使用されます。 |
+| [Reflect](#Reflect) | この方法では、グラデーション ストップが逆順で繰り返し再生され、塗りつぶし領域をカバーします。 |
+| [Repeat](#Repeat) | この方法では、グラデーション ストップが順番に繰り返され、塗りつぶし領域が覆われるまで続きます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pad {#Pad}
+```
+public static final XpsSpreadMethod Pad
+```
+
+
+この方法では、最初の色と最後の色が、開始時と終了時の残りの塗りつぶし領域を埋めるために使用されます。
+
+### Reflect {#Reflect}
+```
+public static final XpsSpreadMethod Reflect
+```
+
+
+この方法では、グラデーション ストップが逆順で繰り返し再生され、塗りつぶし領域をカバーします。
+
+### Repeat {#Repeat}
+```
+public static final XpsSpreadMethod Repeat
+```
+
+
+この方法では、グラデーション ストップが順番に繰り返され、塗りつぶし領域が覆われるまで続きます。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsSpreadMethod valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod)
+### values() {#values--}
+```
+public static XpsSpreadMethod[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsSpreadMethod[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsstylesimulations/_index.md
+++ b/japanese/java/com.aspose.xps/xpsstylesimulations/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsStyleSimulations"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Glyphs 要素の StyleSimulations プロパティの有効な値。"
+type: docs
+weight: 64
+url: /ja/java/com.aspose.xps/xpsstylesimulations/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsStyleSimulations extends Enum<XpsStyleSimulations>
+```
+
+Glyphs 要素の StyleSimulations プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [BoldItalicSimulation](#BoldItalicSimulation) | 太字斜体シミュレーション |
+| [BoldSimulation](#BoldSimulation) | 太字シミュレーション |
+| [ItalicSimulation](#ItalicSimulation) | 斜体シミュレーション |
+| [None](#None) | スタイルシミュレーションなし |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoldItalicSimulation {#BoldItalicSimulation}
+```
+public static final XpsStyleSimulations BoldItalicSimulation
+```
+
+
+太字斜体シミュレーション
+
+### BoldSimulation {#BoldSimulation}
+```
+public static final XpsStyleSimulations BoldSimulation
+```
+
+
+太字シミュレーション
+
+### ItalicSimulation {#ItalicSimulation}
+```
+public static final XpsStyleSimulations ItalicSimulation
+```
+
+
+斜体シミュレーション
+
+### None {#None}
+```
+public static final XpsStyleSimulations None
+```
+
+
+スタイルシミュレーションなし
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsStyleSimulations valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsStyleSimulations](../../com.aspose.xps/xpsstylesimulations)
+### values() {#values--}
+```
+public static XpsStyleSimulations[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsStyleSimulations[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpssweepdirection/_index.md
+++ b/japanese/java/com.aspose.xps/xpssweepdirection/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsSweepDirection"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "ArcSegment 要素の SweepDirection プロパティの有効な値。"
+type: docs
+weight: 65
+url: /ja/java/com.aspose.xps/xpssweepdirection/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsSweepDirection extends Enum<XpsSweepDirection>
+```
+
+ArcSegment 要素の SweepDirection プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [Clockwise](#Clockwise) | 時計回り方向。 |
+| [Counterclockwise](#Counterclockwise) | 反時計回り方向。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Clockwise {#Clockwise}
+```
+public static final XpsSweepDirection Clockwise
+```
+
+
+時計回り方向。
+
+### Counterclockwise {#Counterclockwise}
+```
+public static final XpsSweepDirection Counterclockwise
+```
+
+
+反時計回り方向。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsSweepDirection valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsSweepDirection](../../com.aspose.xps/xpssweepdirection)
+### values() {#values--}
+```
+public static XpsSweepDirection[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsSweepDirection[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpstilemode/_index.md
+++ b/japanese/java/com.aspose.xps/xpstilemode/_index.md
@@ -1,0 +1,277 @@
+---
+title: "XpsTileMode"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "タイルブラシの TileMode プロパティの有効な値。"
+type: docs
+weight: 66
+url: /ja/java/com.aspose.xps/xpstilemode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsTileMode extends Enum<XpsTileMode>
+```
+
+タイルブラシの TileMode プロパティの有効な値。
+## フィールド
+
+| フィールド | 説明 |
+| --- | --- |
+| [FlipX](#FlipX) | タイルの配置は Tile タイルモードに似ていますが、交互の列のタイルは水平方向に反転します。 |
+| [FlipXY](#FlipXY) | タイルの配置は Tile タイルモードに似っていますが、交互の列のタイルは水平方向に、交互の行のタイルは垂直方向に反転します。 |
+| [FlipY](#FlipY) | タイルの配置は Tile タイルモードに似っていますが、交互の行のタイルは垂直方向に反転します。 |
+| [None](#None) | このモードでは、単一のベースタイルのみが描画されます。 |
+| [Tile](#Tile) | このモードでは、ベースタイルが描画され、残りの領域はベースタイルを繰り返して埋められます。各タイルの右端が次のタイルの左端に、下端が次のタイルの上端に接するように配置されます。 |
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FlipX {#FlipX}
+```
+public static final XpsTileMode FlipX
+```
+
+
+タイルの配置は Tile タイルモードに似ていますが、交互の列のタイルは水平方向に反転します。ベースタイルはビューポートで指定された位置に配置されます。このタイルの左右の列にあるタイルは水平方向に反転します。
+
+### FlipXY {#FlipXY}
+```
+public static final XpsTileMode FlipXY
+```
+
+
+タイルの配置は Tile タイルモードに似っていますが、交互の列のタイルは水平方向に、交互の行のタイルは垂直方向に反転します。ベースタイルはビューポートで指定された位置に配置されます。
+
+### FlipY {#FlipY}
+```
+public static final XpsTileMode FlipY
+```
+
+
+タイルの配置は Tile タイルモードに似っていますが、交互の行のタイルは垂直方向に反転します。ベースタイルはビューポートで指定された位置に配置されます。上下の行は垂直方向に反転します。
+
+### None {#None}
+```
+public static final XpsTileMode None
+```
+
+
+このモードでは、単一のベースタイルのみが描画されます。残りの領域は透明のままです。
+
+### Tile {#Tile}
+```
+public static final XpsTileMode Tile
+```
+
+
+このモードでは、ベースタイルが描画され、残りの領域はベースタイルを繰り返して埋められます。各タイルの右端が次のタイルの左端に、下端が次のタイルの上端に接するように配置されます。
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsTileMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| 名前 | java.lang.String |  |
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode)
+### values() {#values--}
+```
+public static XpsTileMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsTileMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpstilingbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpstilingbrush/_index.md
@@ -1,0 +1,249 @@
+---
+title: "XpsTilingBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "タイルブラシ要素 VisualBrush と ImageBrush の共通機能をカプセル化するクラスです。"
+type: docs
+weight: 51
+url: /ja/java/com.aspose.xps/xpstilingbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush)
+```
+public abstract class XpsTilingBrush extends XpsTransformableBrush
+```
+
+タイルブラシ要素（VisualBrush と ImageBrush）の共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getTileMode()](#getTileMode--) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [getViewbox()](#getViewbox--) | ビュー ポートにマッピングされるブラシのソース コンテンツ領域を返します。 |
+| [getViewport()](#getViewport--) | 最初のブラシタイルの位置とサイズを返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setTileMode(XpsTileMode value)](#setTileMode-com.aspose.xps.XpsTileMode-) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [setViewbox(Rectangle2D value)](#setViewbox-java.awt.geom.Rectangle2D-) | ビュー ポートにマッピングされるブラシのソース コンテンツ領域を設定します。 |
+| [setViewport(Rectangle2D value)](#setViewport-java.awt.geom.Rectangle2D-) | 最初のブラシタイルの位置とサイズを設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getTileMode() {#getTileMode--}
+```
+public XpsTileMode getTileMode()
+```
+
+
+塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を返します。
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode) - Value specifying how tiling is performed in the filled geometry.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### getViewbox() {#getViewbox--}
+```
+public Rectangle2D getViewbox()
+```
+
+
+ビュー ポートにマッピングされるブラシのソース コンテンツ領域を返します。
+
+**Returns:**
+java.awt.geom.Rectangle2D - ビュー ポートにマッピングされるブラシのソース コンテンツ領域。
+### getViewport() {#getViewport--}
+```
+public Rectangle2D getViewport()
+```
+
+
+最初のブラシタイルの位置とサイズを返します。以降のタイルはタイル モードで指定されるように、このタイルを基準に配置されます。
+
+**Returns:**
+java.awt.geom.Rectangle2D - 最初のブラシタイルの位置とサイズ。
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setTileMode(XpsTileMode value) {#setTileMode-com.aspose.xps.XpsTileMode-}
+```
+public void setTileMode(XpsTileMode value)
+```
+
+
+塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsTileMode](../../com.aspose.xps/xpstilemode) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### setViewbox(Rectangle2D value) {#setViewbox-java.awt.geom.Rectangle2D-}
+```
+public void setViewbox(Rectangle2D value)
+```
+
+
+ビュー ポートにマッピングされるブラシのソース コンテンツ領域を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Rectangle2D | ビュー ポートにマッピングされるブラシのソース コンテンツ領域。 |
+
+### setViewport(Rectangle2D value) {#setViewport-java.awt.geom.Rectangle2D-}
+```
+public void setViewport(Rectangle2D value)
+```
+
+
+最初のブラシタイルの位置とサイズを設定します。以降のタイルはタイル モードで指定されるように、このタイルを基準に配置されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Rectangle2D | 最初のブラシタイルの位置とサイズ。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpstransformablebrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpstransformablebrush/_index.md
@@ -1,0 +1,177 @@
+---
+title: "XpsTransformableBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "SolidColorBrush を除く、変形可能なブラシ要素の共通機能をカプセル化するクラス。"
+type: docs
+weight: 52
+url: /ja/java/com.aspose.xps/xpstransformablebrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush)
+
+**All Implemented Interfaces:**
+com.aspose.xps.ITransformableProperty
+```
+public abstract class XpsTransformableBrush extends XpsBrush implements ITransformableProperty
+```
+
+変形可能なブラシ要素（SolidColorBrush を除くすべて）の共通機能をカプセル化するクラス。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsvisual/_index.md
+++ b/japanese/java/com.aspose.xps/xpsvisual/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsVisual"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "Visual 要素の機能をカプセル化するクラス。"
+type: docs
+weight: 53
+url: /ja/java/com.aspose.xps/xpsvisual/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public final class XpsVisual extends XpsObject
+```
+
+Visual 要素の機能をカプセル化するクラス。このプロパティ要素は、単一のビジュアルブラシタイルの内容を定義するマークアップを含みます。そのタイルは、ビジュアルブラシが適用される幾何領域を塗りつぶすために使用できます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/japanese/java/com.aspose.xps/xpsvisualbrush/_index.md
+++ b/japanese/java/com.aspose.xps/xpsvisualbrush/_index.md
@@ -1,0 +1,285 @@
+---
+title: "XpsVisualBrush"
+second_title: "Aspose.Page for Java API リファレンス"
+description: "VisualBrush プロパティ要素の機能をカプセル化するクラス。"
+type: docs
+weight: 54
+url: /ja/java/com.aspose.xps/xpsvisualbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsTilingBrush](../../com.aspose.xps/xpstilingbrush)
+```
+public final class XpsVisualBrush extends XpsTilingBrush
+```
+
+VisualBrush プロパティ要素の機能をカプセル化するクラス。この要素は描画で領域を塗りつぶすために使用されます。
+## メソッド
+
+| メソッド | 説明 |
+| --- | --- |
+| [deepClone()](#deepClone--) | この visual brush をクローンします。 |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | ブラシの塗りの均一な透明度を定義する値を返します。 |
+| [getTileMode()](#getTileMode--) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を返します。 |
+| [getTransform()](#getTransform--) | ブラシの座標空間に適用される行列変換を返します。 |
+| [getViewbox()](#getViewbox--) | ビュー ポートにマッピングされるブラシのソース コンテンツ領域を返します。 |
+| [getViewport()](#getViewport--) | 最初のブラシタイルの位置とサイズを返します。 |
+| [getVisual()](#getVisual--) | brush\\u2019s のソースコンテンツを描画するために使用される Path、Glyphs、または Canvas 要素を返します。 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | ブラシの塗りの均一な透明度を定義する値を設定します。 |
+| [setTileMode(XpsTileMode value)](#setTileMode-com.aspose.xps.XpsTileMode-) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を設定します。 |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | ブラシの座標空間に適用される行列変換を設定します。 |
+| [setViewbox(Rectangle2D value)](#setViewbox-java.awt.geom.Rectangle2D-) | ビュー ポートにマッピングされるブラシのソース コンテンツ領域を設定します。 |
+| [setViewport(Rectangle2D value)](#setViewport-java.awt.geom.Rectangle2D-) | 最初のブラシタイルの位置とサイズを設定します。 |
+| [setVisual(XpsContentElement visual)](#setVisual-com.aspose.xps.XpsContentElement-) | visual を visual brush の Visual 要素として設定します。 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsVisualBrush deepClone()
+```
+
+
+この visual brush をクローンします。
+
+**Returns:**
+[XpsVisualBrush](../../com.aspose.xps/xpsvisualbrush) - Clone of this visual brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を返します。
+
+**Returns:**
+float - ブラシの塗りの均一な透明度を定義する値。
+### getTileMode() {#getTileMode--}
+```
+public XpsTileMode getTileMode()
+```
+
+
+塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を返します。
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode) - Value specifying how tiling is performed in the filled geometry.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+ブラシの座標空間に適用される行列変換を返します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### getViewbox() {#getViewbox--}
+```
+public Rectangle2D getViewbox()
+```
+
+
+ビュー ポートにマッピングされるブラシのソース コンテンツ領域を返します。
+
+**Returns:**
+java.awt.geom.Rectangle2D - ビュー ポートにマッピングされるブラシのソース コンテンツ領域。
+### getViewport() {#getViewport--}
+```
+public Rectangle2D getViewport()
+```
+
+
+最初のブラシタイルの位置とサイズを返します。以降のタイルはタイル モードで指定されるように、このタイルを基準に配置されます。
+
+**Returns:**
+java.awt.geom.Rectangle2D - 最初のブラシタイルの位置とサイズ。
+### getVisual() {#getVisual--}
+```
+public XpsContentElement getVisual()
+```
+
+
+brush\\u2019s のソースコンテンツを描画するために使用される Path、Glyphs、または Canvas 要素を返します。
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - A Path, Glyphs, or Canvas element used to draw the brush\\u2019s source content.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+ブラシの塗りの均一な透明度を定義する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | float | ブラシの塗りの均一な透明度を定義する値。 |
+
+### setTileMode(XpsTileMode value) {#setTileMode-com.aspose.xps.XpsTileMode-}
+```
+public void setTileMode(XpsTileMode value)
+```
+
+
+塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsTileMode](../../com.aspose.xps/xpstilemode) | 塗りつぶされたジオメトリでタイル処理がどのように行われるかを指定する値。 |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+ブラシの座標空間に適用される行列変換を設定します。Transform プロパティは現在の有効なレンダー変換と連結され、ブラシローカルの有効なレンダー変換を生成します。ブラシのビュー ポートはローカルの有効なレンダー変換を使用して変換されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | ブラシの座標空間に適用される行列変換。 |
+
+### setViewbox(Rectangle2D value) {#setViewbox-java.awt.geom.Rectangle2D-}
+```
+public void setViewbox(Rectangle2D value)
+```
+
+
+ビュー ポートにマッピングされるブラシのソース コンテンツ領域を設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Rectangle2D | ビュー ポートにマッピングされるブラシのソース コンテンツ領域。 |
+
+### setViewport(Rectangle2D value) {#setViewport-java.awt.geom.Rectangle2D-}
+```
+public void setViewport(Rectangle2D value)
+```
+
+
+最初のブラシタイルの位置とサイズを設定します。以降のタイルはタイル モードで指定されるように、このタイルを基準に配置されます。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| value | java.awt.geom.Rectangle2D | 最初のブラシタイルの位置とサイズ。 |
+
+### setVisual(XpsContentElement visual) {#setVisual-com.aspose.xps.XpsContentElement-}
+```
+public void setVisual(XpsContentElement visual)
+```
+
+
+visual を visual brush の Visual 要素として設定します。
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| visual | [XpsContentElement](../../com.aspose.xps/xpscontentelement) | 要素。 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| パラメータ | 型 | 説明 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 392/392
- Errors: 0
- Source: `english/java`
- Output: `japanese/java`

🤖 Generated by RDA