### PR TITLE
[auto] Translate JAVA API Reference to Korean

### DIFF
--- a/korean/java/_index.md
+++ b/korean/java/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Aspose.Page용 Java"
+type: docs
+weight: 11
+url: /ko/java/
+description: "Aspose.Page용 Java API 참조는 예제, 코드 스니펫 및 API 문서를 포함합니다. 패키지, 클래스, 인터페이스 및 기타 API 세부 정보를 제공합니다."
+is_root: true
+---
+## Packages
+| 패키지 | 설명 |
+| --- | --- |
+| [com.aspose.eps](./com.aspose.eps) | **com.aspose.eps**는 PS/EPS 파일을 다루는 모든 클래스의 루트 패키지입니다. |
+| [com.aspose.eps.cpp](./com.aspose.eps.cpp) |  |
+| [com.aspose.eps.device](./com.aspose.eps.device) | **com.aspose.eps.device** 패키지는 PS/EPS를 다른 형식으로 변환할 때 사용할 수 있는 가능한 장치와 저장 옵션의 클래스를 제공합니다. |
+| [com.aspose.eps.plugins](./com.aspose.eps.plugins) | ``` **com.aspose.eps.plugins** ```는 EPS 플러그인 클래스를 포함합니다. |
+| [com.aspose.page](./com.aspose.page) | **Aspose.Page**는 **Device**와 같이 직접 포함되거나 여러 하위 패키지를 통해 간접적으로 포함되는 Aspose.Page 라이브러리의 모든 클래스에 대한 루트 패키지입니다. |
+| [com.aspose.page.plugins](./com.aspose.page.plugins) | ``` **com.aspose.page.plugins** ```는 모든 Aspose.Page 플러그인에 공통적인 인터페이스와 클래스를 포함합니다. |
+| [com.aspose.xps](./com.aspose.xps) | **com.aspose.xps**는 XPS 문서를 다루는 모든 클래스의 루트 패키지입니다. |
+| [com.aspose.xps.features.EventBasedModifications](./com.aspose.xps.features.eventbasedmodifications) | **com.aspose.xps.features.EventBasedModifications** 패키지는 XPS 문서의 이벤트 기반 수정과 관련된 클래스를 제공합니다. |
+| [com.aspose.xps.features.HyperlinkCollector](./com.aspose.xps.features.hyperlinkcollector) | **com.aspose.xps.features.HyperlinkCollector** 패키지는 하이퍼링크를 포함하는 XPS 요소를 수집하기 위한 클래스를 제공합니다. |
+| [com.aspose.xps.metadata](./com.aspose.xps.metadata) | **com.aspose.xps.metadata** 패키지는 XPS 문서의 메타데이터를 설명하는 클래스를 제공합니다. |
+| [com.aspose.xps.plugins](./com.aspose.xps.plugins) | ``` **com.aspose.xps.plugins** ```는 XPS 플러그인 클래스를 포함합니다. |
+| [com.aspose.xps.rendering](./com.aspose.xps.rendering) | **com.aspose.xps.rendering** 패키지는 XPS 문서를 다른 형식으로 렌더링하기 위한 기본 클래스를 제공합니다. |

--- a/korean/java/com.aspose.eps.cpp/_index.md
+++ b/korean/java/com.aspose.eps.cpp/_index.md
@@ -1,0 +1,14 @@
+---
+title: "com.aspose.eps.cpp"
+second_title: "Aspose.Page용 Java API 참조"
+description: 
+type: docs
+weight: 11
+url: /ko/java/com.aspose.eps.cpp/
+---
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [PSObjectEqComparer<T>](../com.aspose.eps.cpp/psobjecteqcomparer) |  |

--- a/korean/java/com.aspose.eps.cpp/psobjecteqcomparer/_index.md
+++ b/korean/java/com.aspose.eps.cpp/psobjecteqcomparer/_index.md
@@ -1,0 +1,186 @@
+---
+title: "PSObjectEqComparer"
+second_title: "Aspose.Page용 Java API 참조"
+description: 
+type: docs
+weight: 10
+url: /ko/java/com.aspose.eps.cpp/psobjecteqcomparer/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.util.Comparator
+```
+public class PSObjectEqComparer<T> implements Comparator<T>
+```
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PSObjectEqComparer()](#PSObjectEqComparer--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [compare(T x, T y)](#compare-T-T-) |  |
+| [equals(T x, T y)](#equals-T-T-) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHashCode(T obj)](#getHashCode-T-) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PSObjectEqComparer() {#PSObjectEqComparer--}
+```
+public PSObjectEqComparer()
+```
+
+
+### compare(T x, T y) {#compare-T-T-}
+```
+public int compare(T x, T y)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | T |  |
+| y | T |  |
+
+**Returns:**
+int
+### equals(T x, T y) {#equals-T-T-}
+```
+public boolean equals(T x, T y)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | T |  |
+| y | T |  |
+
+**Returns:**
+boolean
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHashCode(T obj) {#getHashCode-T-}
+```
+public int getHashCode(T obj)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T |  |
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.device/_index.md
+++ b/korean/java/com.aspose.eps.device/_index.md
@@ -1,0 +1,27 @@
+---
+title: "com.aspose.eps.device"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.eps.device 패키지는 PS/EPS를 다른 형식으로 변환할 때 사용할 수 있는 가능한 장치와 저장 옵션의 클래스를 제공합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.eps.device/
+---
+
+**com.aspose.eps.device** 패키지는 PS/EPS를 다른 형식으로 변환할 때 사용할 수 있는 가능한 장치와 저장 옵션의 클래스를 제공합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [ImageSaveOptions](../com.aspose.eps.device/imagesaveoptions) | 이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다. |
+| [PdfSaveOptions](../com.aspose.eps.device/pdfsaveoptions) | 이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다. |
+| [PsSaveOptions](../com.aspose.eps.device/pssaveoptions) | 이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다. |
+| [TextDevice](../com.aspose.eps.device/textdevice) |  |
+
+## 열거형
+
+| 열거형 | 설명 |
+| --- | --- |
+| [PsSaveFormat](../com.aspose.eps.device/pssaveformat) | 이 열거형에는 사용 가능한 저장 형식 옵션이 포함되어 있습니다. |
+| [SmoothingMode](../com.aspose.eps.device/smoothingmode) | 스무딩 모드 열거형. |

--- a/korean/java/com.aspose.eps.device/imagesaveoptions/_index.md
+++ b/korean/java/com.aspose.eps.device/imagesaveoptions/_index.md
@@ -1,0 +1,501 @@
+---
+title: "ImageSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.eps.device/imagesaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+```
+public class ImageSaveOptions extends SaveOptions
+```
+
+이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ImageSaveOptions()](#ImageSaveOptions--) | ImageSaveOptions 클래스의 새 인스턴스를 suppressErrors 플래그는 (true), debug 플래그는 (false)인 기본값으로 초기화합니다. |
+| [ImageSaveOptions(ImageFormat imageFormat)](#ImageSaveOptions-com.aspose.page.ImageFormat-) | ImageSaveOptions의 새 인스턴스를 지정된 이미지 형식으로 초기화합니다. |
+| [ImageSaveOptions(Dimension size)](#ImageSaveOptions-java.awt.Dimension-) | ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기로 초기화합니다. |
+| [ImageSaveOptions(Dimension size, ImageFormat imageFormat)](#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-) | ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기와 이미지 형식으로 초기화합니다. |
+| [ImageSaveOptions(ImageFormat imageFormat, boolean supressErrors)](#ImageSaveOptions-com.aspose.page.ImageFormat-boolean-) | ImageSaveOptions의 새 인스턴스를 지정된 이미지 형식과 suppressErrors 플래그로 초기화합니다. |
+| [ImageSaveOptions(Dimension size, boolean supressErrors)](#ImageSaveOptions-java.awt.Dimension-boolean-) | ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기와 suppressErrors 플래그로 초기화합니다. |
+| [ImageSaveOptions(Dimension size, ImageFormat imageFormat, boolean supressErrors)](#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-boolean-) | ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기, 이미지 형식 및 suppressErrors 플래그로 초기화합니다. |
+| [ImageSaveOptions(boolean supressErrors)](#ImageSaveOptions-boolean-) | ImageSaveOptions 클래스의 새 인스턴스를 debug 플래그가 (false)인 기본값으로 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageFormat()](#getImageFormat--) | 결과 이미지의 이미지 형식을 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getResolution()](#getResolution--) | 결과 이미지의 해상도를 반환합니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 스무딩 모드를 가져옵니다. |
+| [getTryJoinImageFragments()](#getTryJoinImageFragments--) | 라이브러리가 이미지 조각을 결합하려고 시도할지 여부를 나타냅니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageFormat(ImageFormat imageFormat)](#setImageFormat-com.aspose.page.ImageFormat-) | 결과 이미지의 이미지 형식을 지정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setResolution(float resolution)](#setResolution-float-) | 결과 이미지의 해상도를 지정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSmoothingMode(SmoothingMode smoothingMode)](#setSmoothingMode-com.aspose.eps.device.SmoothingMode-) | 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTryJoinImageFragments(boolean tryJoinImageFragments)](#setTryJoinImageFragments-boolean-) | 라이브러리가 이미지 조각을 결합하려고 시도할지 여부를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions() {#ImageSaveOptions--}
+```
+public ImageSaveOptions()
+```
+
+
+ImageSaveOptions 클래스의 새 인스턴스를 suppressErrors 플래그는 (true), debug 플래그는 (false)인 기본값으로 초기화합니다.
+
+### ImageSaveOptions(ImageFormat imageFormat) {#ImageSaveOptions-com.aspose.page.ImageFormat-}
+```
+public ImageSaveOptions(ImageFormat imageFormat)
+```
+
+
+ImageSaveOptions의 새 인스턴스를 지정된 이미지 형식으로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 이미지 형식입니다. |
+
+### ImageSaveOptions(Dimension size) {#ImageSaveOptions-java.awt.Dimension-}
+```
+public ImageSaveOptions(Dimension size)
+```
+
+
+ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 이미지 크기. |
+
+### ImageSaveOptions(Dimension size, ImageFormat imageFormat) {#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-}
+```
+public ImageSaveOptions(Dimension size, ImageFormat imageFormat)
+```
+
+
+ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기와 이미지 형식으로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 이미지 크기. |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 이미지의 형식. |
+
+### ImageSaveOptions(ImageFormat imageFormat, boolean supressErrors) {#ImageSaveOptions-com.aspose.page.ImageFormat-boolean-}
+```
+public ImageSaveOptions(ImageFormat imageFormat, boolean supressErrors)
+```
+
+
+ImageSaveOptions의 새 인스턴스를 지정된 이미지 형식과 suppressErrors 플래그로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 이미지의 형식. |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### ImageSaveOptions(Dimension size, boolean supressErrors) {#ImageSaveOptions-java.awt.Dimension-boolean-}
+```
+public ImageSaveOptions(Dimension size, boolean supressErrors)
+```
+
+
+ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기와 suppressErrors 플래그로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 이미지 크기. |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### ImageSaveOptions(Dimension size, ImageFormat imageFormat, boolean supressErrors) {#ImageSaveOptions-java.awt.Dimension-com.aspose.page.ImageFormat-boolean-}
+```
+public ImageSaveOptions(Dimension size, ImageFormat imageFormat, boolean supressErrors)
+```
+
+
+ImageSaveOptions의 새 인스턴스를 지정된 이미지 크기, 이미지 형식 및 suppressErrors 플래그로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 이미지 크기. |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 이미지의 형식. |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### ImageSaveOptions(boolean supressErrors) {#ImageSaveOptions-boolean-}
+```
+public ImageSaveOptions(boolean supressErrors)
+```
+
+
+ImageSaveOptions 클래스의 새 인스턴스를 debug 플래그가 (false)인 기본값으로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageFormat() {#getImageFormat--}
+```
+public ImageFormat getImageFormat()
+```
+
+
+결과 이미지의 이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat) - An output image format.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+결과 이미지의 해상도를 반환합니다.
+
+**Returns:**
+float - 이미지 해상도입니다.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.eps.device/smoothingmode) - the smoothingMode.
+### getTryJoinImageFragments() {#getTryJoinImageFragments--}
+```
+public boolean getTryJoinImageFragments()
+```
+
+
+라이브러리가 이미지 조각을 결합하려고 시도할지 여부를 나타냅니다. 이는 소스 PS/EPS 파일의 이미지가 조각으로 나뉘어 있을 때 사용됩니다. 이 경우 이 플래그가 없으면 조각 사이에 얇은 틈이 남게 됩니다.
+
+**Returns:**
+boolean - 플래그 값입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageFormat(ImageFormat imageFormat) {#setImageFormat-com.aspose.page.ImageFormat-}
+```
+public void setImageFormat(ImageFormat imageFormat)
+```
+
+
+결과 이미지의 이미지 형식을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 출력 이미지 형식입니다. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setResolution(float resolution) {#setResolution-float-}
+```
+public void setResolution(float resolution)
+```
+
+
+결과 이미지의 해상도를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 해상도 | float | 이미지 해상도입니다. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode smoothingMode) {#setSmoothingMode-com.aspose.eps.device.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode smoothingMode)
+```
+
+
+스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| smoothingMode | [SmoothingMode](../../com.aspose.eps.device/smoothingmode) | 설정할 smoothingMode |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTryJoinImageFragments(boolean tryJoinImageFragments) {#setTryJoinImageFragments-boolean-}
+```
+public void setTryJoinImageFragments(boolean tryJoinImageFragments)
+```
+
+
+라이브러리가 이미지 조각을 결합하려고 시도할지 여부를 지정합니다. 이는 소스 PS/EPS 파일의 이미지가 조각으로 나뉘어 있을 때 사용됩니다. 이 경우 이 플래그가 없으면 조각 사이에 얇은 틈이 남게 됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| tryJoinImageFragments | boolean | 플래그 값입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.device/pdfsaveoptions/_index.md
+++ b/korean/java/com.aspose.eps.device/pdfsaveoptions/_index.md
@@ -1,0 +1,341 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.eps.device/pdfsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+```
+public class PdfSaveOptions extends SaveOptions
+```
+
+이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, suppressErrors 플래그는 (true), debug 플래그는 (false)인 기본값을 사용합니다. |
+| [PdfSaveOptions(boolean supressErrors)](#PdfSaveOptions-boolean-) | PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, debug 플래그는 (false)인 기본값을 사용합니다. |
+| [PdfSaveOptions(Dimension size)](#PdfSaveOptions-java.awt.Dimension-) | PdfSaveOptions 클래스의 새 인스턴스를 페이지 크기로 초기화합니다. |
+| [PdfSaveOptions(boolean supressErrors, Dimension size)](#PdfSaveOptions-boolean-java.awt.Dimension-) | PdfSaveOptions 클래스의 새 인스턴스를 debug 플래그가 (false)인 기본값과 페이지 크기로 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, suppressErrors 플래그는 (true), debug 플래그는 (false)인 기본값을 사용합니다.
+
+### PdfSaveOptions(boolean supressErrors) {#PdfSaveOptions-boolean-}
+```
+public PdfSaveOptions(boolean supressErrors)
+```
+
+
+PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, debug 플래그는 (false)인 기본값을 사용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### PdfSaveOptions(Dimension size) {#PdfSaveOptions-java.awt.Dimension-}
+```
+public PdfSaveOptions(Dimension size)
+```
+
+
+PdfSaveOptions 클래스의 새 인스턴스를 페이지 크기로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 크기입니다. |
+
+### PdfSaveOptions(boolean supressErrors, Dimension size) {#PdfSaveOptions-boolean-java.awt.Dimension-}
+```
+public PdfSaveOptions(boolean supressErrors, Dimension size)
+```
+
+
+PdfSaveOptions 클래스의 새 인스턴스를 debug 플래그가 (false)인 기본값과 페이지 크기로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+| 크기 | java.awt.Dimension | 페이지 크기입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.device/pssaveformat/_index.md
+++ b/korean/java/com.aspose.eps.device/pssaveformat/_index.md
@@ -1,0 +1,250 @@
+---
+title: "PsSaveFormat"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 열거형에는 사용 가능한 저장 형식 옵션이 포함되어 있습니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.eps.device/pssaveformat/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PsSaveFormat extends Enum<PsSaveFormat>
+```
+
+이 열거형은 저장 형식의 사용 가능한 옵션을 포함합니다. PS 또는 EPS가 될 수 있습니다. EPS는 1페이지 문서에만 사용되며 PS 파일은 페이지 수에 제한이 없습니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [EPS](#EPS) | 이 옵션은 결과 문서가 캡슐화된 PostScript(EPS) 파일이어야 함을 나타냅니다. |
+| [PS](#PS) | 이 옵션은 결과 문서가 PostScript(PS) 또는 캡슐화된 PostScript(EPS) 파일이어야 함을 나타냅니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EPS {#EPS}
+```
+public static final PsSaveFormat EPS
+```
+
+
+이 옵션은 결과 문서가 Encapsulated PostScript (EPS) 파일이어야 함을 나타냅니다. 1페이지 문서에만 사용됩니다;
+
+### PS {#PS}
+```
+public static final PsSaveFormat PS
+```
+
+
+이 옵션은 결과 문서가 PostScript(PS) 또는 캡슐화된 PostScript(EPS) 파일이어야 함을 나타냅니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PsSaveFormat valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[PsSaveFormat](../../com.aspose.eps.device/pssaveformat)
+### values() {#values--}
+```
+public static PsSaveFormat[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.eps.device.PsSaveFormat[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.device/pssaveoptions/_index.md
+++ b/korean/java/com.aspose.eps.device/pssaveoptions/_index.md
@@ -1,0 +1,487 @@
+---
+title: "PsSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.eps.device/pssaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+```
+public class PsSaveOptions extends SaveOptions
+```
+
+이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsSaveOptions()](#PsSaveOptions--) | PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, suppressErrors 플래그는 (true), debug 플래그는 (false)인 기본값을 사용합니다. |
+| [PsSaveOptions(boolean supressErrors)](#PsSaveOptions-boolean-) | PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, debug 플래그는 (false)인 기본값을 사용합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBackgroundColor()](#getBackgroundColor--) |  |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getEmbedFontsAs()](#getEmbedFontsAs--) |  |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getMargins()](#getMargins--) |  |
+| [getPageSize()](#getPageSize--) |  |
+| [getSaveFormat()](#getSaveFormat--) |  |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isEmbedFonts()](#isEmbedFonts--) | PS 문서에 사용된 글꼴을 포함할지 여부를 나타냅니다 |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [isTransparent()](#isTransparent--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBackgroundColor(Color backgroundColor)](#setBackgroundColor-java.awt.Color-) |  |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setEmbedFonts(boolean embedFonts)](#setEmbedFonts-boolean-) | PS 문서에 사용된 글꼴을 포함할지 지정합니다 |
+| [setEmbedFontsAs(String embedFontsAs)](#setEmbedFontsAs-java.lang.String-) | PS 문서에 글꼴을 포함할 글꼴 유형을 지정합니다 |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setMargins(Insets margins)](#setMargins-java.awt.Insets-) |  |
+| [setPageSize(Dimension pageSize)](#setPageSize-java.awt.Dimension-) |  |
+| [setSaveFormat(PsSaveFormat saveFormat)](#setSaveFormat-com.aspose.eps.device.PsSaveFormat-) | 결과 파일의 저장 형식을 지정합니다 |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTransparent(boolean transparent)](#setTransparent-boolean-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsSaveOptions() {#PsSaveOptions--}
+```
+public PsSaveOptions()
+```
+
+
+PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, suppressErrors 플래그는 (true), debug 플래그는 (false)인 기본값을 사용합니다.
+
+### PsSaveOptions(boolean supressErrors) {#PsSaveOptions-boolean-}
+```
+public PsSaveOptions(boolean supressErrors)
+```
+
+
+PdfSaveOptions 클래스의 새 인스턴스를 초기화하고, debug 플래그는 (false)인 기본값을 사용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBackgroundColor() {#getBackgroundColor--}
+```
+public Color getBackgroundColor()
+```
+
+
+
+
+**Returns:**
+java.awt.Color - 배경 색상
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getEmbedFontsAs() {#getEmbedFontsAs--}
+```
+public String getEmbedFontsAs()
+```
+
+
+
+
+**Returns:**
+java.lang.String - PS 문서에 글꼴을 포함할 글꼴 유형
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getMargins() {#getMargins--}
+```
+public Insets getMargins()
+```
+
+
+
+
+**Returns:**
+java.awt.Insets - 페이지 여백
+### getPageSize() {#getPageSize--}
+```
+public Dimension getPageSize()
+```
+
+
+
+
+**Returns:**
+java.awt.Dimension - 페이지 크기
+### getSaveFormat() {#getSaveFormat--}
+```
+public PsSaveFormat getSaveFormat()
+```
+
+
+
+
+**Returns:**
+[PsSaveFormat](../../com.aspose.eps.device/pssaveformat) - save format of resulting file
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isEmbedFonts() {#isEmbedFonts--}
+```
+public boolean isEmbedFonts()
+```
+
+
+PS 문서에 사용된 글꼴을 포함할지 여부를 나타냅니다
+
+**Returns:**
+boolean - embedFonts 플래그 값
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### isTransparent() {#isTransparent--}
+```
+public boolean isTransparent()
+```
+
+
+
+
+**Returns:**
+boolean - 배경이 투명한지 여부를 나타냅니다
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBackgroundColor(Color backgroundColor) {#setBackgroundColor-java.awt.Color-}
+```
+public void setBackgroundColor(Color backgroundColor)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| backgroundColor | java.awt.Color | 배경 색상을 지정합니다 |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setEmbedFonts(boolean embedFonts) {#setEmbedFonts-boolean-}
+```
+public void setEmbedFonts(boolean embedFonts)
+```
+
+
+PS 문서에 사용된 글꼴을 포함할지 지정합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| embedFonts | boolean | embedFonts 플래그 |
+
+### setEmbedFontsAs(String embedFontsAs) {#setEmbedFontsAs-java.lang.String-}
+```
+public void setEmbedFontsAs(String embedFontsAs)
+```
+
+
+PS 문서에 글꼴을 포함할 글꼴 유형을 지정합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| embedFontsAs | java.lang.String | 글꼴 유형 |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setMargins(Insets margins) {#setMargins-java.awt.Insets-}
+```
+public void setMargins(Insets margins)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 여백 | java.awt.Insets | 페이지 여백을 지정합니다 |
+
+### setPageSize(Dimension pageSize) {#setPageSize-java.awt.Dimension-}
+```
+public void setPageSize(Dimension pageSize)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageSize | java.awt.Dimension | 페이지 크기를 지정합니다 |
+
+### setSaveFormat(PsSaveFormat saveFormat) {#setSaveFormat-com.aspose.eps.device.PsSaveFormat-}
+```
+public void setSaveFormat(PsSaveFormat saveFormat)
+```
+
+
+결과 파일의 저장 형식을 지정합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveFormat | [PsSaveFormat](../../com.aspose.eps.device/pssaveformat) | 결과 파일의 형식 |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTransparent(boolean transparent) {#setTransparent-boolean-}
+```
+public void setTransparent(boolean transparent)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 투명 | boolean | 배경이 투명한지 여부를 지정합니다 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.device/smoothingmode/_index.md
+++ b/korean/java/com.aspose.eps.device/smoothingmode/_index.md
@@ -1,0 +1,259 @@
+---
+title: "SmoothingMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "스무딩 모드 열거형."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.eps.device/smoothingmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum SmoothingMode extends Enum<SmoothingMode>
+```
+
+스무딩 모드 열거형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ANTIALIAS](#ANTIALIAS) | 안티앨리어싱 스무딩 모드 |
+| [HIGH_QUALITY](#HIGH-QUALITY) | 고품질이지만 낮은 속도의 스무딩 모드 |
+| [HIGH_SPEED](#HIGH-SPEED) | 고속이지만 낮은 품질의 스무딩 모드 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ANTIALIAS {#ANTIALIAS}
+```
+public static final SmoothingMode ANTIALIAS
+```
+
+
+안티앨리어싱 스무딩 모드
+
+### HIGH_QUALITY {#HIGH-QUALITY}
+```
+public static final SmoothingMode HIGH_QUALITY
+```
+
+
+고품질이지만 낮은 속도의 스무딩 모드
+
+### HIGH_SPEED {#HIGH-SPEED}
+```
+public static final SmoothingMode HIGH_SPEED
+```
+
+
+고속이지만 낮은 품질의 스무딩 모드
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static SmoothingMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[SmoothingMode](../../com.aspose.eps.device/smoothingmode)
+### values() {#values--}
+```
+public static SmoothingMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.eps.device.SmoothingMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.device/textdevice/_index.md
+++ b/korean/java/com.aspose.eps.device/textdevice/_index.md
@@ -1,0 +1,1357 @@
+---
+title: "TextDevice"
+second_title: "Aspose.Page용 Java API 참조"
+description: 
+type: docs
+weight: 13
+url: /ko/java/com.aspose.eps.device/textdevice/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.Device](../../com.aspose.page/device)
+
+**All Implemented Interfaces:**
+[com.aspose.page.IMultiPageDevice](../../com.aspose.page/imultipagedevice)
+```
+public class TextDevice extends Device implements IMultiPageDevice
+```
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TextDevice()](#TextDevice--) |  |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_SIZE](#DEFAULT-SIZE) |  |
+| [EMIT_ERRORS](#EMIT-ERRORS) |  |
+| [EMIT_WARNINGS](#EMIT-WARNINGS) |  |
+| [VERSION](#VERSION) | 현재 장치 버전입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [closePage()](#closePage--) |  |
+| [create()](#create--) |  |
+| [dispose()](#dispose--) |  |
+| [draw(Shape path)](#draw-java.awt.Shape-) | 경로를 그립니다. |
+| [drawArc(float x, float y, float width, float height, float startAngle, float arcAngle)](#drawArc-float-float-float-float-float-float-) | 호를 그립니다. |
+| [drawImage(BufferedImage image, AffineTransform transform, Color bkg)](#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-) | 지정된 변환 및 배경을 사용하여 이미지를 그립니다. |
+| [drawLine(float x1, float y1, float x2, float y2)](#drawLine-float-float-float-float-) | 선분을 그립니다. |
+| [drawOval(float x, float y, float width, float height)](#drawOval-float-float-float-float-) | 타원을 그립니다. |
+| [drawPolygon(float[] xPoints, float[] yPoints, int nPoints)](#drawPolygon-float---float---int-) | 다각형을 그립니다. |
+| [drawPolygon(int[] xPoints, int[] yPoints, int nPoints)](#drawPolygon-int---int---int-) | 다각형을 그립니다. |
+| [drawPolyline(float[] xPoints, float[] yPoints, int nPoints)](#drawPolyline-float---float---int-) | 폴리라인을 그립니다. |
+| [drawPolyline(int[] xPoints, int[] yPoints, int nPoints)](#drawPolyline-int---int---int-) | 폴리라인을 그립니다. |
+| [drawRect(float x, float y, float width, float height)](#drawRect-float-float-float-float-) | 사각형을 그립니다. |
+| [drawRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)](#drawRoundRect-float-float-float-float-float-float-) | 라운드 사각형을 그립니다. |
+| [drawString(String str, float x, float y)](#drawString-java.lang.String-float-float-) |  |
+| [endDocument()](#endDocument--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fill(Shape path)](#fill-java.awt.Shape-) | 경로를 채웁니다. |
+| [fillArc(float x, float y, float width, float height, float startAngle, float arcAngle)](#fillArc-float-float-float-float-float-float-) | 호를 채웁니다. |
+| [fillOval(float x, float y, float width, float height)](#fillOval-float-float-float-float-) | 타원을 채웁니다. |
+| [fillPolygon(float[] xPoints, float[] yPoints, int nPoints)](#fillPolygon-float---float---int-) | 다각형을 채웁니다. |
+| [fillPolygon(int[] xPoints, int[] yPoints, int nPoints)](#fillPolygon-int---int---int-) | 다각형을 채웁니다. |
+| [fillRect(float x, float y, float width, float height)](#fillRect-float-float-float-float-) | 사각형을 채웁니다. |
+| [fillRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)](#fillRoundRect-float-float-float-float-float-float-) | 라운드 사각형을 그립니다. |
+| [getBackground()](#getBackground--) | 페이지의 현재 배경을 가져옵니다. |
+| [getCharTM()](#getCharTM--) | 현재 문자 변환을 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getCreator()](#getCreator--) | 결과 장치 출력의 생성자를 가져옵니다. |
+| [getCurrentPageNumber()](#getCurrentPageNumber--) |  |
+| [getFont()](#getFont--) | 현재 글꼴을 가져옵니다. |
+| [getOpacity()](#getOpacity--) | 현재 불투명도를 가져옵니다. |
+| [getOpacityMask()](#getOpacityMask--) | 현재 불투명도 마스크를 가져옵니다. |
+| [getPages()](#getPages--) |  |
+| [getPaint()](#getPaint--) | 현재 페인트를 가져옵니다. |
+| [getProperties()](#getProperties--) | 메타데이터를 포함한 장치 속성을 가져옵니다. |
+| [getProperty(String key)](#getProperty-java.lang.String-) | 문자열 속성 값을 가져옵니다. |
+| [getPropertyColor(String key)](#getPropertyColor-java.lang.String-) | 색상 속성 값을 가져옵니다. |
+| [getPropertyDouble(String key)](#getPropertyDouble-java.lang.String-) | 실수 속성 값을 가져옵니다. |
+| [getPropertyInt(String key)](#getPropertyInt-java.lang.String-) | 정수 속성 값을 가져옵니다. |
+| [getPropertyMargins(String key)](#getPropertyMargins-java.lang.String-) | 여백 속성 값을 가져옵니다. |
+| [getPropertyMatrix(String key)](#getPropertyMatrix-java.lang.String-) | 행렬 속성 값을 가져옵니다. |
+| [getPropertyRectangle(String key)](#getPropertyRectangle-java.lang.String-) | 사각형 속성 값을 가져옵니다. |
+| [getPropertySize(String key)](#getPropertySize-java.lang.String-) | 크기 속성 값을 가져옵니다. |
+| [getSaveOptions()](#getSaveOptions--) | 저장 옵션을 반환합니다. |
+| [getSize()](#getSize--) | 페이지의 크기를 가져옵니다. |
+| [getStroke()](#getStroke--) | 현재 스트로크를 가져옵니다. |
+| [getText()](#getText--) |  |
+| [getText(int startPage, int endPage)](#getText-int-int-) |  |
+| [getTextRenderingMode()](#getTextRenderingMode--) | 현재 텍스트 렌더링 모드를 가져옵니다. |
+| [getTextStrokeWidth()](#getTextStrokeWidth--) | 현재 텍스트 스트로크 너비를 가져옵니다. |
+| [getTransform()](#getTransform--) | 현재 변환을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [initClip()](#initClip--) | 디바이스의 클립을 초기화합니다. |
+| [initPageNumbers()](#initPageNumbers--) |  |
+| [isDirectRGB()](#isDirectRGB--) |  |
+| [isMainDocument()](#isMainDocument--) |  |
+| [isProperty(String key)](#isProperty-java.lang.String-) | 불리언 속성의 값을 가져옵니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [openPage(float width, float height)](#openPage-float-float-) |  |
+| [openPage(String title)](#openPage-java.lang.String-) |  |
+| [renew()](#renew--) |  |
+| [renewForMerge(boolean mainDocument)](#renewForMerge-boolean-) |  |
+| [reset()](#reset--) |  |
+| [reset(boolean zeroPageNumbers)](#reset-boolean-) |  |
+| [rotate(double theta)](#rotate-double-) | 현재 변환 행렬을 회전시킵니다. |
+| [rotate(double theta, double x, double y)](#rotate-double-double-double-) | 현재 변환 행렬을 점을 중심으로 회전시킵니다. |
+| [scale(double x, double y)](#scale-double-double-) | 현재 변환 행렬을 스케일링합니다. |
+| [setBackground(Color background)](#setBackground-java.awt.Color-) | 페이지의 현재 배경을 지정합니다. |
+| [setCharTM(AffineTransform charTM)](#setCharTM-java.awt.geom.AffineTransform-) | 문자 변환을 지정합니다. |
+| [setClip(Shape clipPath)](#setClip-java.awt.Shape-) | 디바이스의 클립을 지정합니다. |
+| [setCreator(String creator)](#setCreator-java.lang.String-) | 결과 디바이스 출력의 제작자를 지정합니다. |
+| [setFont(ITrFont font)](#setFont-com.aspose.page.ITrFont-) | 글꼴을 지정합니다. |
+| [setOpacity(float opacity)](#setOpacity-float-) | 불투명도를 지정합니다. |
+| [setOpacityMask(Paint opacityMask)](#setOpacityMask-java.awt.Paint-) | 불투명도 마스크를 지정합니다. |
+| [setPaint(Paint paint)](#setPaint-java.awt.Paint-) | 페인트를 지정합니다. |
+| [setProperties(UserProperties props)](#setProperties-com.aspose.page.UserProperties-) | 메타데이터를 포함한 디바이스 속성을 지정합니다. |
+| [setSaveOptions(SaveOptions options)](#setSaveOptions-com.aspose.page.SaveOptions-) | 렌더링 프로세스 관리를 위한 옵션을 지정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) |  |
+| [setStroke(Stroke stroke)](#setStroke-java.awt.Stroke-) | 스트로크를 지정합니다. |
+| [setTextRenderingMode(TextRenderingMode textRenderingMode)](#setTextRenderingMode-com.aspose.page.TextRenderingMode-) | 텍스트 렌더링 모드를 지정합니다. |
+| [setTextStrokeWidth(float textStrokeWidth)](#setTextStrokeWidth-float-) | 텍스트 스트로크 너비를 지정합니다. |
+| [setTransform(AffineTransform transform)](#setTransform-java.awt.geom.AffineTransform-) | 현재 변환을 지정합니다. |
+| [shear(double shx, double shy)](#shear-double-double-) | 현재 변환 행렬을 전단합니다. |
+| [startDocument()](#startDocument--) |  |
+| [toString()](#toString--) |  |
+| [transform(AffineTransform transform)](#transform-java.awt.geom.AffineTransform-) | 현재 변환 행렬을 변환합니다. |
+| [translate(double x, double y)](#translate-double-double-) | 현재 변환 행렬을 평행 이동합니다. |
+| [updatePageParameters(IMultiPageDevice device)](#updatePageParameters-com.aspose.page.IMultiPageDevice-) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+| [writeComment(String comment)](#writeComment-java.lang.String-) | 주석을 작성합니다. |
+| [writeString(ITrFont font, String str)](#writeString-com.aspose.page.ITrFont-java.lang.String-) | 지정된 글꼴로 문자열을 출력합니다. |
+| [writeWarning(String warning)](#writeWarning-java.lang.String-) |  |
+### TextDevice() {#TextDevice--}
+```
+public TextDevice()
+```
+
+
+### DEFAULT_SIZE {#DEFAULT-SIZE}
+```
+public static final Dimension DEFAULT_SIZE
+```
+
+
+### EMIT_ERRORS {#EMIT-ERRORS}
+```
+public static final String EMIT_ERRORS
+```
+
+
+### EMIT_WARNINGS {#EMIT-WARNINGS}
+```
+public static final String EMIT_WARNINGS
+```
+
+
+### VERSION {#VERSION}
+```
+public static String VERSION
+```
+
+
+현재 장치 버전입니다.
+
+### closePage() {#closePage--}
+```
+public void closePage()
+```
+
+
+페이지가 렌더링된 후 장치에 필요한 준비를 수행합니다.
+
+### create() {#create--}
+```
+public Device create()
+```
+
+
+이 장치의 복사본을 생성합니다.
+
+**Returns:**
+[Device](../../com.aspose.page/device)
+### dispose() {#dispose--}
+```
+public void dispose()
+```
+
+
+장치를 해제합니다.
+
+### draw(Shape path) {#draw-java.awt.Shape-}
+```
+public void draw(Shape path)
+```
+
+
+경로를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.awt.Shape | 그릴 경로입니다. |
+
+### drawArc(float x, float y, float width, float height, float startAngle, float arcAngle) {#drawArc-float-float-float-float-float-float-}
+```
+public void drawArc(float x, float y, float width, float height, float startAngle, float arcAngle)
+```
+
+
+호를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 호의 중심 X 좌표입니다. |
+| y | float | 호의 중심 Y 좌표입니다. |
+| 너비 | float | 외접 사각형의 너비입니다. |
+| 높이 | float | 외접 사각형의 높이입니다. |
+| startAngle | float | 호의 시작 각도입니다. |
+| arcAngle | float | 호의 각도입니다. |
+
+### drawImage(BufferedImage image, AffineTransform transform, Color bkg) {#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-}
+```
+public void drawImage(BufferedImage image, AffineTransform transform, Color bkg)
+```
+
+
+지정된 변환 및 배경을 사용하여 이미지를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 그릴 이미지입니다. |
+| transform | java.awt.geom.AffineTransform | 변환입니다. |
+| bkg | java.awt.Color | 배경 색상입니다. |
+
+### drawLine(float x1, float y1, float x2, float y2) {#drawLine-float-float-float-float-}
+```
+public void drawLine(float x1, float y1, float x2, float y2)
+```
+
+
+선분을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x1 | float | 세그먼트 시작점의 X 좌표입니다. |
+| y1 | float | 세그먼트 시작점의 Y 좌표입니다. |
+| x2 | float | 세그먼트 끝점의 X 좌표입니다. |
+| y2 | float | 세그먼트 끝점의 Y 좌표입니다. |
+
+### drawOval(float x, float y, float width, float height) {#drawOval-float-float-float-float-}
+```
+public void drawOval(float x, float y, float width, float height)
+```
+
+
+타원을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 타원의 중심 X 좌표입니다. |
+| y | float | 타원의 중심 Y 좌표. |
+| 너비 | float | 외접 사각형의 너비입니다. |
+| 높이 | float | 외접 사각형의 높이입니다. |
+
+### drawPolygon(float[] xPoints, float[] yPoints, int nPoints) {#drawPolygon-float---float---int-}
+```
+public void drawPolygon(float[] xPoints, float[] yPoints, int nPoints)
+```
+
+
+다각형을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xPoints | float[] | 점들의 X 좌표. |
+| yPoints | float[] | 점들의 Y 좌표. |
+| nPoints | int | 포인트 수. |
+
+### drawPolygon(int[] xPoints, int[] yPoints, int nPoints) {#drawPolygon-int---int---int-}
+```
+public void drawPolygon(int[] xPoints, int[] yPoints, int nPoints)
+```
+
+
+다각형을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xPoints | int[] | 점들의 X 좌표. |
+| yPoints | int[] | 점들의 Y 좌표. |
+| nPoints | int | 포인트 수. |
+
+### drawPolyline(float[] xPoints, float[] yPoints, int nPoints) {#drawPolyline-float---float---int-}
+```
+public void drawPolyline(float[] xPoints, float[] yPoints, int nPoints)
+```
+
+
+폴리라인을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xPoints | float[] | 점들의 X 좌표. |
+| yPoints | float[] | 점들의 Y 좌표. |
+| nPoints | int | 포인트 수. |
+
+### drawPolyline(int[] xPoints, int[] yPoints, int nPoints) {#drawPolyline-int---int---int-}
+```
+public void drawPolyline(int[] xPoints, int[] yPoints, int nPoints)
+```
+
+
+폴리라인을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xPoints | int[] | 점들의 X 좌표. |
+| yPoints | int[] | 점들의 Y 좌표. |
+| nPoints | int | 포인트 수. |
+
+### drawRect(float x, float y, float width, float height) {#drawRect-float-float-float-float-}
+```
+public void drawRect(float x, float y, float width, float height)
+```
+
+
+사각형을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 사각형의 왼쪽 위 모서리 X 좌표. |
+| y | float | 사각형의 왼쪽 위 모서리 Y 좌표. |
+| 너비 | float | 사각형의 너비. |
+| 높이 | float | 사각형의 높이. |
+
+### drawRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight) {#drawRoundRect-float-float-float-float-float-float-}
+```
+public void drawRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)
+```
+
+
+라운드 사각형을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 사각형의 왼쪽 위 모서리 X 좌표. |
+| y | float | 사각형의 왼쪽 위 모서리 Y 좌표. |
+| 너비 | float | 사각형의 너비. |
+| 높이 | float | 사각형의 높이. |
+| arcWidth | float | 사각형의 각을 둥글게 만드는 호의 외접 사각형 너비. |
+| arcHeight | float | 사각형의 각을 둥글게 만드는 호의 외접 사각형 높이. |
+
+### drawString(String str, float x, float y) {#drawString-java.lang.String-float-float-}
+```
+public void drawString(String str, float x, float y)
+```
+
+
+주어진 점에 문자열을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| str | java.lang.String |  |
+| x | float |  |
+| y | float |  |
+
+### endDocument() {#endDocument--}
+```
+public void endDocument()
+```
+
+
+문서가 렌더링된 후 장치를 위한 필요한 준비를 수행합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fill(Shape path) {#fill-java.awt.Shape-}
+```
+public void fill(Shape path)
+```
+
+
+경로를 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.awt.Shape | 채워질 경로. |
+
+### fillArc(float x, float y, float width, float height, float startAngle, float arcAngle) {#fillArc-float-float-float-float-float-float-}
+```
+public void fillArc(float x, float y, float width, float height, float startAngle, float arcAngle)
+```
+
+
+호를 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 호의 중심 X 좌표입니다. |
+| y | float | 호의 중심 Y 좌표입니다. |
+| 너비 | float | 외접 사각형의 너비입니다. |
+| 높이 | float | 외접 사각형의 높이입니다. |
+| startAngle | float | 호의 시작 각도입니다. |
+| arcAngle | float | 호의 각도입니다. |
+
+### fillOval(float x, float y, float width, float height) {#fillOval-float-float-float-float-}
+```
+public void fillOval(float x, float y, float width, float height)
+```
+
+
+타원을 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 타원의 중심 X 좌표입니다. |
+| y | float | 타원의 중심 Y 좌표. |
+| 너비 | float | 외접 사각형의 너비입니다. |
+| 높이 | float | 외접 사각형의 높이입니다. |
+
+### fillPolygon(float[] xPoints, float[] yPoints, int nPoints) {#fillPolygon-float---float---int-}
+```
+public void fillPolygon(float[] xPoints, float[] yPoints, int nPoints)
+```
+
+
+다각형을 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xPoints | float[] | 점들의 X 좌표. |
+| yPoints | float[] | 점들의 Y 좌표. |
+| nPoints | int | 포인트 수. |
+
+### fillPolygon(int[] xPoints, int[] yPoints, int nPoints) {#fillPolygon-int---int---int-}
+```
+public void fillPolygon(int[] xPoints, int[] yPoints, int nPoints)
+```
+
+
+다각형을 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xPoints | int[] | 점들의 X 좌표. |
+| yPoints | int[] | 점들의 Y 좌표. |
+| nPoints | int | 포인트 수. |
+
+### fillRect(float x, float y, float width, float height) {#fillRect-float-float-float-float-}
+```
+public void fillRect(float x, float y, float width, float height)
+```
+
+
+사각형을 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 사각형의 왼쪽 위 모서리 X 좌표. |
+| y | float | 사각형의 왼쪽 위 모서리 Y 좌표. |
+| 너비 | float | 사각형의 너비. |
+| 높이 | float | 사각형의 높이. |
+
+### fillRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight) {#fillRoundRect-float-float-float-float-float-float-}
+```
+public void fillRoundRect(float x, float y, float width, float height, float arcWidth, float arcHeight)
+```
+
+
+라운드 사각형을 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | 사각형의 왼쪽 위 모서리 X 좌표. |
+| y | float | 사각형의 왼쪽 위 모서리 Y 좌표. |
+| 너비 | float | 사각형의 너비. |
+| 높이 | float | 사각형의 높이. |
+| arcWidth | float | 사각형의 각을 둥글게 만드는 호의 외접 사각형 너비. |
+| arcHeight | float | 사각형의 각을 둥글게 만드는 호의 외접 사각형 높이. |
+
+### getBackground() {#getBackground--}
+```
+public Color getBackground()
+```
+
+
+페이지의 현재 배경을 가져옵니다.
+
+**Returns:**
+java.awt.Color - 페이지의 현재 배경
+### getCharTM() {#getCharTM--}
+```
+public AffineTransform getCharTM()
+```
+
+
+현재 문자 변환을 가져옵니다.
+
+**Returns:**
+java.awt.geom.AffineTransform - 현재 문자 변환.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCreator() {#getCreator--}
+```
+public String getCreator()
+```
+
+
+결과 장치 출력의 생성자를 가져옵니다.
+
+**Returns:**
+java.lang.String - 생성자 값.
+### getCurrentPageNumber() {#getCurrentPageNumber--}
+```
+public int getCurrentPageNumber()
+```
+
+
+현재 페이지 번호를 가져옵니다.
+
+**Returns:**
+int
+### getFont() {#getFont--}
+```
+public ITrFont getFont()
+```
+
+
+현재 글꼴을 가져옵니다.
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - Current font.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+현재 불투명도를 가져옵니다.
+
+**Returns:**
+float - 현재 불투명도.
+### getOpacityMask() {#getOpacityMask--}
+```
+public Paint getOpacityMask()
+```
+
+
+현재 불투명도 마스크를 가져옵니다.
+
+**Returns:**
+java.awt.Paint - 현재 불투명도 마스크.
+### getPages() {#getPages--}
+```
+public List<String> getPages()
+```
+
+
+
+
+**Returns:**
+java.util.List<java.lang.String>
+### getPaint() {#getPaint--}
+```
+public Paint getPaint()
+```
+
+
+현재 페인트를 가져옵니다.
+
+**Returns:**
+java.awt.Paint - 현재 paint.
+### getProperties() {#getProperties--}
+```
+public UserProperties getProperties()
+```
+
+
+메타데이터를 포함한 장치 속성을 가져옵니다.
+
+**Returns:**
+[UserProperties](../../com.aspose.page/userproperties) - Device properties.
+### getProperty(String key) {#getProperty-java.lang.String-}
+```
+public String getProperty(String key)
+```
+
+
+문자열 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.lang.String - 속성 값.
+### getPropertyColor(String key) {#getPropertyColor-java.lang.String-}
+```
+public Color getPropertyColor(String key)
+```
+
+
+색상 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Color - 속성 값.
+### getPropertyDouble(String key) {#getPropertyDouble-java.lang.String-}
+```
+public double getPropertyDouble(String key)
+```
+
+
+실수 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+double - 속성 값.
+### getPropertyInt(String key) {#getPropertyInt-java.lang.String-}
+```
+public int getPropertyInt(String key)
+```
+
+
+정수 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+int - 속성 값.
+### getPropertyMargins(String key) {#getPropertyMargins-java.lang.String-}
+```
+public Insets getPropertyMargins(String key)
+```
+
+
+여백 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Insets - 속성 값.
+### getPropertyMatrix(String key) {#getPropertyMatrix-java.lang.String-}
+```
+public AffineTransform getPropertyMatrix(String key)
+```
+
+
+행렬 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.geom.AffineTransform - 속성 값.
+### getPropertyRectangle(String key) {#getPropertyRectangle-java.lang.String-}
+```
+public Rectangle getPropertyRectangle(String key)
+```
+
+
+사각형 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Rectangle - 속성 값.
+### getPropertySize(String key) {#getPropertySize-java.lang.String-}
+```
+public Dimension getPropertySize(String key)
+```
+
+
+크기 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Dimension - 속성 값.
+### getSaveOptions() {#getSaveOptions--}
+```
+public SaveOptions getSaveOptions()
+```
+
+
+저장 옵션을 반환합니다.
+
+**Returns:**
+[SaveOptions](../../com.aspose.page/saveoptions) - The save options.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 크기.
+### getStroke() {#getStroke--}
+```
+public Stroke getStroke()
+```
+
+
+현재 스트로크를 가져옵니다.
+
+**Returns:**
+java.awt.Stroke - 현재 스트로크.
+### getText() {#getText--}
+```
+public String getText()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getText(int startPage, int endPage) {#getText-int-int-}
+```
+public String getText(int startPage, int endPage)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPage | int |  |
+| endPage | int |  |
+
+**Returns:**
+java.lang.String
+### getTextRenderingMode() {#getTextRenderingMode--}
+```
+public TextRenderingMode getTextRenderingMode()
+```
+
+
+현재 텍스트 렌더링 모드를 가져옵니다.
+
+**Returns:**
+[TextRenderingMode](../../com.aspose.page/textrenderingmode) - Current text rendering mode.
+### getTextStrokeWidth() {#getTextStrokeWidth--}
+```
+public float getTextStrokeWidth()
+```
+
+
+현재 텍스트 스트로크 너비를 가져옵니다.
+
+**Returns:**
+float - 현재 텍스트 스트로크 너비.
+### getTransform() {#getTransform--}
+```
+public AffineTransform getTransform()
+```
+
+
+현재 변환을 가져옵니다.
+
+**Returns:**
+java.awt.geom.AffineTransform - 현재 변환.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initClip() {#initClip--}
+```
+public void initClip()
+```
+
+
+디바이스의 클립을 초기화합니다.
+
+### initPageNumbers() {#initPageNumbers--}
+```
+public void initPageNumbers()
+```
+
+
+렌더링할 페이지 수를 초기화합니다.
+
+### isDirectRGB() {#isDirectRGB--}
+```
+public boolean isDirectRGB()
+```
+
+
+디바이스가 직접 RGB 모드, 즉 RGB를 사용하는지 여부를 나타냅니다.
+
+**Returns:**
+boolean
+### isMainDocument() {#isMainDocument--}
+```
+public boolean isMainDocument()
+```
+
+
+
+
+**Returns:**
+boolean
+### isProperty(String key) {#isProperty-java.lang.String-}
+```
+public boolean isProperty(String key)
+```
+
+
+불리언 속성의 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+boolean - 속성 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### openPage(float width, float height) {#openPage-float-float-}
+```
+public boolean openPage(float width, float height)
+```
+
+
+페이지 렌더링 전에 디바이스에 필요한 준비를 수행합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float |  |
+| 높이 | float |  |
+
+**Returns:**
+boolean
+### openPage(String title) {#openPage-java.lang.String-}
+```
+public boolean openPage(String title)
+```
+
+
+페이지 렌더링 전에 디바이스에 필요한 준비를 수행합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 제목 | java.lang.String |  |
+
+**Returns:**
+boolean
+### renew() {#renew--}
+```
+public void renew()
+```
+
+
+전체 문서에 대해 디바이스를 초기 상태로 재설정합니다. 출력 스트림을 재설정하는 데 사용됩니다.
+
+### renewForMerge(boolean mainDocument) {#renewForMerge-boolean-}
+```
+public void renewForMerge(boolean mainDocument)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mainDocument | boolean |  |
+
+### reset() {#reset--}
+```
+public void reset()
+```
+
+
+페이지에 대해 디바이스를 초기 상태로 재설정합니다.
+
+### reset(boolean zeroPageNumbers) {#reset-boolean-}
+```
+public void reset(boolean zeroPageNumbers)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| zeroPageNumbers | boolean |  |
+
+### rotate(double theta) {#rotate-double-}
+```
+public void rotate(double theta)
+```
+
+
+현재 변환 행렬을 회전합니다. writeTransform(Transform)를 호출합니다. 양의 각도 theta로 회전하면 양의 x축상의 점이 양의 y축 방향으로 회전합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| theta | double | 회전할 라디안 단위 각도. |
+
+### rotate(double theta, double x, double y) {#rotate-double-double-double-}
+```
+public void rotate(double theta, double x, double y)
+```
+
+
+현재 변환 행렬을 점을 중심으로 회전시킵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| theta | double | 라디안 단위 회전 각도. |
+| x | double | 점의 X 좌표. |
+| y | double | 점의 Y 좌표. |
+
+### scale(double x, double y) {#scale-double-double-}
+```
+public void scale(double x, double y)
+```
+
+
+현재 변환 행렬을 스케일합니다. writeTransform(Transform)를 호출합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | double | X 축의 스케일. |
+| y | double | Y 축의 스케일. |
+
+### setBackground(Color background) {#setBackground-java.awt.Color-}
+```
+public void setBackground(Color background)
+```
+
+
+페이지의 현재 배경을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| background | java.awt.Color | 페이지의 배경. |
+
+### setCharTM(AffineTransform charTM) {#setCharTM-java.awt.geom.AffineTransform-}
+```
+public void setCharTM(AffineTransform charTM)
+```
+
+
+문자 변환을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| charTM | java.awt.geom.AffineTransform | \\u0421haracters 변환. |
+
+### setClip(Shape clipPath) {#setClip-java.awt.Shape-}
+```
+public void setClip(Shape clipPath)
+```
+
+
+디바이스의 클립을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| clipPath | java.awt.Shape | 클리핑 경로. |
+
+### setCreator(String creator) {#setCreator-java.lang.String-}
+```
+public void setCreator(String creator)
+```
+
+
+결과 디바이스 출력의 제작자를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| creator | java.lang.String | 제작자 값. |
+
+### setFont(ITrFont font) {#setFont-com.aspose.page.ITrFont-}
+```
+public void setFont(ITrFont font)
+```
+
+
+글꼴을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| font | [ITrFont](../../com.aspose.page/itrfont) | 폰트. |
+
+### setOpacity(float opacity) {#setOpacity-float-}
+```
+public void setOpacity(float opacity)
+```
+
+
+불투명도를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| opacity | float | 불투명도. |
+
+### setOpacityMask(Paint opacityMask) {#setOpacityMask-java.awt.Paint-}
+```
+public void setOpacityMask(Paint opacityMask)
+```
+
+
+불투명도 마스크를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| opacityMask | java.awt.Paint | 불투명도 마스크. |
+
+### setPaint(Paint paint) {#setPaint-java.awt.Paint-}
+```
+public void setPaint(Paint paint)
+```
+
+
+페인트를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| paint | java.awt.Paint | 페인트. |
+
+### setProperties(UserProperties props) {#setProperties-com.aspose.page.UserProperties-}
+```
+public void setProperties(UserProperties props)
+```
+
+
+메타데이터를 포함한 디바이스 속성을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| props | [UserProperties](../../com.aspose.page/userproperties) | 디바이스 속성. |
+
+### setSaveOptions(SaveOptions options) {#setSaveOptions-com.aspose.page.SaveOptions-}
+```
+public void setSaveOptions(SaveOptions options)
+```
+
+
+렌더링 프로세스 관리를 위한 옵션을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 렌더링 프로세스를 관리하기 위한 옵션. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension |  |
+
+### setStroke(Stroke stroke) {#setStroke-java.awt.Stroke-}
+```
+public void setStroke(Stroke stroke)
+```
+
+
+스트로크를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| stroke | java.awt.Stroke | 스트로크. |
+
+### setTextRenderingMode(TextRenderingMode textRenderingMode) {#setTextRenderingMode-com.aspose.page.TextRenderingMode-}
+```
+public void setTextRenderingMode(TextRenderingMode textRenderingMode)
+```
+
+
+텍스트 렌더링 모드를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| textRenderingMode | [TextRenderingMode](../../com.aspose.page/textrenderingmode) | 텍스트 렌더링 모드. |
+
+### setTextStrokeWidth(float textStrokeWidth) {#setTextStrokeWidth-float-}
+```
+public void setTextStrokeWidth(float textStrokeWidth)
+```
+
+
+텍스트 스트로크 너비를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| textStrokeWidth | float | 텍스트 스트로크 너비. |
+
+### setTransform(AffineTransform transform) {#setTransform-java.awt.geom.AffineTransform-}
+```
+public void setTransform(AffineTransform transform)
+```
+
+
+현재 변환을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transform | java.awt.geom.AffineTransform | 변환.. |
+
+### shear(double shx, double shy) {#shear-double-double-}
+```
+public void shear(double shx, double shy)
+```
+
+
+현재 변환 행렬을 전단합니다. writeTransform(Transform)를 호출합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| shx | double | X축 전단. |
+| shy | double | Y축 전단. |
+
+### startDocument() {#startDocument--}
+```
+public void startDocument()
+```
+
+
+문서 렌더링을 시작하기 전에 장치를 위한 필요한 준비를 수행합니다.
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+장치 유형의 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### transform(AffineTransform transform) {#transform-java.awt.geom.AffineTransform-}
+```
+public void transform(AffineTransform transform)
+```
+
+
+현재 변환 행렬을 변환합니다. writeTransform(Transform)를 호출합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| transform | java.awt.geom.AffineTransform | 적용될 변환. |
+
+### translate(double x, double y) {#translate-double-double-}
+```
+public void translate(double x, double y)
+```
+
+
+현재 변환 행렬을 평행 이동합니다. writeTransform(Transform)를 호출합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | double | X축 평행 이동. |
+| y | double | Y축 평행 이동. |
+
+### updatePageParameters(IMultiPageDevice device) {#updatePageParameters-com.aspose.page.IMultiPageDevice-}
+```
+public void updatePageParameters(IMultiPageDevice device)
+```
+
+
+다른 다중 페이지 장치에서 페이지 매개변수를 업데이트합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| device | [IMultiPageDevice](../../com.aspose.page/imultipagedevice) |  |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+
+### writeComment(String comment) {#writeComment-java.lang.String-}
+```
+public void writeComment(String comment)
+```
+
+
+주석을 작성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 주석 | java.lang.String | 작성될 주석. |
+
+### writeString(ITrFont font, String str) {#writeString-com.aspose.page.ITrFont-java.lang.String-}
+```
+public void writeString(ITrFont font, String str)
+```
+
+
+지정된 글꼴로 문자열을 출력합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| font | [ITrFont](../../com.aspose.page/itrfont) | 지정된 글꼴. |
+| str | java.lang.String | 문자열. |
+
+### writeWarning(String warning) {#writeWarning-java.lang.String-}
+```
+public void writeWarning(String warning)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 경고 | java.lang.String |  |
+

--- a/korean/java/com.aspose.eps.plugins/_index.md
+++ b/korean/java/com.aspose.eps.plugins/_index.md
@@ -1,0 +1,20 @@
+---
+title: "com.aspose.eps.plugins"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.eps.plugins에는 EPS 플러그인 클래스가 포함되어 있습니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.eps.plugins/
+---
+
+이  **com.aspose.eps.plugins**  은 EPS 플러그인 클래스를 포함합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [PsConverter](../com.aspose.eps.plugins/psconverter) | PsConverter 플러그인을 나타냅니다. |
+| [PsConverterOptions](../com.aspose.eps.plugins/psconverteroptions) | [PsConverter](../com.aspose.eps.plugins/psconverter) 플러그인의 옵션 기본 클래스를 나타냅니다. |
+| [PsConverterToImageOptions](../com.aspose.eps.plugins/psconvertertoimageoptions) | [PsConverter](../com.aspose.eps.plugins/psconverter) 플러그인의 PS/EPS를 이미지로 변환하는 옵션을 나타냅니다. |
+| [PsConverterToPdfOptions](../com.aspose.eps.plugins/psconvertertopdfoptions) | [PsConverter](../com.aspose.eps.plugins/psconverter) 플러그인의 PS/EPS를 PDF로 변환하는 옵션을 나타냅니다. |

--- a/korean/java/com.aspose.eps.plugins/psconverter/_index.md
+++ b/korean/java/com.aspose.eps.plugins/psconverter/_index.md
@@ -1,0 +1,175 @@
+---
+title: "PsConverter"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PsConverter 플러그인을 나타냅니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.eps.plugins/psconverter/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPlugin](../../com.aspose.page.plugins/iplugin)
+```
+public class PsConverter implements IPlugin
+```
+
+PsConverter 플러그인을 나타냅니다.
+
+이 예제는 PS/EPS 파일을 PDF 문서로 변환하는 방법을 보여줍니다.
+
+// PsConverter 생성 PsConverter converter = new PsConverter(); // 파일로 출력 데이터 유형을 설정하기 위해 PsConverterToPdfOptions 객체 생성 PsConverterToPdfOptions opt = new PsConverterToPdfOptions(); // 입력 파일 경로 추가 opt.addDataSource(new FileDataSource(inputPath)); // 출력 파일 경로 설정 opt.addSaveDataSource(new FileDataSource(outputPath)); // 변환 프로세스 시작 ResultContainer results = converter.process(opt);
+
+이 예제는 PS/EPS 파일을 파일 출력으로 이미지로 변환하는 방법을 보여줍니다.
+
+// PsConverter 생성 PsConverter converter = new PsConverter(); // JPEG 대상 이미지 형식으로 PsConverterToImageOptions 생성. 결과 이미지의 기본 형식은 PNG입니다. // 또한 결과 이미지의 크기, 해상도, 스무딩 모드 및 JPEG 결과 이미지 형식의 JPEG 품질 수준을 설정할 수 있습니다. PsConverterToImageOptions opt = new PsConverterToImageOptions(ImageFormat.Jpeg); // 입력 파일 경로 추가 opt.addDataSource(new FileDataSource(inputPath)); // 입력 PS 파일이 다중 페이지인 경우 결과는 이름이 [\"outputPath\" without extension][pageNumber started from 0].[extension from \"outputPath\"]인 이미지 파일 집합이 됩니다. opt.addSaveDataSource(new FileDataSource(outputPath)); // 변환 프로세스 시작 converter.process(opt);
+
+이 예제는 PS/EPS 파일을 바이트 배열 출력으로 이미지로 변환하는 방법을 보여줍니다.
+
+바이트 배열 출력 데이터소스(byte[][])에서 하나의 바이트 배열은 한 페이지의 이미지를 포함합니다. 따라서, 한 페이지 문서의 경우 결과는 [1][] 배열을 포함하고, 다중 페이지 문서의 경우 결과는 [입력 PS 문서의 페이지 수][] 배열을 포함합니다. // PsConverter 생성 PsConverter converter = new PsConverter(); // JPEG 대상 이미지 형식으로 PsConverterToImageOptions 생성. 결과 이미지의 기본 형식은 PNG입니다. // 또한 결과 이미지의 크기, 해상도, 스무딩 모드 및 JPEG 결과 이미지 형식의 JPEG 품질 수준을 설정할 수 있습니다. PsConverterToImageOptions opt = new PsConverterToImageOptions(ImageFormat.Jpeg); // 입력 파일 경로 추가 opt.addDataSource(new FileDataSource(inputPath)); // 입력 PS 파일이 다중 페이지인 경우 결과는 이름이 [\"outputPath\" without extension][pageNumber started from 0].[extension from \"outputPath\"]인 이미지 파일 집합이 됩니다. opt.addSaveDataSource(new ByteArrayDataSource()); // 변환 프로세스 시작 converter.process(opt); // 결과 바이트 배열 가져오기 byte[][] imagesBytes = (byte [][]) ((ByteArrayResult)results.ResultCollection[0]).Data;
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsConverter()](#PsConverter--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [dispose()](#dispose--) | IDisposable 구현. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [process(IPluginOptions options)](#process-com.aspose.page.plugins.IPluginOptions-) | 지정된 매개변수로 PsConverter 처리를 시작합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverter() {#PsConverter--}
+```
+public PsConverter()
+```
+
+
+### dispose() {#dispose--}
+```
+public final void dispose()
+```
+
+
+IDisposable 구현.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### process(IPluginOptions options) {#process-com.aspose.page.plugins.IPluginOptions-}
+```
+public final ResultContainer process(IPluginOptions options)
+```
+
+
+지정된 매개변수로 PsConverter 처리를 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [IPluginOptions](../../com.aspose.page.plugins/ipluginoptions) | PsConverter에 대한 지침을 포함하는 옵션 객체입니다. |
+
+**Returns:**
+[ResultContainer](../../com.aspose.page.plugins/resultcontainer) - An ResultContainer object containing the result of the operation.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.plugins/psconverteroptions/_index.md
+++ b/korean/java/com.aspose.eps.plugins/psconverteroptions/_index.md
@@ -1,0 +1,299 @@
+---
+title: "PsConverterOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인 옵션의 기본 클래스를 나타냅니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.eps.plugins/psconverteroptions/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPluginOptions](../../com.aspose.page.plugins/ipluginoptions), [com.aspose.page.plugins.IDataContainer](../../com.aspose.page.plugins/idatacontainer), [com.aspose.page.plugins.ISaveInstruction](../../com.aspose.page.plugins/isaveinstruction)
+```
+public class PsConverterOptions implements IPluginOptions, IDataContainer, ISaveInstruction
+```
+
+플러그인에 대한 옵션의 기본 클래스를 나타냅니다 [PsConverter](../../com.aspose.eps.plugins/psconverter) 플러그인.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | PsConverter 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다. |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | PsConverterOptions 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | PsConverterOptions 플러그인 데이터 컬렉션을 반환합니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOperationName()](#getOperationName--) | 작업 이름을 반환합니다. |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+PsConverter 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 추가할 데이터 소스입니다. |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+PsConverterOptions 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 저장 작업 결과를 위한 데이터 소스(파일 또는 스트림)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+PsConverterOptions 플러그인 데이터 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOperationName() {#getOperationName--}
+```
+public String getOperationName()
+```
+
+
+작업 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.plugins/psconvertertoimageoptions/_index.md
+++ b/korean/java/com.aspose.eps.plugins/psconvertertoimageoptions/_index.md
@@ -1,0 +1,452 @@
+---
+title: "PsConverterToImageOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인에 대한 PS/EPS에서 이미지 변환기 옵션을 나타냅니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.eps.plugins/psconvertertoimageoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.eps.plugins.PsConverterOptions](../../com.aspose.eps.plugins/psconverteroptions)
+```
+public class PsConverterToImageOptions extends PsConverterOptions
+```
+
+플러그인에 대한 PS/EPS에서 이미지 변환기 옵션을 나타냅니다 [PsConverter](../../com.aspose.eps.plugins/psconverter) 플러그인.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsConverterToImageOptions()](#PsConverterToImageOptions--) | 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다. |
+| [PsConverterToImageOptions(ImageFormat imageFormat)](#PsConverterToImageOptions-com.aspose.page.ImageFormat-) | 이미지 형식을 지정하여 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다. |
+| [PsConverterToImageOptions(Dimension size)](#PsConverterToImageOptions-java.awt.Dimension-) | 결과 이미지의 크기를 지정하여 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다. |
+| [PsConverterToImageOptions(ImageFormat imageFormat, Dimension size)](#PsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-) | 이미지 형식을 지정하여 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | PsConverter 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다. |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | PsConverterOptions 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | PsConverterOptions 플러그인 데이터 컬렉션을 반환합니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageFormat()](#getImageFormat--) | 이미지 형식을 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOperationName()](#getOperationName--) | 작업 이름을 반환합니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다. |
+| [getSize()](#getSize--) | 결과 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 이미지 렌더링을 위한 스무딩 모드를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageFormat(ImageFormat imageFormat)](#setImageFormat-com.aspose.page.ImageFormat-) | 이미지 형식을 가져옵니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setResolution(int resolution)](#setResolution-int-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 결과 이미지의 크기를 설정합니다. |
+| [setSmoothingMode(SmoothingMode smoothingMode)](#setSmoothingMode-com.aspose.eps.device.SmoothingMode-) | 이미지 렌더링을 위한 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterToImageOptions() {#PsConverterToImageOptions--}
+```
+public PsConverterToImageOptions()
+```
+
+
+새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다.
+
+### PsConverterToImageOptions(ImageFormat imageFormat) {#PsConverterToImageOptions-com.aspose.page.ImageFormat-}
+```
+public PsConverterToImageOptions(ImageFormat imageFormat)
+```
+
+
+이미지 형식을 지정하여 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 결과 이미지의 형식입니다. |
+
+### PsConverterToImageOptions(Dimension size) {#PsConverterToImageOptions-java.awt.Dimension-}
+```
+public PsConverterToImageOptions(Dimension size)
+```
+
+
+결과 이미지의 크기를 지정하여 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 결과 이미지의 크기입니다. |
+
+### PsConverterToImageOptions(ImageFormat imageFormat, Dimension size) {#PsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-}
+```
+public PsConverterToImageOptions(ImageFormat imageFormat, Dimension size)
+```
+
+
+이미지 형식을 지정하여 새 인스턴스인 [PsConverterToImageOptions](../../com.aspose.eps.plugins/psconvertertoimageoptions) 객체를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 결과 이미지의 형식입니다. |
+| 크기 | java.awt.Dimension |  |
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+PsConverter 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 추가할 데이터 소스입니다. |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+PsConverterOptions 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 저장 작업 결과를 위한 데이터 소스(파일 또는 스트림)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+PsConverterOptions 플러그인 데이터 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageFormat() {#getImageFormat--}
+```
+public ImageFormat getImageFormat()
+```
+
+
+이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat) - An image format.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+작업 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+int - 이미지 해상도입니다.
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+결과 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 이미지 크기입니다.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+이미지 렌더링을 위한 스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.eps.device/smoothingmode) - A smoothing mode.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageFormat(ImageFormat imageFormat) {#setImageFormat-com.aspose.page.ImageFormat-}
+```
+public void setImageFormat(ImageFormat imageFormat)
+```
+
+
+이미지 형식을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 결과 이미지의 형식입니다. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setResolution(int resolution) {#setResolution-int-}
+```
+public void setResolution(int resolution)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 해상도 | int | 결과 이미지의 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+결과 이미지의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 결과 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode smoothingMode) {#setSmoothingMode-com.aspose.eps.device.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode smoothingMode)
+```
+
+
+이미지 렌더링을 위한 스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| smoothingMode | [SmoothingMode](../../com.aspose.eps.device/smoothingmode) | 스무딩 모드. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps.plugins/psconvertertopdfoptions/_index.md
+++ b/korean/java/com.aspose.eps.plugins/psconvertertopdfoptions/_index.md
@@ -1,0 +1,309 @@
+---
+title: "PsConverterToPdfOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인에 대한 PS/EPS에서 PDF 변환기 옵션을 나타냅니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.eps.plugins/psconvertertopdfoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.eps.plugins.PsConverterOptions](../../com.aspose.eps.plugins/psconverteroptions)
+```
+public class PsConverterToPdfOptions extends PsConverterOptions
+```
+
+플러그인에 대한 PS/EPS에서 PDF 변환기 옵션을 나타냅니다 [PsConverter](../../com.aspose.eps.plugins/psconverter) 플러그인.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsConverterToPdfOptions()](#PsConverterToPdfOptions--) | 새 인스턴스인 [PsConverterToPdfOptions](../../com.aspose.eps.plugins/psconvertertopdfoptions) 객체를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | PsConverter 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다. |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | PsConverterOptions 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | PsConverterOptions 플러그인 데이터 컬렉션을 반환합니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOperationName()](#getOperationName--) | 작업 이름을 반환합니다. |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterToPdfOptions() {#PsConverterToPdfOptions--}
+```
+public PsConverterToPdfOptions()
+```
+
+
+새 인스턴스인 [PsConverterToPdfOptions](../../com.aspose.eps.plugins/psconvertertopdfoptions) 객체를 초기화합니다.
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+PsConverter 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 추가할 데이터 소스입니다. |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+PsConverterOptions 플러그인 데이터 컬렉션에 새 데이터 소스를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 저장 작업 결과를 위한 데이터 소스(파일 또는 스트림)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+PsConverterOptions 플러그인 데이터 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+작업 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/_index.md
+++ b/korean/java/com.aspose.eps/_index.md
@@ -1,0 +1,31 @@
+---
+title: "com.aspose.eps"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.eps는 PS/EPS 파일을 다루는 모든 클래스의 최상위 패키지입니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.eps/
+---
+
+**com.aspose.eps**는 PS/EPS 파일을 다루는 모든 클래스의 루트 패키지입니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [FontConstants](../com.aspose.eps/fontconstants) | 이 클래스는 글꼴 저장을 위한 상수 집합을 정의합니다. |
+| [HatchPaintLibrary](../com.aspose.eps/hatchpaintlibrary) | GDI+ 해치 브러시를 XPS 및 PDF에 기록하기에 적합한 이미지로 변환합니다. |
+| [LoadOptions](../com.aspose.eps/loadoptions) | 문서 로드 옵션을 위한 기본 클래스입니다. |
+| [PageConstants](../com.aspose.eps/pageconstants) | 이 클래스는 페이지를 설명하는 상수 집합을 정의합니다. |
+| [PsConverterException](../com.aspose.eps/psconverterexception) | 이 클래스는 PS 파일이 PDF 문서로 변환되는 동안 발생한 오류에 대한 정보를 포함합니다. |
+| [PsConverterLicenseException](../com.aspose.eps/psconverterlicenseexception) | 이 클래스는 Aspose.Page 제품 라이선스와 관련된 오류에 대한 정보를 포함합니다. |
+| [PsDocument](../com.aspose.eps/psdocument) | 이 클래스는 PS/EPS 문서를 캡슐화합니다. |
+| [PsDocumentException](../com.aspose.eps/psdocumentexception) | 이 클래스는 PS 파일이 생성, 완료 및 저장되는 동안 발생하는 오류에 대한 정보를 포함합니다. |
+| [PsLoadOptions](../com.aspose.eps/psloadoptions) | PS 문서 로드 옵션. |
+
+## 열거형
+
+| 열거형 | 설명 |
+| --- | --- |
+| [HatchStyle](../com.aspose.eps/hatchstyle) | .NET에서 사용되는 해치 스타일의 이름을 저장합니다. |

--- a/korean/java/com.aspose.eps/fontconstants/_index.md
+++ b/korean/java/com.aspose.eps/fontconstants/_index.md
@@ -1,0 +1,184 @@
+---
+title: "FontConstants"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 글꼴 저장을 위한 상수 집합을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.eps/fontconstants/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class FontConstants
+```
+
+이 클래스는 글꼴 저장을 위한 상수 집합을 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [EMBED_FONTS](#EMBED-FONTS) | 저장된 문서에 폰트를 포함할지 여부를 나타내는 속성의 키 |
+| [EMBED_FONTS_AS](#EMBED-FONTS-AS) | 문서를 저장할 때 사용할 폰트 유형을 나타내는 속성의 키 |
+| [EMBED_FONTS_TRUETYPE](#EMBED-FONTS-TRUETYPE) | \"TrueType\" 폰트 유형 값 \"EMBED\\_FONTS\\_AS\" 키에 대한 |
+| [EMBED_FONTS_TYPE1](#EMBED-FONTS-TYPE1) | \"Type3\" 폰트 유형 값 \"EMBED\\_FONTS\\_AS\" 키에 대한 |
+| [EMBED_FONTS_TYPE3](#EMBED-FONTS-TYPE3) | \"Type3\" 폰트 유형 값 \"EMBED\\_FONTS\\_AS\" 키에 대한 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEmbedFontsAsList()](#getEmbedFontsAsList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EMBED_FONTS {#EMBED-FONTS}
+```
+public static final String EMBED_FONTS
+```
+
+
+저장된 문서에 폰트를 포함할지 여부를 나타내는 속성의 키
+
+### EMBED_FONTS_AS {#EMBED-FONTS-AS}
+```
+public static final String EMBED_FONTS_AS
+```
+
+
+문서를 저장할 때 사용할 폰트 유형을 나타내는 속성의 키
+
+### EMBED_FONTS_TRUETYPE {#EMBED-FONTS-TRUETYPE}
+```
+public static final String EMBED_FONTS_TRUETYPE
+```
+
+
+\"TrueType\" 폰트 유형 값 \"EMBED\\_FONTS\\_AS\" 키에 대한
+
+### EMBED_FONTS_TYPE1 {#EMBED-FONTS-TYPE1}
+```
+public static final String EMBED_FONTS_TYPE1
+```
+
+
+\"Type3\" 폰트 유형 값 \"EMBED\\_FONTS\\_AS\" 키에 대한
+
+### EMBED_FONTS_TYPE3 {#EMBED-FONTS-TYPE3}
+```
+public static final String EMBED_FONTS_TYPE3
+```
+
+
+\"Type3\" 폰트 유형 값 \"EMBED\\_FONTS\\_AS\" 키에 대한
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEmbedFontsAsList() {#getEmbedFontsAsList--}
+```
+public static final String[] getEmbedFontsAsList()
+```
+
+
+
+
+**Returns:**
+java.lang.String[] - 사용 가능한 \"EMBED\\_FONTS\\_AS\" 값
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/hatchpaintlibrary/_index.md
+++ b/korean/java/com.aspose.eps/hatchpaintlibrary/_index.md
@@ -1,0 +1,153 @@
+---
+title: "HatchPaintLibrary"
+second_title: "Aspose.Page용 Java API 참조"
+description: "GDI 해치 브러시를 XPS 및 PDF에 기록하기에 적합한 이미지로 변환합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.eps/hatchpaintlibrary/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HatchPaintLibrary
+```
+
+GDI+ 해치 브러시를 XPS 및 PDF에 기록하기에 적합한 이미지로 변환합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [HatchSize](#HatchSize) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHatchTexturePaint(HatchStyle style, Color foreColor, Color backColor)](#getHatchTexturePaint-com.aspose.eps.HatchStyle-java.awt.Color-java.awt.Color-) | 해치 스타일에 따라 해치 패턴을 캡슐화하는 TexturePaint를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### HatchSize {#HatchSize}
+```
+public static final int HatchSize
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHatchTexturePaint(HatchStyle style, Color foreColor, Color backColor) {#getHatchTexturePaint-com.aspose.eps.HatchStyle-java.awt.Color-java.awt.Color-}
+```
+public static TexturePaint getHatchTexturePaint(HatchStyle style, Color foreColor, Color backColor)
+```
+
+
+해치 스타일에 따라 해치 패턴을 캡슐화하는 TexturePaint를 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| style | [HatchStyle](../../com.aspose.eps/hatchstyle) | 해치 스타일. |
+| foreColor | java.awt.Color | 전경 색상. |
+| backColor | java.awt.Color | 배경 색상. |
+
+**Returns:**
+java.awt.TexturePaint - 해치 텍스처 패턴을 반환합니다
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/hatchstyle/_index.md
+++ b/korean/java/com.aspose.eps/hatchstyle/_index.md
@@ -1,0 +1,635 @@
+---
+title: "HatchStyle"
+second_title: "Aspose.Page용 Java API 참조"
+description: ".NET에서 사용되는 해치 스타일의 이름을 저장합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.eps/hatchstyle/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum HatchStyle extends Enum<HatchStyle>
+```
+
+.NET에서 사용되는 해치 스타일의 이름을 저장합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BackwardDiagonal](#BackwardDiagonal) |  |
+| [Cross](#Cross) |  |
+| [DarkDownwardDiagonal](#DarkDownwardDiagonal) |  |
+| [DarkHorizontal](#DarkHorizontal) |  |
+| [DarkUpwardDiagonal](#DarkUpwardDiagonal) |  |
+| [DarkVertical](#DarkVertical) |  |
+| [DashedDownwardDiagonal](#DashedDownwardDiagonal) |  |
+| [DashedHorizontal](#DashedHorizontal) |  |
+| [DashedUpwardDiagonal](#DashedUpwardDiagonal) |  |
+| [DashedVertical](#DashedVertical) |  |
+| [DiagonalBrick](#DiagonalBrick) |  |
+| [DiagonalCross](#DiagonalCross) |  |
+| [Divot](#Divot) |  |
+| [DottedDiamond](#DottedDiamond) |  |
+| [DottedGrid](#DottedGrid) |  |
+| [ForwardDiagonal](#ForwardDiagonal) |  |
+| [Horizontal](#Horizontal) |  |
+| [HorizontalBrick](#HorizontalBrick) |  |
+| [LargeCheckerBoard](#LargeCheckerBoard) |  |
+| [LargeConfetti](#LargeConfetti) |  |
+| [LargeGrid](#LargeGrid) |  |
+| [LightDownwardDiagonal](#LightDownwardDiagonal) |  |
+| [LightHorizontal](#LightHorizontal) |  |
+| [LightUpwardDiagonal](#LightUpwardDiagonal) |  |
+| [LightVertical](#LightVertical) |  |
+| [Max](#Max) |  |
+| [Min](#Min) |  |
+| [NarrowHorizontal](#NarrowHorizontal) |  |
+| [NarrowVertical](#NarrowVertical) |  |
+| [OutlinedDiamond](#OutlinedDiamond) |  |
+| [Percent05](#Percent05) |  |
+| [Percent10](#Percent10) |  |
+| [Percent20](#Percent20) |  |
+| [Percent25](#Percent25) |  |
+| [Percent30](#Percent30) |  |
+| [Percent40](#Percent40) |  |
+| [Percent50](#Percent50) |  |
+| [Percent60](#Percent60) |  |
+| [Percent70](#Percent70) |  |
+| [Percent75](#Percent75) |  |
+| [Percent80](#Percent80) |  |
+| [Percent90](#Percent90) |  |
+| [Plaid](#Plaid) |  |
+| [Shingle](#Shingle) |  |
+| [SmallCheckerBoard](#SmallCheckerBoard) |  |
+| [SmallConfetti](#SmallConfetti) |  |
+| [SmallGrid](#SmallGrid) |  |
+| [SolidDiamond](#SolidDiamond) |  |
+| [Sphere](#Sphere) |  |
+| [Trellis](#Trellis) |  |
+| [Vertical](#Vertical) |  |
+| [Wave](#Wave) |  |
+| [Weave](#Weave) |  |
+| [WideDownwardDiagonal](#WideDownwardDiagonal) |  |
+| [WideUpwardDiagonal](#WideUpwardDiagonal) |  |
+| [ZigZag](#ZigZag) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [getValue()](#getValue--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BackwardDiagonal {#BackwardDiagonal}
+```
+public static final HatchStyle BackwardDiagonal
+```
+
+
+### Cross {#Cross}
+```
+public static final HatchStyle Cross
+```
+
+
+### DarkDownwardDiagonal {#DarkDownwardDiagonal}
+```
+public static final HatchStyle DarkDownwardDiagonal
+```
+
+
+### DarkHorizontal {#DarkHorizontal}
+```
+public static final HatchStyle DarkHorizontal
+```
+
+
+### DarkUpwardDiagonal {#DarkUpwardDiagonal}
+```
+public static final HatchStyle DarkUpwardDiagonal
+```
+
+
+### DarkVertical {#DarkVertical}
+```
+public static final HatchStyle DarkVertical
+```
+
+
+### DashedDownwardDiagonal {#DashedDownwardDiagonal}
+```
+public static final HatchStyle DashedDownwardDiagonal
+```
+
+
+### DashedHorizontal {#DashedHorizontal}
+```
+public static final HatchStyle DashedHorizontal
+```
+
+
+### DashedUpwardDiagonal {#DashedUpwardDiagonal}
+```
+public static final HatchStyle DashedUpwardDiagonal
+```
+
+
+### DashedVertical {#DashedVertical}
+```
+public static final HatchStyle DashedVertical
+```
+
+
+### DiagonalBrick {#DiagonalBrick}
+```
+public static final HatchStyle DiagonalBrick
+```
+
+
+### DiagonalCross {#DiagonalCross}
+```
+public static final HatchStyle DiagonalCross
+```
+
+
+### Divot {#Divot}
+```
+public static final HatchStyle Divot
+```
+
+
+### DottedDiamond {#DottedDiamond}
+```
+public static final HatchStyle DottedDiamond
+```
+
+
+### DottedGrid {#DottedGrid}
+```
+public static final HatchStyle DottedGrid
+```
+
+
+### ForwardDiagonal {#ForwardDiagonal}
+```
+public static final HatchStyle ForwardDiagonal
+```
+
+
+### Horizontal {#Horizontal}
+```
+public static final HatchStyle Horizontal
+```
+
+
+### HorizontalBrick {#HorizontalBrick}
+```
+public static final HatchStyle HorizontalBrick
+```
+
+
+### LargeCheckerBoard {#LargeCheckerBoard}
+```
+public static final HatchStyle LargeCheckerBoard
+```
+
+
+### LargeConfetti {#LargeConfetti}
+```
+public static final HatchStyle LargeConfetti
+```
+
+
+### LargeGrid {#LargeGrid}
+```
+public static final HatchStyle LargeGrid
+```
+
+
+### LightDownwardDiagonal {#LightDownwardDiagonal}
+```
+public static final HatchStyle LightDownwardDiagonal
+```
+
+
+### LightHorizontal {#LightHorizontal}
+```
+public static final HatchStyle LightHorizontal
+```
+
+
+### LightUpwardDiagonal {#LightUpwardDiagonal}
+```
+public static final HatchStyle LightUpwardDiagonal
+```
+
+
+### LightVertical {#LightVertical}
+```
+public static final HatchStyle LightVertical
+```
+
+
+### Max {#Max}
+```
+public static final HatchStyle Max
+```
+
+
+### Min {#Min}
+```
+public static final HatchStyle Min
+```
+
+
+### NarrowHorizontal {#NarrowHorizontal}
+```
+public static final HatchStyle NarrowHorizontal
+```
+
+
+### NarrowVertical {#NarrowVertical}
+```
+public static final HatchStyle NarrowVertical
+```
+
+
+### OutlinedDiamond {#OutlinedDiamond}
+```
+public static final HatchStyle OutlinedDiamond
+```
+
+
+### Percent05 {#Percent05}
+```
+public static final HatchStyle Percent05
+```
+
+
+### Percent10 {#Percent10}
+```
+public static final HatchStyle Percent10
+```
+
+
+### Percent20 {#Percent20}
+```
+public static final HatchStyle Percent20
+```
+
+
+### Percent25 {#Percent25}
+```
+public static final HatchStyle Percent25
+```
+
+
+### Percent30 {#Percent30}
+```
+public static final HatchStyle Percent30
+```
+
+
+### Percent40 {#Percent40}
+```
+public static final HatchStyle Percent40
+```
+
+
+### Percent50 {#Percent50}
+```
+public static final HatchStyle Percent50
+```
+
+
+### Percent60 {#Percent60}
+```
+public static final HatchStyle Percent60
+```
+
+
+### Percent70 {#Percent70}
+```
+public static final HatchStyle Percent70
+```
+
+
+### Percent75 {#Percent75}
+```
+public static final HatchStyle Percent75
+```
+
+
+### Percent80 {#Percent80}
+```
+public static final HatchStyle Percent80
+```
+
+
+### Percent90 {#Percent90}
+```
+public static final HatchStyle Percent90
+```
+
+
+### Plaid {#Plaid}
+```
+public static final HatchStyle Plaid
+```
+
+
+### Shingle {#Shingle}
+```
+public static final HatchStyle Shingle
+```
+
+
+### SmallCheckerBoard {#SmallCheckerBoard}
+```
+public static final HatchStyle SmallCheckerBoard
+```
+
+
+### SmallConfetti {#SmallConfetti}
+```
+public static final HatchStyle SmallConfetti
+```
+
+
+### SmallGrid {#SmallGrid}
+```
+public static final HatchStyle SmallGrid
+```
+
+
+### SolidDiamond {#SolidDiamond}
+```
+public static final HatchStyle SolidDiamond
+```
+
+
+### Sphere {#Sphere}
+```
+public static final HatchStyle Sphere
+```
+
+
+### Trellis {#Trellis}
+```
+public static final HatchStyle Trellis
+```
+
+
+### Vertical {#Vertical}
+```
+public static final HatchStyle Vertical
+```
+
+
+### Wave {#Wave}
+```
+public static final HatchStyle Wave
+```
+
+
+### Weave {#Weave}
+```
+public static final HatchStyle Weave
+```
+
+
+### WideDownwardDiagonal {#WideDownwardDiagonal}
+```
+public static final HatchStyle WideDownwardDiagonal
+```
+
+
+### WideUpwardDiagonal {#WideUpwardDiagonal}
+```
+public static final HatchStyle WideUpwardDiagonal
+```
+
+
+### ZigZag {#ZigZag}
+```
+public static final HatchStyle ZigZag
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### getValue() {#getValue--}
+```
+public int getValue()
+```
+
+
+
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static HatchStyle valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[HatchStyle](../../com.aspose.eps/hatchstyle)
+### values() {#values--}
+```
+public static HatchStyle[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.eps.HatchStyle[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/loadoptions/_index.md
+++ b/korean/java/com.aspose.eps/loadoptions/_index.md
@@ -1,0 +1,124 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서 로드 옵션을 위한 기본 클래스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.eps/loadoptions/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class LoadOptions
+```
+
+문서 로드 옵션을 위한 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/pageconstants/_index.md
+++ b/korean/java/com.aspose.eps/pageconstants/_index.md
@@ -1,0 +1,449 @@
+---
+title: "PageConstants"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 페이지를 설명하는 상수 집합을 정의합니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.eps/pageconstants/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class PageConstants
+```
+
+이 클래스는 페이지를 설명하는 일련의 상수를 정의합니다. 다양한 여백, 방향, 재스케일링 및 표준 페이지 크기에 대한 편리한 객체가 제공됩니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BACKGROUND](#BACKGROUND) | 배경 키 |
+| [BACKGROUND_COLOR](#BACKGROUND-COLOR) | 배경 색상 키 |
+| [FIT_TO_PAGE](#FIT-TO-PAGE) | 내용을 페이지에 맞추기 키 |
+| [MARGINS_LARGE](#MARGINS-LARGE) | "Large" 페이지 여백 값 |
+| [MARGINS_MEDIUM](#MARGINS-MEDIUM) | "Medium" 페이지 여백 값 |
+| [MARGINS_SMALL](#MARGINS-SMALL) | "Small" 페이지 여백 값 |
+| [MARGINS_ZERO](#MARGINS-ZERO) | "Zero" 페이지 여백 값 |
+| [ORIENTATION](#ORIENTATION) | Orientation 키, 페이지의 지정된 방향인 Portret 또는 Landscape용. |
+| [ORIENTATION_BEST_FIT](#ORIENTATION-BEST-FIT) | "Best fit" 방향 값 |
+| [ORIENTATION_LANDSCAPE](#ORIENTATION-LANDSCAPE) | "Landscape" 방향 값 |
+| [ORIENTATION_PORTRAIT](#ORIENTATION-PORTRAIT) | "Portrait" 방향 값 |
+| [PAGE_MARGINS](#PAGE-MARGINS) | 페이지 여백 키 |
+| [PAGE_SIZE](#PAGE-SIZE) | 페이지 크기 키 |
+| [SIZE_A3](#SIZE-A3) | "A3" 페이지 크기 값 |
+| [SIZE_A4](#SIZE-A4) | "A4" 페이지 크기 값 |
+| [SIZE_A5](#SIZE-A5) | "A5" 페이지 크기 값 |
+| [SIZE_A6](#SIZE-A6) | "A6" 페이지 크기 값 |
+| [SIZE_EXECUTIVE](#SIZE-EXECUTIVE) | "Executive" 페이지 크기 값 |
+| [SIZE_INTERNATIONAL](#SIZE-INTERNATIONAL) | "International" 페이지 크기 값 |
+| [SIZE_LEDGER](#SIZE-LEDGER) | "Ledger" 페이지 크기 값 |
+| [SIZE_LEGAL](#SIZE-LEGAL) | "Legal" 페이지 크기 값 |
+| [SIZE_LETTER](#SIZE-LETTER) | "Letter" 페이지 크기 값 |
+| [TRANSPARENT](#TRANSPARENT) | 투명 배경 키 |
+| [VIEWING_ORIENTATION](#VIEWING-ORIENTATION) | 페이지 내용의 방향을 구분하는 회전 행렬을 위한 보기 방향 키. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMargins(Insets insets, String orientation)](#getMargins-java.awt.Insets-java.lang.String-) | 지정된 방향에서 페이지 여백 계산 |
+| [getMargins(String size)](#getMargins-java.lang.String-) |  |
+| [getOrientationList()](#getOrientationList--) |  |
+| [getSize(Dimension size, String orientation)](#getSize-java.awt.Dimension-java.lang.String-) | 주어진 페이지 방향에서 페이지 크기 계산 |
+| [getSize(String size)](#getSize-java.lang.String-) | "Portrait" 페이지 방향에서 페이지 크기 계산 |
+| [getSize(String size, String orientation)](#getSize-java.lang.String-java.lang.String-) | 주어진 페이지 방향에서 페이지 크기 계산 |
+| [getSizeList()](#getSizeList--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BACKGROUND {#BACKGROUND}
+```
+public static final String BACKGROUND
+```
+
+
+배경 키
+
+### BACKGROUND_COLOR {#BACKGROUND-COLOR}
+```
+public static final String BACKGROUND_COLOR
+```
+
+
+배경 색상 키
+
+### FIT_TO_PAGE {#FIT-TO-PAGE}
+```
+public static final String FIT_TO_PAGE
+```
+
+
+내용을 페이지에 맞추기 키
+
+### MARGINS_LARGE {#MARGINS-LARGE}
+```
+public static final String MARGINS_LARGE
+```
+
+
+"Large" 페이지 여백 값
+
+### MARGINS_MEDIUM {#MARGINS-MEDIUM}
+```
+public static final String MARGINS_MEDIUM
+```
+
+
+"Medium" 페이지 여백 값
+
+### MARGINS_SMALL {#MARGINS-SMALL}
+```
+public static final String MARGINS_SMALL
+```
+
+
+"Small" 페이지 여백 값
+
+### MARGINS_ZERO {#MARGINS-ZERO}
+```
+public static final String MARGINS_ZERO
+```
+
+
+"Zero" 페이지 여백 값
+
+### ORIENTATION {#ORIENTATION}
+```
+public static final String ORIENTATION
+```
+
+
+Orientation 키, 페이지의 지정된 방향인 Portret 또는 Landscape용.
+
+### ORIENTATION_BEST_FIT {#ORIENTATION-BEST-FIT}
+```
+public static final String ORIENTATION_BEST_FIT
+```
+
+
+"Best fit" 방향 값
+
+### ORIENTATION_LANDSCAPE {#ORIENTATION-LANDSCAPE}
+```
+public static final String ORIENTATION_LANDSCAPE
+```
+
+
+"Landscape" 방향 값
+
+### ORIENTATION_PORTRAIT {#ORIENTATION-PORTRAIT}
+```
+public static final String ORIENTATION_PORTRAIT
+```
+
+
+"Portrait" 방향 값
+
+### PAGE_MARGINS {#PAGE-MARGINS}
+```
+public static final String PAGE_MARGINS
+```
+
+
+페이지 여백 키
+
+### PAGE_SIZE {#PAGE-SIZE}
+```
+public static final String PAGE_SIZE
+```
+
+
+페이지 크기 키
+
+### SIZE_A3 {#SIZE-A3}
+```
+public static final String SIZE_A3
+```
+
+
+"A3" 페이지 크기 값
+
+### SIZE_A4 {#SIZE-A4}
+```
+public static final String SIZE_A4
+```
+
+
+"A4" 페이지 크기 값
+
+### SIZE_A5 {#SIZE-A5}
+```
+public static final String SIZE_A5
+```
+
+
+"A5" 페이지 크기 값
+
+### SIZE_A6 {#SIZE-A6}
+```
+public static final String SIZE_A6
+```
+
+
+"A6" 페이지 크기 값
+
+### SIZE_EXECUTIVE {#SIZE-EXECUTIVE}
+```
+public static final String SIZE_EXECUTIVE
+```
+
+
+"Executive" 페이지 크기 값
+
+### SIZE_INTERNATIONAL {#SIZE-INTERNATIONAL}
+```
+public static final String SIZE_INTERNATIONAL
+```
+
+
+"International" 페이지 크기 값
+
+### SIZE_LEDGER {#SIZE-LEDGER}
+```
+public static final String SIZE_LEDGER
+```
+
+
+"Ledger" 페이지 크기 값
+
+### SIZE_LEGAL {#SIZE-LEGAL}
+```
+public static final String SIZE_LEGAL
+```
+
+
+"Legal" 페이지 크기 값
+
+### SIZE_LETTER {#SIZE-LETTER}
+```
+public static final String SIZE_LETTER
+```
+
+
+"Letter" 페이지 크기 값
+
+### TRANSPARENT {#TRANSPARENT}
+```
+public static final String TRANSPARENT
+```
+
+
+투명 배경 키
+
+### VIEWING_ORIENTATION {#VIEWING-ORIENTATION}
+```
+public static final String VIEWING_ORIENTATION
+```
+
+
+페이지 내용의 방향을 구분하는 회전 행렬을 위한 보기 방향 키. 기본 보기 방향 행렬은 항등 행렬입니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMargins(Insets insets, String orientation) {#getMargins-java.awt.Insets-java.lang.String-}
+```
+public static final Insets getMargins(Insets insets, String orientation)
+```
+
+
+지정된 방향에서 페이지 여백 계산
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인셋 | java.awt.Insets | 원본 여백 |
+| 방향 | java.lang.String | 페이지 방향 |
+
+**Returns:**
+java.awt.Insets - 주어진 방향에 대한 사전 정의된 페이지 여백
+### getMargins(String size) {#getMargins-java.lang.String-}
+```
+public static final Insets getMargins(String size)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.lang.String | 사전 정의된 페이지 크기 |
+
+**Returns:**
+java.awt.Insets - 사전 정의된 페이지 여백
+### getOrientationList() {#getOrientationList--}
+```
+public static final String[] getOrientationList()
+```
+
+
+
+
+**Returns:**
+java.lang.String[] - 사용 가능한 방향 값
+### getSize(Dimension size, String orientation) {#getSize-java.awt.Dimension-java.lang.String-}
+```
+public static final Dimension getSize(Dimension size, String orientation)
+```
+
+
+주어진 페이지 방향에서 페이지 크기 계산
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 원본 페이지 크기 |
+| 방향 | java.lang.String | 페이지 방향 |
+
+**Returns:**
+java.awt.Dimension - 계산된 페이지 크기
+### getSize(String size) {#getSize-java.lang.String-}
+```
+public static final Dimension getSize(String size)
+```
+
+
+"Portrait" 페이지 방향에서 페이지 크기 계산
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.lang.String | 사전 정의된 페이지 크기 |
+
+**Returns:**
+java.awt.Dimension - 계산된 페이지 크기
+### getSize(String size, String orientation) {#getSize-java.lang.String-java.lang.String-}
+```
+public static final Dimension getSize(String size, String orientation)
+```
+
+
+주어진 페이지 방향에서 페이지 크기 계산
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.lang.String | 사전 정의된 페이지 크기 |
+| 방향 | java.lang.String | 페이지 방향 |
+
+**Returns:**
+java.awt.Dimension - 계산된 페이지 크기
+### getSizeList() {#getSizeList--}
+```
+public static final String[] getSizeList()
+```
+
+
+
+
+**Returns:**
+java.lang.String[] - 사용 가능한 페이지 크기 값
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/psconverterexception/_index.md
+++ b/korean/java/com.aspose.eps/psconverterexception/_index.md
@@ -1,0 +1,289 @@
+---
+title: "PsConverterException"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 PS 파일이 PDF 문서로 변환되는 동안 발생한 오류에 대한 정보를 포함합니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.eps/psconverterexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class PsConverterException extends Exception
+```
+
+이 클래스는 PS 파일이 PDF 문서로 변환되는 동안 발생한 오류에 대한 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsConverterException(String errorStr)](#PsConverterException-java.lang.String-) | errorStr 문자열로부터 PsConverterException의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterException(String errorStr) {#PsConverterException-java.lang.String-}
+```
+public PsConverterException(String errorStr)
+```
+
+
+errorStr 문자열로부터 PsConverterException의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| errorStr | java.lang.String | 변환 오류의 이유를 설명하는 문자열입니다. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/psconverterlicenseexception/_index.md
+++ b/korean/java/com.aspose.eps/psconverterlicenseexception/_index.md
@@ -1,0 +1,289 @@
+---
+title: "PsConverterLicenseException"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 Aspose.Page 제품 라이선스와 관련된 오류에 대한 정보를 포함합니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.eps/psconverterlicenseexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, [com.aspose.eps.PsConverterException](../../com.aspose.eps/psconverterexception)
+```
+public class PsConverterLicenseException extends PsConverterException
+```
+
+이 클래스는 Aspose.Page 제품 라이선스와 관련된 오류에 대한 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsConverterLicenseException(String errorStr)](#PsConverterLicenseException-java.lang.String-) | errorStr 문자열에서  PsConverterLicenseException  의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsConverterLicenseException(String errorStr) {#PsConverterLicenseException-java.lang.String-}
+```
+public PsConverterLicenseException(String errorStr)
+```
+
+
+errorStr 문자열에서  PsConverterLicenseException  의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| errorStr | java.lang.String | 변환 오류의 이유를 설명하는 문자열입니다. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/psdocument/_index.md
+++ b/korean/java/com.aspose.eps/psdocument/_index.md
@@ -1,0 +1,1432 @@
+---
+title: "PsDocument"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 PS/EPS 문서를 캡슐화합니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.eps/psdocument/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.Document](../../com.aspose.page/document)
+```
+public final class PsDocument extends Document
+```
+
+이 클래스는 PS/EPS 문서를 캡슐화합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsDocument()](#PsDocument--) | 초기화된 페이지와 함께 빈 PsDocument를 초기화합니다. |
+| [PsDocument(String outPsFilePath, PsSaveOptions options)](#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | 초기화된 페이지와 함께 빈 PsDocument를 초기화합니다. |
+| [PsDocument(OutputStream psStream, PsSaveOptions options)](#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | 초기화된 페이지와 함께 빈 PsDocument를 초기화합니다. |
+| [PsDocument(String outPsFilePath, PsSaveOptions options, boolean multipaged)](#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-boolean-) | 빈 PsDocument를 초기화합니다. |
+| [PsDocument(OutputStream psStream, PsSaveOptions options, boolean multipaged)](#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-boolean-) | 빈 PsDocument를 초기화합니다. |
+| [PsDocument(String outPsFilePath, PsSaveOptions options, int numberOfPages)](#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-int-) | Postscript 문서 페이지 수를 미리 알 경우 빈 PsDocument를 초기화합니다. |
+| [PsDocument(OutputStream psStream, PsSaveOptions options, int numberOfPages)](#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-int-) | Postscript 문서 페이지 수를 미리 알 경우 빈 PsDocument를 초기화합니다. |
+| [PsDocument(String psFilePath)](#PsDocument-java.lang.String-) | 입력 PS/EPS 파일로 PsDocument를 초기화합니다. |
+| [PsDocument(InputStream psStream)](#PsDocument-java.io.InputStream-) | PS/EPS 파일 스트림으로 PsDocument를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clip(Shape s)](#clip-java.awt.Shape-) | 현재 그래픽 상태에 클립을 추가합니다. |
+| [clipAndNewPath(Shape s)](#clipAndNewPath-java.awt.Shape-) | 현재 그래픽 상태에 클립을 추가하고 "newpath" 연산자를 기록합니다. |
+| [clipRectangle(Rectangle2D.Float rect)](#clipRectangle-java.awt.geom.Rectangle2D.Float-) | 현재 그래픽 상태에 클리핑 사각형을 추가합니다. |
+| [clipText(String text, Font font, float x, float y)](#clipText-java.lang.String-java.awt.Font-float-float-) | 주어진 글꼴의 지정된 텍스트 윤곽선에서 클립을 추가합니다. |
+| [closePage()](#closePage--) | 현재 페이지를 완료합니다. |
+| [convertType1FontToTTF(String type1FontFilePath, String outputDir)](#convertType1FontToTTF-java.lang.String-java.lang.String-) | Type 1 글꼴을 TrueType으로 변환합니다. |
+| [convertType3FontToTTF(String type3FontFilePath, OutputStream outputStream)](#convertType3FontToTTF-java.lang.String-java.io.OutputStream-) | Type 3 글꼴을 TrueType으로 변환합니다. |
+| [convertType3FontToTTF(String type3FontFilePath, String outputDir)](#convertType3FontToTTF-java.lang.String-java.lang.String-) | Type 3 글꼴을 TrueType으로 변환합니다. |
+| [cropEps(OutputStream epsStream, float[] cropBox)](#cropEps-java.io.OutputStream-float---) | 주어진 PsDocument를 EPS 파일로 잘라냅니다. |
+| [draw(Shape shape)](#draw-java.awt.Shape-) | 임의의 경로를 그립니다. |
+| [drawExplicitImageMask(BufferedImage image24bpp, BufferedImage alphaMask1bpp, AffineTransform transform)](#drawExplicitImageMask-java.awt.image.BufferedImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-) | 마스크된 이미지를 그립니다. |
+| [drawImage(BufferedImage image)](#drawImage-java.awt.image.BufferedImage-) | 이미지를 그립니다. |
+| [drawImage(BufferedImage image, AffineTransform transform, Color bkg)](#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-) | 배경이 있는 변환된 이미지를 그립니다. |
+| [drawTransparentImage(BufferedImage image, AffineTransform transform, int transparencyThreshold)](#drawTransparentImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-int-) | 배경이 있는 변환된 투명 이미지를 그립니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [extractEpsBoundingBox()](#extractEpsBoundingBox--) | EPS 파일을 읽고 %%BoundingBox 주석에서 EPS 이미지의 경계 상자를 추출하거나, 존재하지 않을 경우 기본 페이지 크기 (0, 0, 595, 842)의 경계를 사용합니다. |
+| [extractEpsSize()](#extractEpsSize--) | EPS 파일을 읽고 %%BoundingBox 주석에서 EPS 이미지의 크기를 추출하거나, 존재하지 않을 경우 기본 페이지 크기 (595, 842)를 사용합니다. |
+| [extractText(SaveOptions options, int startPage, int endPage)](#extractText-com.aspose.page.SaveOptions-int-int-) | PS 파일에서 텍스트를 추출합니다. |
+| [fill(Shape shape)](#fill-java.awt.Shape-) | 임의의 경로를 채웁니다. |
+| [fillAndStrokeText(String text, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | 글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [fillAndStrokeText(String text, float[] advances, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | 글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [fillAndStrokeText(String text, float[] advances, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | 글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [fillAndStrokeText(String text, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)](#fillAndStrokeText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-) | 글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [fillText(String text, DrFont drFont, float x, float y)](#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, DrFont drFont, float x, float y, Paint fill)](#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, float[] advances, DrFont drFont, float x, float y)](#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, float[] advances, DrFont drFont, float x, float y, Paint fill)](#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, float[] advances, Font font, float x, float y)](#fillText-java.lang.String-float---java.awt.Font-float-float-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, float[] advances, Font font, float x, float y, Paint fill)](#fillText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, Font font, float x, float y)](#fillText-java.lang.String-java.awt.Font-float-float-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [fillText(String text, Font font, float x, float y, Paint fill)](#fillText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-) | 글리프 내부를 채워 텍스트 문자열을 추가합니다. |
+| [getClass()](#getClass--) |  |
+| [getInputStream()](#getInputStream--) |  |
+| [getNumberOfPages()](#getNumberOfPages--) | 결과 PDF 문서의 페이지 수를 가져옵니다. |
+| [getPaint()](#getPaint--) | 현재 그래픽 상태의 페인트를 가져옵니다. |
+| [getStroke()](#getStroke--) | 현재 그래픽 상태의 스트로크를 가져옵니다. |
+| [getXmpMetadata()](#getXmpMetadata--) | PS/EPS 파일을 읽고 XmpMetadata가 이미 존재하면 추출하고, 존재하지 않으면 새로 추가합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isLicensed()](#isLicensed--) | Aspose.Page for Java 제품 라이선스에 접근했는지 및 유효한지 여부를 나타냅니다. |
+| [merge(String[] filesForMerge, Device device, SaveOptions options)](#merge-java.lang.String---com.aspose.page.Device-com.aspose.page.SaveOptions-) | PS/EPS 파일을 장치에 병합합니다. |
+| [mergeToPdf(OutputStream pdfStream, String[] filesForMerge, SaveOptions options)](#mergeToPdf-java.io.OutputStream-java.lang.String---com.aspose.page.SaveOptions-) | PS/EPS 파일을 장치에 병합합니다. |
+| [mergeToPdf(String outPdfFilePath, String[] filesForMerge, SaveOptions options)](#mergeToPdf-java.lang.String-java.lang.String---com.aspose.page.SaveOptions-) | PS/EPS 파일을 장치에 병합합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [openPage(float width, float height)](#openPage-float-float-) | 새 페이지를 만들고 현재 페이지로 설정합니다. |
+| [openPage(String pageName)](#openPage-java.lang.String-) | 문서 크기로 새 페이지를 만들고 현재 페이지로 설정합니다. |
+| [outlineText(String text, DrFont drFont, float x, float y)](#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, float[] advances, DrFont drFont, float x, float y)](#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, float[] advances, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, float[] advances, Font font, float x, float y)](#outlineText-java.lang.String-float---java.awt.Font-float-float-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, float[] advances, Font font, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, Font font, float x, float y)](#outlineText-java.lang.String-java.awt.Font-float-float-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [outlineText(String text, Font font, float x, float y, Paint outlinePaint, Stroke stroke)](#outlineText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-) | 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다. |
+| [resizeEps(OutputStream epsStream, DimensionF newSizeInUnits, Units units)](#resizeEps-java.io.OutputStream-com.aspose.page.DimensionF-com.aspose.page.Units-) | 주어진 PsDocument를 EPS 파일로 크기 조정합니다. |
+| [rotate(float angleRadians)](#rotate-float-) | 원점을 기준으로 반시계 방향 회전을 현재 그래픽 상태에 추가합니다 (현재 행렬을 회전시킵니다). |
+| [rotate(int angleDegrees)](#rotate-int-) | 원점을 기준으로 반시계 방향 회전을 현재 그래픽 상태에 추가합니다 (현재 행렬을 회전시킵니다). |
+| [save()](#save--) | 주어진 PsDocument를 PS 또는 EPS 파일로 저장합니다. |
+| [save(Device device, SaveOptions options)](#save-com.aspose.page.Device-com.aspose.page.SaveOptions-) | PS/EPS 파일을 장치에 저장합니다. |
+| [save(OutputStream epsStream)](#save-java.io.OutputStream-) | 주어진 PsDocument를 스트림에 저장합니다. |
+| [save(String outEpsFilePath)](#save-java.lang.String-) | 주어진 PsDocument를 EPS 파일로 저장합니다. |
+| [saveAsImage(ImageSaveOptions options)](#saveAsImage-com.aspose.eps.device.ImageSaveOptions-) | PS/EPS 파일을 이미지 파일로 저장합니다. |
+| [saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)](#saveAsImage-com.aspose.eps.device.ImageSaveOptions-java.lang.String-java.lang.String-) | PS/EPS 파일을 지정된 디렉터리와 파일 이름으로 이미지 파일에 저장합니다. |
+| [saveAsImagesBytes(ImageSaveOptions options)](#saveAsImagesBytes-com.aspose.eps.device.ImageSaveOptions-) | PS/EPS 파일을 이미지 바이트 배열로 저장합니다. |
+| [saveAsPdf(OutputStream pdfStream, PdfSaveOptions options)](#saveAsPdf-java.io.OutputStream-com.aspose.eps.device.PdfSaveOptions-) | PS/EPS 파일을 출력 PDF 스트림에 저장합니다. |
+| [saveAsPdf(String outPdfFilePath, PdfSaveOptions options)](#saveAsPdf-java.lang.String-com.aspose.eps.device.PdfSaveOptions-) | PS/EPS 파일을 PDF 파일로 저장합니다. |
+| [saveImageAsEps(BufferedImage image, OutputStream epsStream, PsSaveOptions options)](#saveImageAsEps-java.awt.image.BufferedImage-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | BufferedImage 객체를 EPS 파일로 저장합니다. |
+| [saveImageAsEps(BufferedImage image, String epsFilePath, PsSaveOptions options)](#saveImageAsEps-java.awt.image.BufferedImage-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | BufferedImage 객체를 EPS 파일로 저장합니다. |
+| [saveImageAsEps(InputStream imageStream, OutputStream epsStream, PsSaveOptions options)](#saveImageAsEps-java.io.InputStream-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | 입력 스트림의 PNG/JPEG/BMP/GIF 이미지를 EPS 출력 스트림으로 저장합니다. |
+| [saveImageAsEps(String imageFilePath, String epsFilePath, PsSaveOptions options)](#saveImageAsEps-java.lang.String-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | 파일의 PNG/JPEG/BMP/GIF 이미지를 EPS 파일로 저장합니다. |
+| [scale(float xScale, float yScale)](#scale-float-float-) | 현재 그래픽 상태에 스케일을 추가합니다 (현재 행렬을 스케일). |
+| [setInputStream(InputStream is)](#setInputStream-java.io.InputStream-) | 입력 스트림을 지정합니다. |
+| [setPageDevice(Map<String,Object> pageParams)](#setPageDevice-java.util.Map-java.lang.String-java.lang.Object--) | 페이지 장치 매개변수를 설정합니다 (연산자 "setpagedevice" PostScript 사양을 참조). |
+| [setPageSize(float width, float height)](#setPageSize-float-float-) | 페이지 크기를 설정합니다. |
+| [setPaint(Paint paint)](#setPaint-java.awt.Paint-) | 현재 그래픽 상태에 페인트를 설정합니다. |
+| [setStroke(Stroke stroke)](#setStroke-java.awt.Stroke-) | 현재 그래픽 상태에 스트로크를 설정합니다. |
+| [setTransform(AffineTransform matrix)](#setTransform-java.awt.geom.AffineTransform-) | 현재 변환을 이것으로 설정합니다. |
+| [shear(float shx, float shy)](#shear-float-float-) | 현재 그래픽 상태에 전단 변환을 추가합니다 (현재 행렬을 전단). |
+| [toString()](#toString--) |  |
+| [transform(AffineTransform matrix)](#transform-java.awt.geom.AffineTransform-) | 현재 그래픽 상태에 변환을 추가합니다 (이 행렬을 현재 행렬과 연결). |
+| [translate(float x, float y)](#translate-float-float-) | 현재 그래픽 상태에 평행 이동을 추가합니다 (현재 행렬을 평행 이동). |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+| [writeGraphicsRestore()](#writeGraphicsRestore--) | 현재 그래픽 상태 복원을 기록합니다 (연산자 "grestore"에 대한 PostScript 사양을 참조). |
+| [writeGraphicsSave()](#writeGraphicsSave--) | 현재 그래픽 상태 저장을 기록합니다 (연산자 "gsave"에 대한 PostScript 사양을 참조). |
+### PsDocument() {#PsDocument--}
+```
+public PsDocument()
+```
+
+
+빈 PsDocument를 초기화된 페이지와 함께 초기화합니다. 이 생성자는 PostScript 파일과 관련되지 않은 추가 작업, 예를 들어 글꼴 변환 등에만 사용됩니다.
+
+### PsDocument(String outPsFilePath, PsSaveOptions options) {#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public PsDocument(String outPsFilePath, PsSaveOptions options)
+```
+
+
+초기화된 페이지와 함께 빈 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 출력 PS/EPS 파일 경로입니다. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript 파일 저장을 제어하는 매개변수 집합입니다. |
+
+### PsDocument(OutputStream psStream, PsSaveOptions options) {#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public PsDocument(OutputStream psStream, PsSaveOptions options)
+```
+
+
+초기화된 페이지와 함께 빈 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| psStream | java.io.OutputStream | PS/EPS 파일을 저장할 스트림입니다. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript 파일 저장을 제어하는 매개변수 집합입니다. |
+
+### PsDocument(String outPsFilePath, PsSaveOptions options, boolean multipaged) {#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-boolean-}
+```
+public PsDocument(String outPsFilePath, PsSaveOptions options, boolean multipaged)
+```
+
+
+빈 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 출력 PS/EPS 파일 경로입니다. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript 파일 저장을 제어하는 매개변수 집합입니다. |
+| multipaged | boolean | false인 경우 페이지가 초기화되지 않습니다. 이 경우 페이지 초기화는 명시적인 "openPage(width, height)" 호출을 통해 수행되어야 합니다. |
+
+### PsDocument(OutputStream psStream, PsSaveOptions options, boolean multipaged) {#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-boolean-}
+```
+public PsDocument(OutputStream psStream, PsSaveOptions options, boolean multipaged)
+```
+
+
+빈 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| psStream | java.io.OutputStream | PS/EPS 파일을 저장할 스트림입니다. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript 파일 저장을 제어하는 매개변수 집합입니다. |
+| multipaged | boolean | false인 경우 페이지가 초기화되지 않습니다. 이 경우 페이지 초기화는 명시적인 "openPage(width, height)" 호출을 통해 수행되어야 합니다. |
+
+### PsDocument(String outPsFilePath, PsSaveOptions options, int numberOfPages) {#PsDocument-java.lang.String-com.aspose.eps.device.PsSaveOptions-int-}
+```
+public PsDocument(String outPsFilePath, PsSaveOptions options, int numberOfPages)
+```
+
+
+Postscript 문서 페이지 수를 미리 알 경우 빈 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 출력 PS/EPS 파일 경로입니다. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript 파일 저장을 제어하는 매개변수 집합입니다. |
+| numberOfPages | int | PostScript 문서의 페이지 수입니다. |
+
+### PsDocument(OutputStream psStream, PsSaveOptions options, int numberOfPages) {#PsDocument-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-int-}
+```
+public PsDocument(OutputStream psStream, PsSaveOptions options, int numberOfPages)
+```
+
+
+Postscript 문서 페이지 수를 미리 알 경우 빈 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| psStream | java.io.OutputStream | PS/EPS 파일을 저장할 스트림입니다. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PostScript 파일 저장을 제어하는 매개변수 집합입니다. |
+| numberOfPages | int | PostScript 문서의 페이지 수입니다. |
+
+### PsDocument(String psFilePath) {#PsDocument-java.lang.String-}
+```
+public PsDocument(String psFilePath)
+```
+
+
+입력 PS/EPS 파일로 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| psFilePath | java.lang.String | PS/EPS 파일 경로입니다. |
+
+### PsDocument(InputStream psStream) {#PsDocument-java.io.InputStream-}
+```
+public PsDocument(InputStream psStream)
+```
+
+
+PS/EPS 파일 스트림으로 PsDocument를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| psStream | java.io.InputStream | PS/EPS 파일의 스트림입니다. |
+
+### clip(Shape s) {#clip-java.awt.Shape-}
+```
+public void clip(Shape s)
+```
+
+
+현재 그래픽 상태에 클립을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| s | java.awt.Shape | 클리핑 경로. |
+
+### clipAndNewPath(Shape s) {#clipAndNewPath-java.awt.Shape-}
+```
+public void clipAndNewPath(Shape s)
+```
+
+
+현재 그래픽 상태에 클립을 추가하고 "newpath" 연산자를 기록합니다. 이 클리핑 경로와 "charpath" 연산자로 윤곽이 그려진 글리프와 같은 이후 경로들의 결합을 피하기 위해 필요합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| s | java.awt.Shape | 클리핑 경로. |
+
+### clipRectangle(Rectangle2D.Float rect) {#clipRectangle-java.awt.geom.Rectangle2D.Float-}
+```
+public void clipRectangle(Rectangle2D.Float rect)
+```
+
+
+현재 그래픽 상태에 클리핑 사각형을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| rect | java.awt.geom.Rectangle2D.Float | 클리핑 사각형. |
+
+### clipText(String text, Font font, float x, float y) {#clipText-java.lang.String-java.awt.Font-float-float-}
+```
+public void clipText(String text, Font font, float x, float y)
+```
+
+
+주어진 글꼴의 지정된 텍스트 윤곽선에서 클립을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 텍스트. |
+| font | java.awt.Font | 폰트. |
+| x | float | 텍스트 위치의 X 좌표. |
+| y | float |  |
+
+### closePage() {#closePage--}
+```
+public void closePage()
+```
+
+
+현재 페이지를 완료합니다.
+
+### convertType1FontToTTF(String type1FontFilePath, String outputDir) {#convertType1FontToTTF-java.lang.String-java.lang.String-}
+```
+public void convertType1FontToTTF(String type1FontFilePath, String outputDir)
+```
+
+
+Type 1 폰트를 TrueType으로 변환합니다. 변환된 TTF 폰트 파일의 이름은 입력 Type 1 폰트와 동일하게 ".ttf" 확장자를 붙인 이름이 됩니다. TTF 파일은 지정된 출력 디렉터리에 저장됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| type1FontFilePath | java.lang.String | Type 1 폰트 파일 경로.. |
+| outputDir | java.lang.String | 결과 TrueType 폰트를 저장할 출력 디렉터리. |
+
+### convertType3FontToTTF(String type3FontFilePath, OutputStream outputStream) {#convertType3FontToTTF-java.lang.String-java.io.OutputStream-}
+```
+public void convertType3FontToTTF(String type3FontFilePath, OutputStream outputStream)
+```
+
+
+Type 3 폰트를 TrueType으로 변환합니다. TTF 파일은 제공된 출력 스트림에 저장됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| type3FontFilePath | java.lang.String | Type 3 폰트 파일 경로. |
+| outputStream | java.io.OutputStream | 결과 TrueType 폰트를 저장할 출력 스트림. |
+
+### convertType3FontToTTF(String type3FontFilePath, String outputDir) {#convertType3FontToTTF-java.lang.String-java.lang.String-}
+```
+public void convertType3FontToTTF(String type3FontFilePath, String outputDir)
+```
+
+
+Type 3 폰트를 TrueType으로 변환합니다. 변환된 TTF 폰트 파일의 이름은 입력 Type 3 폰트와 동일하게 ".ttf" 확장자를 붙인 이름이 됩니다. TTF 파일은 지정된 출력 디렉터리에 저장됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| type3FontFilePath | java.lang.String | Type 3 폰트 파일 경로.. |
+| outputDir | java.lang.String | 결과 TrueType 폰트를 저장할 출력 디렉터리. |
+
+### cropEps(OutputStream epsStream, float[] cropBox) {#cropEps-java.io.OutputStream-float---}
+```
+public void cropEps(OutputStream epsStream, float[] cropBox)
+```
+
+
+주어진 PsDocument를 EPS 파일로 잘라냅니다. 기존 %%BoundingBox를 업데이트하거나 새로 생성된 %%BoundingBox와 함께 초기 EPS 파일을 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| epsStream | java.io.OutputStream |  |
+| cropBox | float[] | 크롭 박스 (x0, y0, x, y). |
+
+### draw(Shape shape) {#draw-java.awt.Shape-}
+```
+public void draw(Shape shape)
+```
+
+
+임의의 경로를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| shape | java.awt.Shape | 채우기 경로. |
+
+### drawExplicitImageMask(BufferedImage image24bpp, BufferedImage alphaMask1bpp, AffineTransform transform) {#drawExplicitImageMask-java.awt.image.BufferedImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-}
+```
+public void drawExplicitImageMask(BufferedImage image24bpp, BufferedImage alphaMask1bpp, AffineTransform transform)
+```
+
+
+마스크된 이미지를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image24bpp | java.awt.image.BufferedImage | 그릴 이미지. 24bpp RGB 이미지 형식이어야 합니다. |
+| alphaMask1bpp | java.awt.image.BufferedImage | 이미지 마스크. 1bpp 이미지 형식이어야 합니다. |
+| transform | java.awt.geom.AffineTransform | 이미지를 변환할 행렬. |
+
+### drawImage(BufferedImage image) {#drawImage-java.awt.image.BufferedImage-}
+```
+public void drawImage(BufferedImage image)
+```
+
+
+이미지를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 그릴 이미지. |
+
+### drawImage(BufferedImage image, AffineTransform transform, Color bkg) {#drawImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-java.awt.Color-}
+```
+public void drawImage(BufferedImage image, AffineTransform transform, Color bkg)
+```
+
+
+배경이 있는 변환된 이미지를 그립니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 그릴 이미지. |
+| transform | java.awt.geom.AffineTransform | 이미지를 변환할 행렬. |
+| bkg | java.awt.Color | 이미지의 배경. |
+
+### drawTransparentImage(BufferedImage image, AffineTransform transform, int transparencyThreshold) {#drawTransparentImage-java.awt.image.BufferedImage-java.awt.geom.AffineTransform-int-}
+```
+public void drawTransparentImage(BufferedImage image, AffineTransform transform, int transparencyThreshold)
+```
+
+
+배경과 함께 변환된 투명 이미지를 그립니다. 이미지에 알파 채널이 없으면 불투명 이미지로 그려집니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 그릴 이미지. |
+| transform | java.awt.geom.AffineTransform | 이미지를 변환할 행렬. |
+| transparencyThreshold | int | 투명도를 완전 투명으로 해석할 픽셀 값의 기준값을 정의하는 임계값입니다. 이 임계값 이하의 모든 값은 완전 불투명으로 해석됩니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### extractEpsBoundingBox() {#extractEpsBoundingBox--}
+```
+public int[] extractEpsBoundingBox()
+```
+
+
+EPS 파일을 읽고 %%BoundingBox 주석에서 EPS 이미지의 경계 상자를 추출하거나, 존재하지 않을 경우 기본 페이지 크기 (0, 0, 595, 842)의 경계를 사용합니다.
+
+**Returns:**
+int[] - EPS 이미지의 경계 상자.
+### extractEpsSize() {#extractEpsSize--}
+```
+public Dimension extractEpsSize()
+```
+
+
+EPS 파일을 읽고 %%BoundingBox 주석에서 EPS 이미지의 크기를 추출하거나, 존재하지 않을 경우 기본 페이지 크기 (595, 842)를 사용합니다.
+
+**Returns:**
+java.awt.Dimension - EPS 이미지의 크기.
+### extractText(SaveOptions options, int startPage, int endPage) {#extractText-com.aspose.page.SaveOptions-int-int-}
+```
+public String extractText(SaveOptions options, int startPage, int endPage)
+```
+
+
+PS 파일에서 텍스트를 추출합니다. TrueType 글꼴(Type 42) 또는 TrueType 글꼴로 구성된 복합 글꼴(Type 0)로 작성된 텍스트에만 작동합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 저장 옵션. |
+| startPage | int | 텍스트 추출을 시작할 포함 페이지. |
+| endPage | int | 텍스트를 포함하여 추출할 페이지. |
+
+**Returns:**
+java.lang.String - 선택된 PS 파일 페이지에 포함된 텍스트.
+### fill(Shape shape) {#fill-java.awt.Shape-}
+```
+public void fill(Shape shape)
+```
+
+
+임의의 경로를 채웁니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| shape | java.awt.Shape | 채우기 경로. |
+
+### fillAndStrokeText(String text, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fillPaint | java.awt.Paint | 글리프 내부를 채우는 데 사용되는 fill. |
+| strokePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### fillAndStrokeText(String text, float[] advances, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, float[] advances, DrFont drFont, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fillPaint | java.awt.Paint | 글리프 내부를 채우는 데 사용되는 fill. |
+| strokePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### fillAndStrokeText(String text, float[] advances, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, float[] advances, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. advances 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| advances | float[] |  |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 시스템 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fillPaint | java.awt.Paint | 글리프 내부를 채우는 데 사용되는 fill. |
+| strokePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### fillAndStrokeText(String text, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke) {#fillAndStrokeText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Paint-java.awt.Stroke-}
+```
+public void fillAndStrokeText(String text, Font font, float x, float y, Paint fillPaint, Paint strokePaint, Stroke stroke)
+```
+
+
+글리프 내부를 채우고 글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 시스템 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fillPaint | java.awt.Paint | 글리프 내부를 채우는 데 사용되는 fill. |
+| strokePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### fillText(String text, DrFont drFont, float x, float y) {#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void fillText(String text, DrFont drFont, float x, float y)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### fillText(String text, DrFont drFont, float x, float y, Paint fill) {#fillText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-}
+```
+public void fillText(String text, DrFont drFont, float x, float y, Paint fill)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fill | java.awt.Paint | 글리프를 그리는 데 사용되는 fill. |
+
+### fillText(String text, float[] advances, DrFont drFont, float x, float y) {#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void fillText(String text, float[] advances, DrFont drFont, float x, float y)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### fillText(String text, float[] advances, DrFont drFont, float x, float y, Paint fill) {#fillText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-}
+```
+public void fillText(String text, float[] advances, DrFont drFont, float x, float y, Paint fill)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fill | java.awt.Paint | 글리프를 그리는 데 사용되는 fill. |
+
+### fillText(String text, float[] advances, Font font, float x, float y) {#fillText-java.lang.String-float---java.awt.Font-float-float-}
+```
+public void fillText(String text, float[] advances, Font font, float x, float y)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 시스템 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### fillText(String text, float[] advances, Font font, float x, float y, Paint fill) {#fillText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-}
+```
+public void fillText(String text, float[] advances, Font font, float x, float y, Paint fill)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fill | java.awt.Paint | 글리프를 그리는 데 사용되는 fill. |
+
+### fillText(String text, Font font, float x, float y) {#fillText-java.lang.String-java.awt.Font-float-float-}
+```
+public void fillText(String text, Font font, float x, float y)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 시스템 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### fillText(String text, Font font, float x, float y, Paint fill) {#fillText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-}
+```
+public void fillText(String text, Font font, float x, float y, Paint fill)
+```
+
+
+글리프 내부를 채워 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| fill | java.awt.Paint | 글리프를 그리는 데 사용되는 fill. |
+
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getInputStream() {#getInputStream--}
+```
+public InputStream getInputStream()
+```
+
+
+
+
+**Returns:**
+java.io.InputStream
+### getNumberOfPages() {#getNumberOfPages--}
+```
+public int getNumberOfPages()
+```
+
+
+결과 PDF 문서의 페이지 수를 가져옵니다.
+
+**Returns:**
+int - 페이지 수.
+### getPaint() {#getPaint--}
+```
+public Paint getPaint()
+```
+
+
+현재 그래픽 상태의 페인트를 가져옵니다.
+
+**Returns:**
+java.awt.Paint - 현재 paint.
+### getStroke() {#getStroke--}
+```
+public Stroke getStroke()
+```
+
+
+현재 그래픽 상태의 스트로크를 가져옵니다.
+
+**Returns:**
+java.awt.Stroke - 현재 스트로크.
+### getXmpMetadata() {#getXmpMetadata--}
+```
+public XmpMetadata getXmpMetadata()
+```
+
+
+PS/EPS 파일을 읽고 XmpMetadata가 이미 존재하면 추출하고, 존재하지 않으면 새로 추가합니다.
+
+**Returns:**
+[XmpMetadata](../../com.aspose.eps.xmp/xmpmetadata) - existing or new instance of XMP metadata.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isLicensed() {#isLicensed--}
+```
+public boolean isLicensed()
+```
+
+
+Aspose.Page for Java 제품 라이선스에 접근했는지 및 유효한지 여부를 나타냅니다.
+
+**Returns:**
+boolean - boolean 값
+### merge(String[] filesForMerge, Device device, SaveOptions options) {#merge-java.lang.String---com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public void merge(String[] filesForMerge, Device device, SaveOptions options)
+```
+
+
+PS/EPS 파일을 장치에 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | 이 파일과 병합하여 출력 장치에 사용할 PS/EPS 파일. |
+| device | [Device](../../com.aspose.page/device) | 출력 장치. |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### mergeToPdf(OutputStream pdfStream, String[] filesForMerge, SaveOptions options) {#mergeToPdf-java.io.OutputStream-java.lang.String---com.aspose.page.SaveOptions-}
+```
+public void mergeToPdf(OutputStream pdfStream, String[] filesForMerge, SaveOptions options)
+```
+
+
+PS/EPS 파일을 장치에 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pdfStream | java.io.OutputStream | 출력 PDF 스트림. |
+| filesForMerge | java.lang.String[] | 이 파일과 병합하여 출력 장치에 사용할 PS/EPS 파일. |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### mergeToPdf(String outPdfFilePath, String[] filesForMerge, SaveOptions options) {#mergeToPdf-java.lang.String-java.lang.String---com.aspose.page.SaveOptions-}
+```
+public void mergeToPdf(String outPdfFilePath, String[] filesForMerge, SaveOptions options)
+```
+
+
+PS/EPS 파일을 장치에 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 출력 PDF 파일 경로. |
+| filesForMerge | java.lang.String[] | 이 파일과 병합하여 출력 장치에 사용할 PS/EPS 파일. |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### openPage(float width, float height) {#openPage-float-float-}
+```
+public void openPage(float width, float height)
+```
+
+
+새 페이지를 만들고 현재 페이지로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 새 페이지의 너비. |
+| 높이 | float | 새 페이지의 높이. |
+
+### openPage(String pageName) {#openPage-java.lang.String-}
+```
+public void openPage(String pageName)
+```
+
+
+문서 크기로 새 페이지를 만들고 현재 페이지로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageName | java.lang.String | 새 페이지의 이름. null인 경우 페이지 이름은 페이지의 순번이 됩니다. |
+
+### outlineText(String text, DrFont drFont, float x, float y) {#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void outlineText(String text, DrFont drFont, float x, float y)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### outlineText(String text, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| outlinePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### outlineText(String text, float[] advances, DrFont drFont, float x, float y) {#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-}
+```
+public void outlineText(String text, float[] advances, DrFont drFont, float x, float y)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### outlineText(String text, float[] advances, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-float---com.aspose.foundation.drawing.DrFont-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, float[] advances, DrFont drFont, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| drFont | com.aspose.foundation.drawing.DrFont | 텍스트를 그리는 데 사용될 DrFont. 사용자 지정 폴더에 위치한 사용자 정의 글꼴과 함께 사용할 수 있습니다. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| outlinePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### outlineText(String text, float[] advances, Font font, float x, float y) {#outlineText-java.lang.String-float---java.awt.Font-float-float-}
+```
+public void outlineText(String text, float[] advances, Font font, float x, float y)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 시스템 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### outlineText(String text, float[] advances, Font font, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-float---java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, float[] advances, Font font, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| advances | float[] | 글리프 너비 배열. 길이는 문자열의 글리프 수와 일치해야 합니다. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| outlinePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### outlineText(String text, Font font, float x, float y) {#outlineText-java.lang.String-java.awt.Font-float-float-}
+```
+public void outlineText(String text, Font font, float x, float y)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 시스템 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+
+### outlineText(String text, Font font, float x, float y, Paint outlinePaint, Stroke stroke) {#outlineText-java.lang.String-java.awt.Font-float-float-java.awt.Paint-java.awt.Stroke-}
+```
+public void outlineText(String text, Font font, float x, float y, Paint outlinePaint, Stroke stroke)
+```
+
+
+글리프 윤곽선을 그려 텍스트 문자열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| text | java.lang.String | 추가할 텍스트. |
+| font | java.awt.Font | 텍스트를 그리는 데 사용될 폰트. |
+| x | float | 텍스트 시작점의 X 좌표. |
+| y | float | 텍스트 시작점의 Y 좌표. |
+| outlinePaint | java.awt.Paint | 글리프 외곽선을 그리는 데 사용되는 java.awt.Paint. JDK의 java.awt.Paint 클래스의 모든 하위 클래스가 될 수 있습니다. |
+| stroke | java.awt.Stroke | 글리프 윤곽선을 그리는 데 사용되는 stroke. |
+
+### resizeEps(OutputStream epsStream, DimensionF newSizeInUnits, Units units) {#resizeEps-java.io.OutputStream-com.aspose.page.DimensionF-com.aspose.page.Units-}
+```
+public void resizeEps(OutputStream epsStream, DimensionF newSizeInUnits, Units units)
+```
+
+
+주어진 PsDocument를 EPS 파일로 크기 조정합니다. 이 메서드는 EPS 크기를 추출한 후에만 사용됩니다. 기존 %%BoundingBox를 업데이트한 초기 EPS 파일을 저장하거나 새 파일이 생성됩니다. 페이지 변환 행렬도 설정됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| epsStream | java.io.OutputStream |  |
+| newSizeInUnits | [DimensionF](../../com.aspose.page/dimensionf) | 지정된 단위의 EPS 이미지 새 크기. |
+| units | [Units](../../com.aspose.page/units) | 새 크기의 단위. 포인트, 인치, 밀리미터, 센티미터 및 초기 크기의 백분율이 될 수 있습니다. |
+
+### rotate(float angleRadians) {#rotate-float-}
+```
+public void rotate(float angleRadians)
+```
+
+
+원점을 기준으로 반시계 방향 회전을 현재 그래픽 상태에 추가합니다 (현재 행렬을 회전시킵니다).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angleRadians | float | 라디안 단위의 회전 각도. |
+
+### rotate(int angleDegrees) {#rotate-int-}
+```
+public void rotate(int angleDegrees)
+```
+
+
+원점을 기준으로 반시계 방향 회전을 현재 그래픽 상태에 추가합니다 (현재 행렬을 회전시킵니다).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angleDegrees | int | 도 단위의 회전 각도. |
+
+### save() {#save--}
+```
+public void save()
+```
+
+
+주어진 PsDocument를 PS 또는 EPS 파일로 저장합니다. 이 메서드는 PsDocument가 처음부터 생성된 경우에만 사용됩니다.
+
+### save(Device device, SaveOptions options) {#save-com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public void save(Device device, SaveOptions options)
+```
+
+
+PS/EPS 파일을 장치에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| device | [Device](../../com.aspose.page/device) | 출력 장치. |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### save(OutputStream epsStream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream epsStream)
+```
+
+
+주어진 PsDocument를 스트림에 저장합니다. 이 메서드는 XMP 메타데이터를 업데이트한 후에만 사용됩니다. 기존 메타데이터를 업데이트한 초기 EPS 파일을 저장하거나 getMetadata 메서드를 호출하면서 새 파일을 생성합니다. 마지막 경우에는 필요한 모든 PostScript 코드와 EPS 주석이 추가됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| epsStream | java.io.OutputStream | 출력 EPS 파일 스트림. |
+
+### save(String outEpsFilePath) {#save-java.lang.String-}
+```
+public void save(String outEpsFilePath)
+```
+
+
+주어진 PsDocument를 EPS 파일로 저장합니다. 이 메서드는 XMP 메타데이터를 업데이트한 후에만 사용됩니다. 기존 메타데이터를 업데이트한 초기 EPS 파일을 저장하거나 getMetadata 메서드를 호출하면서 새 파일을 생성합니다. 마지막 경우에는 필요한 모든 PostScript 코드와 EPS 주석이 추가됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outEpsFilePath | java.lang.String | 출력 EPS 파일 경로.. |
+
+### saveAsImage(ImageSaveOptions options) {#saveAsImage-com.aspose.eps.device.ImageSaveOptions-}
+```
+public void saveAsImage(ImageSaveOptions options)
+```
+
+
+PS/EPS 파일을 이미지 파일로 저장합니다. 출력 디렉터리와 파일 이름은 입력 PS 파일과 동일합니다. 파일 확장자는 "options" 매개변수의 이미지 형식에 따라 결정됩니다. 문서가 FileInputStream에서 파생되지 않은 스트림으로 초기화된 경우, 이미지 파일은 기본 파일 이름 템플릿을 사용하여 현재 폴더에 저장됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.eps.device/imagesaveoptions) | 이미지를 저장하기 위한 필수 매개변수와 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate) {#saveAsImage-com.aspose.eps.device.ImageSaveOptions-java.lang.String-java.lang.String-}
+```
+public void saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)
+```
+
+
+지정된 디렉터리와 지정된 파일 이름으로 PS/EPS 파일을 이미지 파일로 저장합니다. 파일 확장자는 "options" 매개변수의 이미지 형식에 따라 결정됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.eps.device/imagesaveoptions) | 이미지를 저장하기 위한 필수 매개변수와 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+| outDir | java.lang.String | 이미지 파일이 저장될 출력 디렉터리입니다. |
+| fileNameTemplate | java.lang.String | 이미지의 파일 이름 템플릿(확장자 제외)입니다. 입력 PS/EPS 파일이 1페이지인 경우 정확히 파일 이름이 사용되며, 그렇지 않은 경우 "\_[n]" 형태가 되며, 여기서 "n"은 0부터 시작하는 페이지 번호이며, 이 뒤에 접미사가 추가됩니다. 파일 확장자는 "option" 매개변수의 이미지 형식에 따라 결정됩니다. |
+
+### saveAsImagesBytes(ImageSaveOptions options) {#saveAsImagesBytes-com.aspose.eps.device.ImageSaveOptions-}
+```
+public byte[][] saveAsImagesBytes(ImageSaveOptions options)
+```
+
+
+PS/EPS 파일을 이미지 바이트 배열로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.eps.device/imagesaveoptions) | 이미지를 저장하기 위한 필수 매개변수와 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+**Returns:**
+byte[][] - 이미지 바이트. 페이지당 하나의 바이트 배열입니다.
+### saveAsPdf(OutputStream pdfStream, PdfSaveOptions options) {#saveAsPdf-java.io.OutputStream-com.aspose.eps.device.PdfSaveOptions-}
+```
+public void saveAsPdf(OutputStream pdfStream, PdfSaveOptions options)
+```
+
+
+PS/EPS 파일을 출력 PDF 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pdfStream | java.io.OutputStream | 출력 PDF 스트림. |
+| options | [PdfSaveOptions](../../com.aspose.eps.device/pdfsaveoptions) | 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### saveAsPdf(String outPdfFilePath, PdfSaveOptions options) {#saveAsPdf-java.lang.String-com.aspose.eps.device.PdfSaveOptions-}
+```
+public void saveAsPdf(String outPdfFilePath, PdfSaveOptions options)
+```
+
+
+PS/EPS 파일을 PDF 파일로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 출력 PDF 파일 경로. |
+| options | [PdfSaveOptions](../../com.aspose.eps.device/pdfsaveoptions) | 변환 중 발생한 오류의 출력을 지정하는 플래그를 포함합니다. |
+
+### saveImageAsEps(BufferedImage image, OutputStream epsStream, PsSaveOptions options) {#saveImageAsEps-java.awt.image.BufferedImage-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(BufferedImage image, OutputStream epsStream, PsSaveOptions options)
+```
+
+
+BufferedImage 객체를 EPS 파일로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 이미지. |
+| epsStream | java.io.OutputStream | EPS 출력 스트림. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 변환 중 발생한 오류의 출력을 지정하는 매개변수를 포함합니다. |
+
+### saveImageAsEps(BufferedImage image, String epsFilePath, PsSaveOptions options) {#saveImageAsEps-java.awt.image.BufferedImage-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(BufferedImage image, String epsFilePath, PsSaveOptions options)
+```
+
+
+BufferedImage 객체를 EPS 파일로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | java.awt.image.BufferedImage | 이미지. |
+| epsFilePath | java.lang.String | EPS 파일 경로. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 변환 중 발생한 오류의 출력을 지정하는 매개변수를 포함합니다. |
+
+### saveImageAsEps(InputStream imageStream, OutputStream epsStream, PsSaveOptions options) {#saveImageAsEps-java.io.InputStream-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(InputStream imageStream, OutputStream epsStream, PsSaveOptions options)
+```
+
+
+입력 스트림의 PNG/JPEG/BMP/GIF 이미지를 EPS 출력 스트림으로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageStream | java.io.InputStream | 이미지 입력 스트림. |
+| epsStream | java.io.OutputStream | EPS 출력 스트림. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 변환 중 발생한 오류의 출력을 지정하는 매개변수를 포함합니다. |
+
+### saveImageAsEps(String imageFilePath, String epsFilePath, PsSaveOptions options) {#saveImageAsEps-java.lang.String-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public static void saveImageAsEps(String imageFilePath, String epsFilePath, PsSaveOptions options)
+```
+
+
+파일의 PNG/JPEG/BMP/GIF 이미지를 EPS 파일로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFilePath | java.lang.String | 이미지 파일 경로. |
+| epsFilePath | java.lang.String | EPS 파일 경로. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | 변환 중 발생한 오류의 출력을 지정하는 매개변수를 포함합니다. |
+
+### scale(float xScale, float yScale) {#scale-float-float-}
+```
+public void scale(float xScale, float yScale)
+```
+
+
+현재 그래픽 상태에 스케일을 추가합니다 (현재 행렬을 스케일).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| xScale | float | X 축의 스케일. |
+| yScale | float | Y 축의 스케일. |
+
+### setInputStream(InputStream is) {#setInputStream-java.io.InputStream-}
+```
+public void setInputStream(InputStream is)
+```
+
+
+입력 스트림을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| is | java.io.InputStream | PS/EPS 파일의 입력 스트림. |
+
+### setPageDevice(Map<String,Object> pageParams) {#setPageDevice-java.util.Map-java.lang.String-java.lang.Object--}
+```
+public void setPageDevice(Map<String,Object> pageParams)
+```
+
+
+페이지 장치 매개변수를 설정합니다(연산자 "setpagedevice" PostScript 사양을 참조). 여기에는 페이지 크기, 색상 등과 같은 매개변수가 포함될 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageParams | java.util.Map<java.lang.String,java.lang.Object> | 페이지의 매개변수입니다. 이 사전에는 페이지 크기와 색상 등이 포함될 수 있습니다. |
+
+### setPageSize(float width, float height) {#setPageSize-float-float-}
+```
+public void setPageSize(float width, float height)
+```
+
+
+페이지 크기를 설정합니다. 하나의 문서에서 서로 다른 크기의 페이지를 만들려면 이 메서드 바로 뒤에  setPageDevice  메서드를 사용하십시오.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 결과 PostScript 파일에서 페이지의 너비입니다. |
+| 높이 | float | 결과 PostScript 파일에서 페이지의 높이입니다. |
+
+### setPaint(Paint paint) {#setPaint-java.awt.Paint-}
+```
+public void setPaint(Paint paint)
+```
+
+
+현재 그래픽 상태에 페인트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| paint | java.awt.Paint | 페인트입니다. JDK에 존재하는  Paint  클래스의 모든 하위 클래스가 될 수 있습니다. |
+
+### setStroke(Stroke stroke) {#setStroke-java.awt.Stroke-}
+```
+public void setStroke(Stroke stroke)
+```
+
+
+현재 그래픽 상태에 스트로크를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| stroke | java.awt.Stroke | 스트로크입니다. |
+
+### setTransform(AffineTransform matrix) {#setTransform-java.awt.geom.AffineTransform-}
+```
+public void setTransform(AffineTransform matrix)
+```
+
+
+현재 변환을 이것으로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| matrix | java.awt.geom.AffineTransform | 변환입니다. |
+
+### shear(float shx, float shy) {#shear-float-float-}
+```
+public void shear(float shx, float shy)
+```
+
+
+현재 그래픽 상태에 전단 변환을 추가합니다 (현재 행렬을 전단).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| shx | float | X 축의 전단입니다. |
+| shy | float | Y 축의 전단입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### transform(AffineTransform matrix) {#transform-java.awt.geom.AffineTransform-}
+```
+public void transform(AffineTransform matrix)
+```
+
+
+현재 그래픽 상태에 변환을 추가합니다 (이 행렬을 현재 행렬과 연결).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| matrix | java.awt.geom.AffineTransform | 변환입니다. |
+
+### translate(float x, float y) {#translate-float-float-}
+```
+public void translate(float x, float y)
+```
+
+
+현재 그래픽 상태에 평행 이동을 추가합니다 (현재 행렬을 평행 이동).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| x | float | X 방향의 이동입니다. |
+| y | float | Y 방향의 이동입니다. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+
+### writeGraphicsRestore() {#writeGraphicsRestore--}
+```
+public void writeGraphicsRestore()
+```
+
+
+현재 그래픽 상태 복원을 기록합니다 (연산자 "grestore"에 대한 PostScript 사양을 참조).
+
+### writeGraphicsSave() {#writeGraphicsSave--}
+```
+public void writeGraphicsSave()
+```
+
+
+현재 그래픽 상태 저장을 기록합니다 (연산자 "gsave"에 대한 PostScript 사양을 참조).
+

--- a/korean/java/com.aspose.eps/psdocumentexception/_index.md
+++ b/korean/java/com.aspose.eps/psdocumentexception/_index.md
@@ -1,0 +1,289 @@
+---
+title: "PsDocumentException"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 PS 파일이 생성, 완료 및 저장되는 동안 발생한 오류에 대한 정보를 포함합니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.eps/psdocumentexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception
+```
+public class PsDocumentException extends Exception
+```
+
+이 클래스는 PS 파일이 생성, 완료 및 저장되는 동안 발생하는 오류에 대한 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsDocumentException(String errorStr)](#PsDocumentException-java.lang.String-) | errorStr 문자열로부터 PsDocumentException의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsDocumentException(String errorStr) {#PsDocumentException-java.lang.String-}
+```
+public PsDocumentException(String errorStr)
+```
+
+
+errorStr 문자열로부터 PsDocumentException의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| errorStr | java.lang.String | 오류 원인을 설명하는 문자열입니다. |
+
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.eps/psloadoptions/_index.md
+++ b/korean/java/com.aspose.eps/psloadoptions/_index.md
@@ -1,0 +1,137 @@
+---
+title: "PsLoadOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PS 문서 로드 옵션."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.eps/psloadoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.eps.LoadOptions](../../com.aspose.eps/loadoptions)
+```
+public class PsLoadOptions extends LoadOptions
+```
+
+PS 문서 로드 옵션.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PsLoadOptions()](#PsLoadOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PsLoadOptions() {#PsLoadOptions--}
+```
+public PsLoadOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/_index.md
+++ b/korean/java/com.aspose.page.plugins/_index.md
@@ -1,0 +1,43 @@
+---
+title: "com.aspose.page.plugins"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.page.plugins는 모든 Aspose.Page 플러그인에 공통적인 인터페이스와 클래스를 포함합니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.page.plugins/
+---
+
+이 **com.aspose.page.plugins**는 모든 Aspose.Page 플러그인에 공통적인 인터페이스와 클래스를 포함합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [ByteArrayDataSource](../com.aspose.page.plugins/bytearraydatasource) |  |
+| [ByteArrayResult](../com.aspose.page.plugins/bytearrayresult) | 바이트 배열 형태의 작업 결과를 나타냅니다. |
+| [DataType](../com.aspose.page.plugins/datatype) | 플러그인 처리를 위한 가능한 데이터 유형을 나타냅니다. |
+| [FileDataSource](../com.aspose.page.plugins/filedatasource) | 플러그인의 로드 및 저장 작업을 위한 파일 데이터 소스를 나타냅니다. |
+| [FileResult](../com.aspose.page.plugins/fileresult) | 파일 경로 문자열 형태의 작업 결과를 나타냅니다. |
+| [PluginExceptionMessages](../com.aspose.page.plugins/pluginexceptionmessages) | 이 클래스는 플러그인에서 발생한 예외에 사용되는 메시지 저장소를 나타냅니다. |
+| [ResultContainer](../com.aspose.page.plugins/resultcontainer) | 플러그인 처리 결과 컬렉션을 포함하는 컨테이너를 나타냅니다. |
+| [StreamDataSource](../com.aspose.page.plugins/streamdatasource) | 플러그인의 로드 및 저장 작업을 위한 스트림 데이터 소스를 나타냅니다. |
+| [StreamResult](../com.aspose.page.plugins/streamresult) | 스트림 형태의 작업 결과를 나타냅니다. |
+| [StringResult](../com.aspose.page.plugins/stringresult) | 문자열 형태의 작업 결과를 나타냅니다. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IDataContainer](../com.aspose.page.plugins/idatacontainer) | 구체적인 데이터 컨테이너(플러그인 옵션)가 구현해야 하는 공통 메서드를 정의하는 일반 데이터 컨테이너 인터페이스. |
+| [IDataSource](../com.aspose.page.plugins/idatasource) | 구체적인 데이터 소스가 구현해야 하는 공통 멤버를 정의하는 일반 데이터 소스 인터페이스. |
+| [IOperationResult](../com.aspose.page.plugins/ioperationresult) | 구체적인 플러그인 작업 결과가 구현해야 하는 공통 메서드를 정의하는 일반 작업 결과 인터페이스. |
+| [IPlugin](../com.aspose.page.plugins/iplugin) | 구체적인 플러그인이 구현해야 하는 공통 메서드를 정의하는 일반 플러그인 인터페이스. |
+| [IPluginOptions](../com.aspose.page.plugins/ipluginoptions) | 구체적인 플러그인 옵션이 구현해야 하는 공통 메서드를 정의하는 일반 플러그인 옵션 인터페이스. |
+| [ISaveInstruction](../com.aspose.page.plugins/isaveinstruction) | 구체적인 플러그인 옵션이 구현해야 하는 공통 멤버를 정의하는 일반 저장 지시 인터페이스. |
+
+## 열거형
+
+| 열거형 | 설명 |
+| --- | --- |
+| [Plugin](../com.aspose.page.plugins/plugin) | 가능한 플러그인을 나타냅니다. |

--- a/korean/java/com.aspose.page.plugins/bytearraydatasource/_index.md
+++ b/korean/java/com.aspose.page.plugins/bytearraydatasource/_index.md
@@ -1,0 +1,147 @@
+---
+title: "ByteArrayDataSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: 
+type: docs
+weight: 10
+url: /ko/java/com.aspose.page.plugins/bytearraydatasource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IDataSource](../../com.aspose.page.plugins/idatasource)
+```
+public final class ByteArrayDataSource implements IDataSource
+```
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ByteArrayDataSource()](#ByteArrayDataSource--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataType()](#getDataType--) | 데이터 소스 유형(파일). |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteArrayDataSource() {#ByteArrayDataSource--}
+```
+public ByteArrayDataSource()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataType() {#getDataType--}
+```
+public final int getDataType()
+```
+
+
+데이터 소스 유형(파일).
+
+**Returns:**
+int
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/bytearrayresult/_index.md
+++ b/korean/java/com.aspose.page.plugins/bytearrayresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "ByteArrayResult"
+second_title: "Aspose.Page용 Java API 참조"
+description: "바이트 배열 형태의 작업 결과를 나타냅니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.page.plugins/bytearrayresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public class ByteArrayResult implements IOperationResult
+```
+
+바이트 배열 형태의 작업 결과를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ByteArrayResult(byte[][] data)](#ByteArrayResult-byte-----) | 바이트 배열을 사용하여 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 원시 데이터를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 결과가 바이트 배열인지 여부를 나타냅니다. |
+| [isFile()](#isFile--) | 결과가 출력 파일 경로인지 여부를 나타냅니다. |
+| [isStream()](#isStream--) | 결과가 출력 스트림인지 여부를 나타냅니다. |
+| [isString()](#isString--) | 결과가 텍스트 문자열인지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 결과를 파일로 변환을 시도합니다. |
+| [toStream()](#toStream--) | 결과를 스트림 객체로 변환을 시도합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteArrayResult(byte[][] data) {#ByteArrayResult-byte-----}
+```
+public ByteArrayResult(byte[][] data)
+```
+
+
+바이트 배열을 사용하여 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | byte[][] | 바이트 배열의 배열입니다. 문서를 이미지로 변환하는 데 사용됩니다. 하나의 바이트 배열은 한 페이지 이미지의 바이트를 포함합니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+원시 데이터를 가져옵니다.
+
+**Returns:**
+java.lang.Object - 출력 데이터를 나타내는 객체.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+결과가 바이트 배열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 바이트 배열이면 true; 그렇지 않으면 false.
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+결과가 출력 파일 경로인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 파일이면 true; 그렇지 않으면 false.
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+결과가 출력 스트림인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 스트림 객체이면 true; 그렇지 않으면 false.
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+결과가 텍스트 문자열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 문자열이면 true; 그렇지 않으면 false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+결과를 파일로 변환을 시도합니다.
+
+**Returns:**
+java.lang.String - 결과가 파일인 경우 출력 파일 경로를 나타내는 문자열; 그렇지 않으면 null.
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+결과를 스트림 객체로 변환을 시도합니다.
+
+**Returns:**
+java.io.OutputStream - 결과가 스트림인 경우 출력 데이터를 나타내는 스트림 객체; 그렇지 않으면 null.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/datatype/_index.md
+++ b/korean/java/com.aspose.page.plugins/datatype/_index.md
@@ -1,0 +1,542 @@
+---
+title: "DataType"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인 처리를 위한 가능한 데이터 유형을 나타냅니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.page.plugins/datatype/
+---
+**Inheritance:**
+java.lang.Object, com.aspose.ms.System.ValueType, com.aspose.ms.System.Enum
+```
+public final class DataType extends System.Enum
+```
+
+플러그인 처리를 위한 가능한 데이터 유형을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ByteArray](#ByteArray) | 데이터 유형은 스트림입니다. |
+| [EnumSeparatorCharArray](#EnumSeparatorCharArray) |  |
+| [File](#File) | 데이터 유형은 해당 경로로 표시되는 파일입니다. |
+| [Stream](#Stream) | 데이터 유형은 스트림입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [Clone()](#Clone--) |  |
+| [CloneTo(T arg0)](#CloneTo-T-) |  |
+| [CloneTo(System.Enum arg0)](#CloneTo-com.aspose.ms.System.Enum-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [format(System.Type arg0, Object arg1, String arg2)](#format-com.aspose.ms.System.Type-java.lang.Object-java.lang.String-) |  |
+| [format(Class<?> arg0, long arg1, String arg2)](#format-java.lang.Class----long-java.lang.String-) |  |
+| [getClass()](#getClass--) |  |
+| [getName(Class<?> arg0, long arg1)](#getName-java.lang.Class----long-) |  |
+| [getNames(System.Type arg0)](#getNames-com.aspose.ms.System.Type-) |  |
+| [getNames(Class<?> arg0)](#getNames-java.lang.Class----) |  |
+| [getUnderlyingType(System.Type arg0)](#getUnderlyingType-com.aspose.ms.System.Type-) |  |
+| [getUnderlyingType(Class<?> arg0)](#getUnderlyingType-java.lang.Class----) |  |
+| [getValue(Class<?> arg0, String arg1)](#getValue-java.lang.Class----java.lang.String-) |  |
+| [getValues(System.Type arg0)](#getValues-com.aspose.ms.System.Type-) |  |
+| [get_Caption()](#get-Caption--) |  |
+| [get_Value()](#get-Value--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isDefined(System.Type arg0, Object arg1)](#isDefined-com.aspose.ms.System.Type-java.lang.Object-) |  |
+| [isDefined(System.Type arg0, String arg1)](#isDefined-com.aspose.ms.System.Type-java.lang.String-) |  |
+| [isDefined(System.Type arg0, long arg1)](#isDefined-com.aspose.ms.System.Type-long-) |  |
+| [isDefined(Class<?> arg0, long arg1)](#isDefined-java.lang.Class----long-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [parse(System.Type arg0, String arg1)](#parse-com.aspose.ms.System.Type-java.lang.String-) |  |
+| [parse(System.Type arg0, String arg1, Boolean arg2)](#parse-com.aspose.ms.System.Type-java.lang.String-java.lang.Boolean-) |  |
+| [parse(Class<?> arg0, String arg1)](#parse-java.lang.Class----java.lang.String-) |  |
+| [parse(Class<?> arg0, String arg1, Boolean arg2)](#parse-java.lang.Class----java.lang.String-java.lang.Boolean-) |  |
+| [register(System.Enum.AbstractEnum arg0)](#register-com.aspose.ms.System.Enum.AbstractEnum-) |  |
+| [toObject(System.Type arg0, Object arg1)](#toObject-com.aspose.ms.System.Type-java.lang.Object-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ByteArray {#ByteArray}
+```
+public static final int ByteArray
+```
+
+
+데이터 유형은 스트림입니다.
+
+### EnumSeparatorCharArray {#EnumSeparatorCharArray}
+```
+public static final char[] EnumSeparatorCharArray
+```
+
+
+### File {#File}
+```
+public static final int File
+```
+
+
+데이터 유형은 해당 경로로 표시되는 파일입니다.
+
+### Stream {#Stream}
+```
+public static final int Stream
+```
+
+
+데이터 유형은 스트림입니다.
+
+### Clone() {#Clone--}
+```
+public System.Enum Clone()
+```
+
+
+
+
+**Returns:**
+com.aspose.ms.System.Enum
+### CloneTo(T arg0) {#CloneTo-T-}
+```
+public abstract void CloneTo(T arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | T |  |
+
+### CloneTo(System.Enum arg0) {#CloneTo-com.aspose.ms.System.Enum-}
+```
+public void CloneTo(System.Enum arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Enum |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### format(System.Type arg0, Object arg1, String arg2) {#format-com.aspose.ms.System.Type-java.lang.Object-java.lang.String-}
+```
+public static String format(System.Type arg0, Object arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.lang.String |  |
+
+**Returns:**
+java.lang.String
+### format(Class<?> arg0, long arg1, String arg2) {#format-java.lang.Class----long-java.lang.String-}
+```
+public static String format(Class<?> arg0, long arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+| arg2 | java.lang.String |  |
+
+**Returns:**
+java.lang.String
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName(Class<?> arg0, long arg1) {#getName-java.lang.Class----long-}
+```
+public static String getName(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+java.lang.String
+### getNames(System.Type arg0) {#getNames-com.aspose.ms.System.Type-}
+```
+public static String[] getNames(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+java.lang.String[]
+### getNames(Class<?> arg0) {#getNames-java.lang.Class----}
+```
+public static Collection<String> getNames(Class<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+
+**Returns:**
+java.util.Collection<java.lang.String>
+### getUnderlyingType(System.Type arg0) {#getUnderlyingType-com.aspose.ms.System.Type-}
+```
+public static System.Type getUnderlyingType(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+com.aspose.ms.System.Type
+### getUnderlyingType(Class<?> arg0) {#getUnderlyingType-java.lang.Class----}
+```
+public static Class<? extends Number> getUnderlyingType(Class<?> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+
+**Returns:**
+java.lang.Class<? extends java.lang.Number>
+### getValue(Class<?> arg0, String arg1) {#getValue-java.lang.Class----java.lang.String-}
+```
+public static long getValue(Class<?> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### getValues(System.Type arg0) {#getValues-com.aspose.ms.System.Type-}
+```
+public static System.Array getValues(System.Type arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+
+**Returns:**
+com.aspose.ms.System.Array
+### get_Caption() {#get-Caption--}
+```
+public String get_Caption()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### get_Value() {#get-Value--}
+```
+public long get_Value()
+```
+
+
+
+
+**Returns:**
+long
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDefined(System.Type arg0, Object arg1) {#isDefined-com.aspose.ms.System.Type-java.lang.Object-}
+```
+public static boolean isDefined(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### isDefined(System.Type arg0, String arg1) {#isDefined-com.aspose.ms.System.Type-java.lang.String-}
+```
+public static boolean isDefined(System.Type arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+boolean
+### isDefined(System.Type arg0, long arg1) {#isDefined-com.aspose.ms.System.Type-long-}
+```
+public static boolean isDefined(System.Type arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | long |  |
+
+**Returns:**
+boolean
+### isDefined(Class<?> arg0, long arg1) {#isDefined-java.lang.Class----long-}
+```
+public static boolean isDefined(Class<?> arg0, long arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | long |  |
+
+**Returns:**
+boolean
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### parse(System.Type arg0, String arg1) {#parse-com.aspose.ms.System.Type-java.lang.String-}
+```
+public static long parse(System.Type arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### parse(System.Type arg0, String arg1, Boolean arg2) {#parse-com.aspose.ms.System.Type-java.lang.String-java.lang.Boolean-}
+```
+public static long parse(System.Type arg0, String arg1, Boolean arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.Boolean |  |
+
+**Returns:**
+long
+### parse(Class<?> arg0, String arg1) {#parse-java.lang.Class----java.lang.String-}
+```
+public static long parse(Class<?> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+long
+### parse(Class<?> arg0, String arg1, Boolean arg2) {#parse-java.lang.Class----java.lang.String-java.lang.Boolean-}
+```
+public static long parse(Class<?> arg0, String arg1, Boolean arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<?> |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.Boolean |  |
+
+**Returns:**
+long
+### register(System.Enum.AbstractEnum arg0) {#register-com.aspose.ms.System.Enum.AbstractEnum-}
+```
+public static void register(System.Enum.AbstractEnum arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Enum.AbstractEnum |  |
+
+### toObject(System.Type arg0, Object arg1) {#toObject-com.aspose.ms.System.Type-java.lang.Object-}
+```
+public static Object toObject(System.Type arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | com.aspose.ms.System.Type |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/filedatasource/_index.md
+++ b/korean/java/com.aspose.page.plugins/filedatasource/_index.md
@@ -1,0 +1,167 @@
+---
+title: "FileDataSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인의 로드 및 저장 작업을 위한 파일 데이터 소스를 나타냅니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.page.plugins/filedatasource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IDataSource](../../com.aspose.page.plugins/idatasource)
+```
+public final class FileDataSource implements IDataSource
+```
+
+플러그인의 로드 및 저장 작업을 위한 파일 데이터 소스를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FileDataSource(String path)](#FileDataSource-java.lang.String-) | 지정된 경로로 새로운 파일 데이터 소스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataType()](#getDataType--) | 데이터 소스 유형(파일). |
+| [getPath()](#getPath--) | 현재 데이터 소스의 파일 경로를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileDataSource(String path) {#FileDataSource-java.lang.String-}
+```
+public FileDataSource(String path)
+```
+
+
+지정된 경로로 새로운 파일 데이터 소스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.lang.String | 소스 파일 경로를 나타내는 문자열입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataType() {#getDataType--}
+```
+public final int getDataType()
+```
+
+
+데이터 소스 유형(파일).
+
+**Returns:**
+int
+### getPath() {#getPath--}
+```
+public final String getPath()
+```
+
+
+현재 데이터 소스의 파일 경로를 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/fileresult/_index.md
+++ b/korean/java/com.aspose.page.plugins/fileresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "FileResult"
+second_title: "Aspose.Page용 Java API 참조"
+description: "파일 경로 문자열 형태의 작업 결과를 나타냅니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.page.plugins/fileresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public final class FileResult implements IOperationResult
+```
+
+파일 경로 문자열 형태의 작업 결과를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [FileResult(String path)](#FileResult-java.lang.String-) | 지정된 출력 파일 경로를 사용하여 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 원시 데이터를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 결과가 바이트 배열인지 여부를 나타냅니다. |
+| [isFile()](#isFile--) | 결과가 출력 파일 경로인지 여부를 나타냅니다. |
+| [isStream()](#isStream--) | 결과가 출력 스트림인지 여부를 나타냅니다. |
+| [isString()](#isString--) | 결과가 텍스트 문자열인지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 결과를 파일로 변환을 시도합니다. |
+| [toStream()](#toStream--) | 결과를 스트림 객체로 변환을 시도합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FileResult(String path) {#FileResult-java.lang.String-}
+```
+public FileResult(String path)
+```
+
+
+지정된 출력 파일 경로를 사용하여 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.lang.String | 파일 경로. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+원시 데이터를 가져옵니다.
+
+**Returns:**
+java.lang.Object - 출력 데이터를 나타내는 객체.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+결과가 바이트 배열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 바이트 배열이면 true; 그렇지 않으면 false.
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+결과가 출력 파일 경로인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 파일이면 true; 그렇지 않으면 false.
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+결과가 출력 스트림인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 스트림 객체이면 true; 그렇지 않으면 false.
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+결과가 텍스트 문자열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 문자열이면 true; 그렇지 않으면 false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+결과를 파일로 변환을 시도합니다.
+
+**Returns:**
+java.lang.String - 결과가 파일인 경우 출력 파일 경로를 나타내는 문자열; 그렇지 않으면 null.
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+결과를 스트림 객체로 변환을 시도합니다.
+
+**Returns:**
+java.io.OutputStream - 결과가 스트림인 경우 출력 데이터를 나타내는 스트림 객체; 그렇지 않으면 null.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/idatacontainer/_index.md
+++ b/korean/java/com.aspose.page.plugins/idatacontainer/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IDataContainer"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구체적인 데이터 컨테이너 플러그인 옵션이 구현해야 하는 공통 메서드를 정의하는 일반 데이터 컨테이너 인터페이스입니다."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.page.plugins/idatacontainer/
+---```
+public interface IDataContainer
+```
+
+General data container interface that defines common methods that concrete data container (plugin options) should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | Adds new data source to the collection |
+| [getDataCollection()](#getDataCollection--) | Gets collection of data sources |
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public abstract void addDataSource(IDataSource dataSource)
+```
+
+
+Adds new data source to the collection
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) |  |
+
+### getDataCollection() {#getDataCollection--}
+```
+public abstract List<IDataSource> getDataCollection()
+```
+
+
+Gets collection of data sources
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>

--- a/korean/java/com.aspose.page.plugins/idatasource/_index.md
+++ b/korean/java/com.aspose.page.plugins/idatasource/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IDataSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구체적인 데이터 소스가 구현해야 하는 공통 멤버를 정의하는 일반 데이터 소스 인터페이스."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.page.plugins/idatasource/
+---```
+public interface IDataSource
+```
+
+General data source interface that defines common members that concrete data sources should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getDataType()](#getDataType--) | Type of data source (file or stream). |
+### getDataType() {#getDataType--}
+```
+public abstract int getDataType()
+```
+
+
+Type of data source (file or stream).
+
+**Returns:**
+int

--- a/korean/java/com.aspose.page.plugins/ioperationresult/_index.md
+++ b/korean/java/com.aspose.page.plugins/ioperationresult/_index.md
@@ -1,0 +1,93 @@
+---
+title: "IOperationResult"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구체적인 플러그인 작업 결과가 구현해야 하는 공통 메서드를 정의하는 일반 작업 결과 인터페이스."
+type: docs
+weight: 22
+url: /ko/java/com.aspose.page.plugins/ioperationresult/
+---```
+public interface IOperationResult
+```
+
+General operation result interface that defines common methods that concrete plugin operation result should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getData()](#getData--) | Gets raw data. |
+| [isByteArray()](#isByteArray--) | Indicates whether the result is a bytes array. |
+| [isFile()](#isFile--) | Indicates whether the result is a path to an output file. |
+| [isStream()](#isStream--) | Indicates whether the result is an output stream. |
+| [isString()](#isString--) | Indicates whether the result is a text string. |
+| [toFile()](#toFile--) | Tries to convert the result to the file. |
+| [toStream()](#toStream--) | Tries to convert the result to a stream object. |
+### getData() {#getData--}
+```
+public abstract Object getData()
+```
+
+
+Gets raw data.
+
+**Returns:**
+java.lang.Object - An object representing output data.
+### isByteArray() {#isByteArray--}
+```
+public abstract boolean isByteArray()
+```
+
+
+Indicates whether the result is a bytes array.
+
+**Returns:**
+boolean -  true  if the result is a bytes array; otherwise  false .
+### isFile() {#isFile--}
+```
+public abstract boolean isFile()
+```
+
+
+Indicates whether the result is a path to an output file.
+
+**Returns:**
+boolean - true if the result is a file; otherwise false.
+### isStream() {#isStream--}
+```
+public abstract boolean isStream()
+```
+
+
+Indicates whether the result is an output stream.
+
+**Returns:**
+boolean - true if the result is a stream object; otherwise false.
+### isString() {#isString--}
+```
+public abstract boolean isString()
+```
+
+
+Indicates whether the result is a text string.
+
+**Returns:**
+boolean - true if the result is a string; otherwise false.
+### toFile() {#toFile--}
+```
+public abstract String toFile()
+```
+
+
+Tries to convert the result to the file.
+
+**Returns:**
+java.lang.String - A string representing the path to the output file if the result is file; otherwise null.
+### toStream() {#toStream--}
+```
+public abstract OutputStream toStream()
+```
+
+
+Tries to convert the result to a stream object.
+
+**Returns:**
+java.io.OutputStream - A stream object representing the output data if the result is stream; otherwise  null .

--- a/korean/java/com.aspose.page.plugins/iplugin/_index.md
+++ b/korean/java/com.aspose.page.plugins/iplugin/_index.md
@@ -1,0 +1,32 @@
+---
+title: "IPlugin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구체적인 플러그인이 구현해야 하는 공통 메서드를 정의하는 일반 플러그인 인터페이스."
+type: docs
+weight: 23
+url: /ko/java/com.aspose.page.plugins/iplugin/
+---```
+public interface IPlugin
+```
+
+General plugin interface that defines common methods that concrete plugin should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [process(IPluginOptions options)](#process-com.aspose.page.plugins.IPluginOptions-) | Charges a plugin to process with defined options |
+### process(IPluginOptions options) {#process-com.aspose.page.plugins.IPluginOptions-}
+```
+public abstract ResultContainer process(IPluginOptions options)
+```
+
+
+Charges a plugin to process with defined options
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| options | [IPluginOptions](../../com.aspose.page.plugins/ipluginoptions) | An options object containing instructions for the plugin |
+
+**Returns:**
+[ResultContainer](../../com.aspose.page.plugins/resultcontainer) - An ResultContainer object containing the result of the processing

--- a/korean/java/com.aspose.page.plugins/ipluginoptions/_index.md
+++ b/korean/java/com.aspose.page.plugins/ipluginoptions/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IPluginOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구체적인 플러그인 옵션이 구현해야 하는 공통 메서드를 정의하는 일반 플러그인 옵션 인터페이스."
+type: docs
+weight: 24
+url: /ko/java/com.aspose.page.plugins/ipluginoptions/
+---```
+public interface IPluginOptions
+```
+
+General plugin option interface that defines common methods that concrete plugin option should implement.

--- a/korean/java/com.aspose.page.plugins/isaveinstruction/_index.md
+++ b/korean/java/com.aspose.page.plugins/isaveinstruction/_index.md
@@ -1,0 +1,41 @@
+---
+title: "ISaveInstruction"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구체적인 플러그인 옵션이 구현해야 하는 공통 멤버를 정의하는 일반 저장 지시 인터페이스."
+type: docs
+weight: 25
+url: /ko/java/com.aspose.page.plugins/isaveinstruction/
+---```
+public interface ISaveInstruction
+```
+
+General save instruction interface that defines common members that concrete plugin option should implement.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | Adds new result save target |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | Gets the collection of added targets (file or stream data sources) for saving operation results. |
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public abstract void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+Adds new result save target
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | Target (file or stream data source) for saving operation results. |
+
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public abstract List<IDataSource> getSaveTargetsCollection()
+```
+
+
+Gets the collection of added targets (file or stream data sources) for saving operation results.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>

--- a/korean/java/com.aspose.page.plugins/plugin/_index.md
+++ b/korean/java/com.aspose.page.plugins/plugin/_index.md
@@ -1,0 +1,253 @@
+---
+title: "Plugin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "가능한 플러그인을 나타냅니다."
+type: docs
+weight: 26
+url: /ko/java/com.aspose.page.plugins/plugin/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum Plugin extends Enum<Plugin>
+```
+
+가능한 플러그인을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) |  |
+| [PsConverter](#PsConverter) |  |
+| [XpsConverter](#XpsConverter) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final Plugin None
+```
+
+
+### PsConverter {#PsConverter}
+```
+public static final Plugin PsConverter
+```
+
+
+### XpsConverter {#XpsConverter}
+```
+public static final Plugin XpsConverter
+```
+
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static Plugin valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[Plugin](../../com.aspose.page.plugins/plugin)
+### values() {#values--}
+```
+public static Plugin[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.plugins.Plugin[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/pluginexceptionmessages/_index.md
+++ b/korean/java/com.aspose.page.plugins/pluginexceptionmessages/_index.md
@@ -1,0 +1,174 @@
+---
+title: "PluginExceptionMessages"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 플러그인에서 발생한 예외에 사용되는 메시지 저장소를 나타냅니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.page.plugins/pluginexceptionmessages/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class PluginExceptionMessages
+```
+
+이 클래스는 플러그인에서 발생한 예외에 사용되는 메시지 저장소를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PluginExceptionMessages()](#PluginExceptionMessages--) |  |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [MustNotBeNull](#MustNotBeNull) |  |
+| [UnsupportedDataType](#UnsupportedDataType) |  |
+| [UnsupportedOutputDataType](#UnsupportedOutputDataType) |  |
+| [WrongOptionTypePsConverter](#WrongOptionTypePsConverter) |  |
+| [WrongOptionTypeXpsConverter](#WrongOptionTypeXpsConverter) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PluginExceptionMessages() {#PluginExceptionMessages--}
+```
+public PluginExceptionMessages()
+```
+
+
+### MustNotBeNull {#MustNotBeNull}
+```
+public static final String MustNotBeNull
+```
+
+
+### UnsupportedDataType {#UnsupportedDataType}
+```
+public static final String UnsupportedDataType
+```
+
+
+### UnsupportedOutputDataType {#UnsupportedOutputDataType}
+```
+public static final String UnsupportedOutputDataType
+```
+
+
+### WrongOptionTypePsConverter {#WrongOptionTypePsConverter}
+```
+public static final String WrongOptionTypePsConverter
+```
+
+
+### WrongOptionTypeXpsConverter {#WrongOptionTypeXpsConverter}
+```
+public static final String WrongOptionTypeXpsConverter
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/resultcontainer/_index.md
+++ b/korean/java/com.aspose.page.plugins/resultcontainer/_index.md
@@ -1,0 +1,148 @@
+---
+title: "ResultContainer"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인 처리 결과 컬렉션을 포함하는 컨테이너를 나타냅니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.page.plugins/resultcontainer/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class ResultContainer
+```
+
+플러그인 처리 결과 컬렉션을 포함하는 컨테이너를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ResultContainer()](#ResultContainer--) | 새 결과 컨테이너를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getResultCollection()](#getResultCollection--) | 작업 결과 컬렉션을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ResultContainer() {#ResultContainer--}
+```
+public ResultContainer()
+```
+
+
+새 결과 컨테이너를 초기화합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getResultCollection() {#getResultCollection--}
+```
+public final List<IOperationResult> getResultCollection()
+```
+
+
+작업 결과 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IOperationResult>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/streamdatasource/_index.md
+++ b/korean/java/com.aspose.page.plugins/streamdatasource/_index.md
@@ -1,0 +1,189 @@
+---
+title: "StreamDataSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인의 로드 및 저장 작업을 위한 스트림 데이터 소스를 나타냅니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.page.plugins/streamdatasource/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IDataSource](../../com.aspose.page.plugins/idatasource)
+```
+public final class StreamDataSource implements IDataSource
+```
+
+플러그인의 로드 및 저장 작업을 위한 스트림 데이터 소스를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StreamDataSource(Object data)](#StreamDataSource-java.lang.Object-) | 지정된 스트림 객체를 사용하여 새로운 스트림 데이터 소스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 현재 데이터 소스의 스트림 객체를 가져옵니다. |
+| [getDataType()](#getDataType--) | 데이터 소스 유형(스트림). |
+| [getInputStream()](#getInputStream--) |  |
+| [getOutputStream()](#getOutputStream--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamDataSource(Object data) {#StreamDataSource-java.lang.Object-}
+```
+public StreamDataSource(Object data)
+```
+
+
+지정된 스트림 객체를 사용하여 새로운 스트림 데이터 소스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 데이터 | java.lang.Object | 스트림 객체 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+현재 데이터 소스의 스트림 객체를 가져옵니다.
+
+**Returns:**
+java.lang.Object
+### getDataType() {#getDataType--}
+```
+public final int getDataType()
+```
+
+
+데이터 소스 유형(스트림).
+
+**Returns:**
+int
+### getInputStream() {#getInputStream--}
+```
+public final InputStream getInputStream()
+```
+
+
+
+
+**Returns:**
+java.io.InputStream
+### getOutputStream() {#getOutputStream--}
+```
+public final OutputStream getOutputStream()
+```
+
+
+
+
+**Returns:**
+java.io.OutputStream
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/streamresult/_index.md
+++ b/korean/java/com.aspose.page.plugins/streamresult/_index.md
@@ -1,0 +1,222 @@
+---
+title: "StreamResult"
+second_title: "Aspose.Page용 Java API 참조"
+description: "스트림 형태의 작업 결과를 나타냅니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.page.plugins/streamresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public final class StreamResult implements IOperationResult
+```
+
+스트림 형태의 작업 결과를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StreamResult(OutputStream stream)](#StreamResult-java.io.OutputStream-) | 지정된 스트림 객체를 사용하여 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 원시 데이터를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 결과가 바이트 배열인지 여부를 나타냅니다. |
+| [isFile()](#isFile--) | 결과가 출력 파일 경로인지 여부를 나타냅니다. |
+| [isStream()](#isStream--) | 결과가 출력 파일 경로인지 여부를 나타냅니다. |
+| [isString()](#isString--) | 결과가 문자열인지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 결과를 파일로 변환을 시도합니다. |
+| [toStream()](#toStream--) | 결과를 스트림 객체로 변환을 시도합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StreamResult(OutputStream stream) {#StreamResult-java.io.OutputStream-}
+```
+public StreamResult(OutputStream stream)
+```
+
+
+지정된 스트림 객체를 사용하여 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 스트림 객체 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+원시 데이터를 가져옵니다.
+
+**Returns:**
+java.lang.Object - 출력 데이터를 나타내는 객체.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+결과가 바이트 배열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 바이트 배열이면 true; 그렇지 않으면 false.
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+결과가 출력 파일 경로인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 파일이면 true; 그렇지 않으면 false.
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+결과가 출력 파일 경로인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 스트림 객체이면 true; 그렇지 않으면 false.
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+결과가 문자열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 문자열이면 true; 그렇지 않으면 false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+결과를 파일로 변환을 시도합니다.
+
+**Returns:**
+java.lang.String - 결과가 파일인 경우 출력 파일 경로를 나타내는 문자열; 그렇지 않으면 null.
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+결과를 스트림 객체로 변환을 시도합니다.
+
+**Returns:**
+java.io.OutputStream - 결과가 스트림인 경우 출력 데이터를 나타내는 스트림 객체; 그렇지 않으면 null.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page.plugins/stringresult/_index.md
+++ b/korean/java/com.aspose.page.plugins/stringresult/_index.md
@@ -1,0 +1,233 @@
+---
+title: "StringResult"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문자열 형태의 작업 결과를 나타냅니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.page.plugins/stringresult/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IOperationResult](../../com.aspose.page.plugins/ioperationresult)
+```
+public final class StringResult implements IOperationResult
+```
+
+문자열 형태의 작업 결과를 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StringResult(String result)](#StringResult-java.lang.String-) | 문자열을 사용하여 새 StringResult 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getData()](#getData--) | 원시 데이터를 가져옵니다. |
+| [getText()](#getText--) | 결과의 문자열 표현을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isByteArray()](#isByteArray--) | 결과가 바이트 배열인지 여부를 나타냅니다. |
+| [isFile()](#isFile--) | 결과가 출력 파일 경로인지 여부를 나타냅니다. |
+| [isStream()](#isStream--) | 결과가 출력 파일 경로인지 여부를 나타냅니다. |
+| [isString()](#isString--) | 결과가 문자열인지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toFile()](#toFile--) | 결과를 파일로 변환을 시도합니다. |
+| [toStream()](#toStream--) | 결과를 스트림 객체로 변환을 시도합니다. |
+| [toString()](#toString--) | 결과를 문자열로 변환하려 시도합니다. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringResult(String result) {#StringResult-java.lang.String-}
+```
+public StringResult(String result)
+```
+
+
+문자열을 사용하여 새 StringResult 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 결과 | java.lang.String | 결과를 나타내는 문자열 |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getData() {#getData--}
+```
+public final Object getData()
+```
+
+
+원시 데이터를 가져옵니다.
+
+**Returns:**
+java.lang.Object - 출력 데이터를 나타내는 객체.
+### getText() {#getText--}
+```
+public final String getText()
+```
+
+
+결과의 문자열 표현을 반환합니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isByteArray() {#isByteArray--}
+```
+public final boolean isByteArray()
+```
+
+
+결과가 바이트 배열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 바이트 배열이면 true; 그렇지 않으면 false.
+### isFile() {#isFile--}
+```
+public final boolean isFile()
+```
+
+
+결과가 출력 파일 경로인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 파일이면 true; 그렇지 않으면 false.
+### isStream() {#isStream--}
+```
+public final boolean isStream()
+```
+
+
+결과가 출력 파일 경로인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 스트림 객체이면 true; 그렇지 않으면 false.
+### isString() {#isString--}
+```
+public final boolean isString()
+```
+
+
+결과가 문자열인지 여부를 나타냅니다.
+
+**Returns:**
+boolean - 결과가 문자열이면 true; 그렇지 않으면 false.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toFile() {#toFile--}
+```
+public final String toFile()
+```
+
+
+결과를 파일로 변환을 시도합니다.
+
+**Returns:**
+java.lang.String - 결과가 파일인 경우 출력 파일 경로를 나타내는 문자열; 그렇지 않으면 null.
+### toStream() {#toStream--}
+```
+public final OutputStream toStream()
+```
+
+
+결과를 스트림 객체로 변환을 시도합니다.
+
+**Returns:**
+java.io.OutputStream - 결과가 스트림인 경우 출력 데이터를 나타내는 스트림 객체; 그렇지 않으면 null.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+결과를 문자열로 변환하려 시도합니다.
+
+**Returns:**
+java.lang.String - 결과가 문자열인 경우 텍스트 내용을 나타내는 문자열이며, 그렇지 않으면 base.ToString()을 반환합니다.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/_index.md
+++ b/korean/java/com.aspose.page/_index.md
@@ -1,0 +1,42 @@
+---
+title: "com.aspose.page"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Aspose.Page는 Device와 같이 직접 포함되거나 여러 하위 패키지를 통해 간접적으로 포함되는 Aspose.Page 라이브러리의 모든 클래스에 대한 루트 패키지입니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.page/
+---
+
+**Aspose.Page**는 **Device**와 같이 직접 포함되거나 여러 하위 패키지를 통해 간접적으로 포함되는 Aspose.Page 라이브러리의 모든 클래스에 대한 루트 패키지입니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [AsposePageException](../com.aspose.page/asposepageexception) | Aspose.Page 애플리케이션 실행 중 발생하는 오류를 나타냅니다. |
+| [DimensionF](../com.aspose.page/dimensionf) | `Dimension` 클래스는 구성 요소의 너비와 높이(단일 정밀도)를 하나의 객체에 캡슐화합니다. |
+| [Document](../com.aspose.page/document) | 캡슐화된 모든 문서의 슈퍼클래스입니다. |
+| [ExternalFontCache](../com.aspose.page/externalfontcache) | 이 클래스를 사용하여 Device가 허용하는 형태로 폰트 캡슐화를 얻을 수 있습니다. |
+| [License](../com.aspose.page/license) | 구성 요소에 대한 라이선스 부여 메서드를 제공합니다. |
+| [Metered](../com.aspose.page/metered) | 계량 키를 설정하는 메서드를 제공합니다. |
+| [SaveOptions](../com.aspose.page/saveoptions) | 이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다. |
+| [TransformedStroke](../com.aspose.page/transformedstroke) | 변환을 포함하는 스트로크입니다. |
+| [UserProperties](../com.aspose.page/userproperties) | 형식이 지정된 속성을 설정하고 반환할 수 있는 특수 속성 클래스입니다. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IGlyph](../com.aspose.page/iglyph) | 이 인터페이스는 글리프의 주요 매개변수에 접근할 수 있게 합니다. |
+| [IInteractiveDevice](../com.aspose.page/iinteractivedevice) | 인터랙티브 기능 처리 메서드를 정의하는 인터페이스입니다. |
+| [IMultiPageSaveOptions](../com.aspose.page/imultipagesaveoptions) | 변환을 위한 페이지 번호 설정 인터페이스를 정의합니다. |
+| [ITrFont](../com.aspose.page/itrfont) | 이 인터페이스는 폰트의 주요 매개변수에 접근할 수 있게 합니다. |
+
+## 열거형
+
+| 열거형 | 설명 |
+| --- | --- |
+| [ImageFormat](../com.aspose.page/imageformat) | 이 열거형은 PS/EPS를 이미지로 변환할 때 지원되는 이미지 형식의 가능한 이름을 포함합니다. |
+| [TextRenderingMode](../com.aspose.page/textrenderingmode) | 이 열거형은 텍스트 렌더링 모드에 대한 가능한 값을 포함합니다. |
+| [Units](../com.aspose.page/units) | 이 열거형은 크기 단위에 대한 가능한 값을 포함합니다. |

--- a/korean/java/com.aspose.page/asposepageexception/_index.md
+++ b/korean/java/com.aspose.page/asposepageexception/_index.md
@@ -1,0 +1,271 @@
+---
+title: "AsposePageException"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Aspose.Page 애플리케이션 실행 중 발생하는 오류를 나타냅니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.page/asposepageexception/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Throwable, java.lang.Exception, java.lang.RuntimeException
+```
+public class AsposePageException extends RuntimeException
+```
+
+Aspose.Page 애플리케이션 실행 중 발생하는 오류를 나타냅니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addSuppressed(Throwable arg0)](#addSuppressed-java.lang.Throwable-) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fillInStackTrace()](#fillInStackTrace--) |  |
+| [getCause()](#getCause--) |  |
+| [getClass()](#getClass--) |  |
+| [getLocalizedMessage()](#getLocalizedMessage--) |  |
+| [getMessage()](#getMessage--) |  |
+| [getStackTrace()](#getStackTrace--) |  |
+| [getSuppressed()](#getSuppressed--) |  |
+| [hashCode()](#hashCode--) |  |
+| [initCause(Throwable arg0)](#initCause-java.lang.Throwable-) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printStackTrace()](#printStackTrace--) |  |
+| [printStackTrace(PrintStream arg0)](#printStackTrace-java.io.PrintStream-) |  |
+| [printStackTrace(PrintWriter arg0)](#printStackTrace-java.io.PrintWriter-) |  |
+| [setStackTrace(StackTraceElement[] arg0)](#setStackTrace-java.lang.StackTraceElement---) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addSuppressed(Throwable arg0) {#addSuppressed-java.lang.Throwable-}
+```
+public final synchronized void addSuppressed(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fillInStackTrace() {#fillInStackTrace--}
+```
+public synchronized Throwable fillInStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getCause() {#getCause--}
+```
+public synchronized Throwable getCause()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getLocalizedMessage() {#getLocalizedMessage--}
+```
+public String getLocalizedMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getMessage() {#getMessage--}
+```
+public String getMessage()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### getStackTrace() {#getStackTrace--}
+```
+public StackTraceElement[] getStackTrace()
+```
+
+
+
+
+**Returns:**
+java.lang.StackTraceElement[]
+### getSuppressed() {#getSuppressed--}
+```
+public final synchronized Throwable[] getSuppressed()
+```
+
+
+
+
+**Returns:**
+java.lang.Throwable[]
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### initCause(Throwable arg0) {#initCause-java.lang.Throwable-}
+```
+public synchronized Throwable initCause(Throwable arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Throwable |  |
+
+**Returns:**
+java.lang.Throwable
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printStackTrace() {#printStackTrace--}
+```
+public void printStackTrace()
+```
+
+
+
+
+### printStackTrace(PrintStream arg0) {#printStackTrace-java.io.PrintStream-}
+```
+public void printStackTrace(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### printStackTrace(PrintWriter arg0) {#printStackTrace-java.io.PrintWriter-}
+```
+public void printStackTrace(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### setStackTrace(StackTraceElement[] arg0) {#setStackTrace-java.lang.StackTraceElement---}
+```
+public void setStackTrace(StackTraceElement[] arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.StackTraceElement[] |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/dimensionf/_index.md
+++ b/korean/java/com.aspose.page/dimensionf/_index.md
@@ -1,0 +1,295 @@
+---
+title: "DimensionF"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Dimension 클래스는 구성 요소의 너비와 높이를 단일 정밀도(single precision)로 하나의 객체에 캡슐화합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.page/dimensionf/
+---
+**Inheritance:**
+java.lang.Object, java.awt.geom.Dimension2D
+
+**All Implemented Interfaces:**
+java.io.Serializable
+```
+public class DimensionF extends Dimension2D implements Serializable
+```
+
+`Dimension` 클래스는 구성 요소의 너비와 높이(단일 정밀도)를 하나의 객체에 캡슐화합니다.
+
+보통 `width`와 `height` 값은 음수가 아닌 정수입니다. 차원을 생성할 수 있는 생성자는 이러한 속성에 음수 값을 설정하는 것을 방지하지 않습니다. `width` 또는 `height` 값이 음수인 경우, 다른 객체에 의해 정의된 일부 메서드의 동작은 정의되지 않습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DimensionF()](#DimensionF--) | 너비와 높이가 0인 `Dimension` 인스턴스를 생성합니다. |
+| [DimensionF(DimensionF d)](#DimensionF-com.aspose.page.DimensionF-) | 지정된 차원과 동일한 너비와 높이를 갖는 `Dimension` 인스턴스를 생성합니다. |
+| [DimensionF(float width, float height)](#DimensionF-float-float-) | `Dimension`을 생성하고 지정된 너비와 높이로 초기화합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [height](#height) | 높이 차원; 음수 값을 사용할 수 있습니다. |
+| [width](#width) | 너비 차원; 음수 값을 사용할 수 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(Object obj)](#equals-java.lang.Object-) | 두 차원 객체가 동일한 값을 갖는지 확인합니다. |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | \{@inheritDoc\} |
+| [getSize()](#getSize--) | 이 `Dimension` 객체의 크기를 가져옵니다. |
+| [getWidth()](#getWidth--) | \{@inheritDoc\} |
+| [hashCode()](#hashCode--) | 이 `Dimension`의 해시 코드를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(DimensionF d)](#setSize-com.aspose.page.DimensionF-) | 이 `Dimension` 객체의 크기를 지정된 크기로 설정합니다. |
+| [setSize(double width, double height)](#setSize-double-double-) | 이 `Dimension` 객체의 크기를 이중 정밀도로 지정된 너비와 높이로 설정합니다. |
+| [setSize(float width, float height)](#setSize-float-float-) | 이 `Dimension` 객체의 크기를 지정된 너비와 높이로 설정합니다. |
+| [setSize(Dimension2D arg0)](#setSize-java.awt.geom.Dimension2D-) |  |
+| [toString()](#toString--) | 이 `Dimension` 객체의 `height`와 `width` 필드 값을 문자열 형태로 반환합니다. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DimensionF() {#DimensionF--}
+```
+public DimensionF()
+```
+
+
+너비와 높이가 0인 `Dimension` 인스턴스를 생성합니다.
+
+### DimensionF(DimensionF d) {#DimensionF-com.aspose.page.DimensionF-}
+```
+public DimensionF(DimensionF d)
+```
+
+
+지정된 차원과 동일한 너비와 높이를 갖는 `Dimension` 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| d | [DimensionF](../../com.aspose.page/dimensionf) | `width`와 `height` 값에 대한 지정된 차원 |
+
+### DimensionF(float width, float height) {#DimensionF-float-float-}
+```
+public DimensionF(float width, float height)
+```
+
+
+`Dimension`을 생성하고 지정된 너비와 높이로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 지정된 너비 |
+| 높이 | float | 지정된 높이 |
+
+### height {#height}
+```
+public float height
+```
+
+
+높이 차원; 음수 값을 사용할 수 있습니다.
+
+### width {#width}
+```
+public float width
+```
+
+
+너비 차원; 음수 값을 사용할 수 있습니다.
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+두 차원 객체가 동일한 값을 갖는지 확인합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getSize() {#getSize--}
+```
+public DimensionF getSize()
+```
+
+
+이 `Dimension` 객체의 크기를 가져옵니다. 이 메서드는 완전성을 위해 포함되었으며, `Component`에 정의된 `getSize` 메서드와 일치합니다.
+
+**Returns:**
+[DimensionF](../../com.aspose.page/dimensionf) - the size of this dimension, a new instance of `Dimension` with the same width and height
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+이 `Dimension`의 해시 코드를 반환합니다.
+
+**Returns:**
+int - 이 `Dimension`에 대한 해시 코드
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(DimensionF d) {#setSize-com.aspose.page.DimensionF-}
+```
+public void setSize(DimensionF d)
+```
+
+
+이 `Dimension` 객체의 크기를 지정된 크기로 설정합니다. 이 메서드는 완전성을 위해 포함되었으며, `Component`에 정의된 `setSize` 메서드와 일치합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| d | [DimensionF](../../com.aspose.page/dimensionf) | 이 `Dimension` 객체의 새로운 크기 |
+
+### setSize(double width, double height) {#setSize-double-double-}
+```
+public void setSize(double width, double height)
+```
+
+
+이 `Dimension` 객체의 크기를 지정된 너비와 높이(두 배 정밀도)로 설정합니다. `width` 또는 `height`가 `Integer.MAX_VALUE`보다 큰 경우 `Integer.MAX_VALUE`로 재설정됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | double | `Dimension` 객체의 새로운 너비 |
+| 높이 | double | `Dimension` 객체의 새로운 높이 |
+
+### setSize(float width, float height) {#setSize-float-float-}
+```
+public void setSize(float width, float height)
+```
+
+
+이 `Dimension` 객체의 크기를 지정된 너비와 높이로 설정합니다. 이 메서드는 완전성을 위해 포함되었으며, `Component`에 정의된 `setSize` 메서드와 일치합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 이 `Dimension` 객체의 새로운 너비 |
+| 높이 | float | 이 `Dimension` 객체의 새로운 높이 |
+
+### setSize(Dimension2D arg0) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.awt.geom.Dimension2D |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+이 `Dimension` 객체의 `height` 및 `width` 필드 값을 문자열로 반환합니다. 이 메서드는 디버깅 목적으로만 사용하도록 설계되었으며, 반환되는 문자열의 내용과 형식은 구현마다 다를 수 있습니다. 반환된 문자열은 비어 있을 수 있지만 `null`은 될 수 없습니다.
+
+**Returns:**
+java.lang.String - 이 `Dimension` 객체의 문자열 표현
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/document/_index.md
+++ b/korean/java/com.aspose.page/document/_index.md
@@ -1,0 +1,161 @@
+---
+title: "문서"
+second_title: "Aspose.Page용 Java API 참조"
+description: "캡슐화된 모든 문서의 슈퍼클래스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.page/document/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class Document
+```
+
+캡슐화된 모든 문서의 슈퍼클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Document()](#Document--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isLicensed()](#isLicensed--) | Aspose.Page for Java 제품 라이선스에 접근했는지 및 유효한지 여부를 나타냅니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [save(Device device, SaveOptions options)](#save-com.aspose.page.Device-com.aspose.page.SaveOptions-) | 이 문서를 장치에 저장합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Document() {#Document--}
+```
+public Document()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isLicensed() {#isLicensed--}
+```
+public boolean isLicensed()
+```
+
+
+Aspose.Page for Java 제품 라이선스에 접근했는지 및 유효한지 여부를 나타냅니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### save(Device device, SaveOptions options) {#save-com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public abstract void save(Device device, SaveOptions options)
+```
+
+
+이 문서를 장치에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| device | [Device](../../com.aspose.page/device) | 출력 장치. |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 옵션. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/externalfontcache/_index.md
+++ b/korean/java/com.aspose.page/externalfontcache/_index.md
@@ -1,0 +1,298 @@
+---
+title: "ExternalFontCache"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스를 사용하여 Device가 허용하는 형태로 폰트 캡슐화를 얻을 수 있습니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.page/externalfontcache/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class ExternalFontCache
+```
+
+이 클래스를 사용하여 Device가 허용하는 형태로 폰트 캡슐화를 얻을 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ExternalFontCache()](#ExternalFontCache--) |  |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [DEFAULT_SIZE](#DEFAULT-SIZE) | 기본 글꼴 크기. |
+| [DEFAULT_STYLE](#DEFAULT-STYLE) | 기본 글꼴 스타일. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [FetchTrFont(String familyName)](#FetchTrFont-java.lang.String-) | DrFont을 글꼴 패밀리 이름, 기본 크기 (1) 및 기본 스타일 (PLAIN)으로 가져옵니다. |
+| [FetchTrFont(String familyName, int style)](#FetchTrFont-java.lang.String-int-) | DrFont을 글꼴 패밀리 이름, 기본 크기 (1) 및 스타일로 가져옵니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [fetchDrFont(String familyName, float sizePoints, int style)](#fetchDrFont-java.lang.String-float-int-) | DrFont을 글꼴 패밀리 이름, 크기 및 스타일로 가져옵니다. |
+| [fetchDrFont(String familyName, float sizePoints, int style, int fontCapitals)](#fetchDrFont-java.lang.String-float-int-int-) | DrFont을 글꼴 패밀리 이름, 크기, 스타일 및 대문자 형태로 가져옵니다. |
+| [fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName)](#fetchDrFont-java.lang.String-float-int-java.lang.String-) | DrFont을 글꼴 패밀리 이름, 크기, 스타일 및 대체 글꼴 패밀리 이름으로 가져옵니다. |
+| [fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName, int fontCapitals)](#fetchDrFont-java.lang.String-float-int-java.lang.String-int-) | DrFont을 글꼴 패밀리 이름, 크기, 스타일, 대문자 형태 및 대체 글꼴 패밀리 이름으로 가져옵니다. |
+| [fetchTTFont(String familyName, int style, String altFamilyName)](#fetchTTFont-java.lang.String-int-java.lang.String-) | TTFont을 글꼴 패밀리 이름, 스타일 및 대체 글꼴 패밀리 이름으로 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] additionalFontFolders)](#setAdditionalFontsFolders-java.lang.String---) | 추가 폰트 폴더를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ExternalFontCache() {#ExternalFontCache--}
+```
+public ExternalFontCache()
+```
+
+
+### DEFAULT_SIZE {#DEFAULT-SIZE}
+```
+public static final float DEFAULT_SIZE
+```
+
+
+기본 글꼴 크기.
+
+### DEFAULT_STYLE {#DEFAULT-STYLE}
+```
+public static final int DEFAULT_STYLE
+```
+
+
+기본 글꼴 스타일.
+
+### FetchTrFont(String familyName) {#FetchTrFont-java.lang.String-}
+```
+public DrFont FetchTrFont(String familyName)
+```
+
+
+DrFont을 글꼴 패밀리 이름, 기본 크기 (1) 및 기본 스타일 (PLAIN)으로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### FetchTrFont(String familyName, int style) {#FetchTrFont-java.lang.String-int-}
+```
+public DrFont FetchTrFont(String familyName, int style)
+```
+
+
+DrFont을 글꼴 패밀리 이름, 기본 크기 (1) 및 스타일로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+| 스타일 | int | 글꼴 스타일. |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### fetchDrFont(String familyName, float sizePoints, int style) {#fetchDrFont-java.lang.String-float-int-}
+```
+public static DrFont fetchDrFont(String familyName, float sizePoints, int style)
+```
+
+
+DrFont을 글꼴 패밀리 이름, 크기 및 스타일로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+| sizePoints | float | 포인트 단위의 글꼴 크기(1포인트는 인치의 1/72입니다). |
+| 스타일 | int | 글꼴 스타일. |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### fetchDrFont(String familyName, float sizePoints, int style, int fontCapitals) {#fetchDrFont-java.lang.String-float-int-int-}
+```
+public DrFont fetchDrFont(String familyName, float sizePoints, int style, int fontCapitals)
+```
+
+
+DrFont을 글꼴 패밀리 이름, 크기, 스타일 및 대문자 형태로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+| sizePoints | float | 포인트 단위의 글꼴 크기(1포인트는 인치의 1/72입니다). |
+| 스타일 | int | 글꼴 스타일. |
+| fontCapitals | int | 글꼴 대문자. |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName) {#fetchDrFont-java.lang.String-float-int-java.lang.String-}
+```
+public DrFont fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName)
+```
+
+
+DrFont을 글꼴 패밀리 이름, 크기, 스타일 및 대체 글꼴 패밀리 이름으로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+| sizePoints | float | 포인트 단위의 글꼴 크기(1포인트는 인치의 1/72입니다). |
+| 스타일 | int | 글꼴 스타일. |
+| altFamilyName | java.lang.String | 대체 글꼴 패밀리 이름. |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName, int fontCapitals) {#fetchDrFont-java.lang.String-float-int-java.lang.String-int-}
+```
+public DrFont fetchDrFont(String familyName, float sizePoints, int style, String altFamilyName, int fontCapitals)
+```
+
+
+DrFont을 글꼴 패밀리 이름, 크기, 스타일, 대문자 형태 및 대체 글꼴 패밀리 이름으로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+| sizePoints | float | 포인트 단위의 글꼴 크기(1포인트는 인치의 1/72입니다). |
+| 스타일 | int | 글꼴 스타일. |
+| altFamilyName | java.lang.String | 대체 글꼴 패밀리 이름. |
+| fontCapitals | int | 글꼴 대문자. |
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### fetchTTFont(String familyName, int style, String altFamilyName) {#fetchTTFont-java.lang.String-int-java.lang.String-}
+```
+public TTFont fetchTTFont(String familyName, int style, String altFamilyName)
+```
+
+
+TTFont을 글꼴 패밀리 이름, 스타일 및 대체 글꼴 패밀리 이름으로 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| familyName | java.lang.String | 글꼴 패밀리 이름. |
+| 스타일 | int | 글꼴 스타일. |
+| altFamilyName | java.lang.String | 대체 글꼴 패밀리 이름. |
+
+**Returns:**
+com.aspose.foundation.truetype.TTFont - TTFont.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] additionalFontFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public static void setAdditionalFontsFolders(String[] additionalFontFolders)
+```
+
+
+추가 글꼴 폴더를 지정합니다. 운영 체제에서 사용하는 글꼴 폴더는 기본적으로 ExternalFont 캐시에서 사용됩니다. 이를 정의할 필요가 없습니다,
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| additionalFontFolders | java.lang.String[] | 추가 글꼴 폴더의 배열입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/iglyph/_index.md
+++ b/korean/java/com.aspose.page/iglyph/_index.md
@@ -1,0 +1,71 @@
+---
+title: "IGlyph"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 인터페이스는 글리프의 주요 매개변수에 접근할 수 있게 합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.page/iglyph/
+---```
+public interface IGlyph
+```
+
+This interface give access to main parameters of glyph.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getAdvanceWidth()](#getAdvanceWidth--) | Gets advanced width of the glyph. |
+| [getCharCode()](#getCharCode--) | Gets char code of the glyph. |
+| [getCharName()](#getCharName--) | Gets character name. |
+| [getGlyphVector()](#getGlyphVector--) | Gets glyphs vectors. |
+| [getLeftSideBearing()](#getLeftSideBearing--) | Gets left side bearing of the glyph. |
+### getAdvanceWidth() {#getAdvanceWidth--}
+```
+public abstract float getAdvanceWidth()
+```
+
+
+Gets advanced width of the glyph.
+
+**Returns:**
+float - Advanced width.
+### getCharCode() {#getCharCode--}
+```
+public abstract char getCharCode()
+```
+
+
+Gets char code of the glyph.
+
+**Returns:**
+char - A char code.
+### getCharName() {#getCharName--}
+```
+public abstract String getCharName()
+```
+
+
+Gets character name.
+
+**Returns:**
+java.lang.String - Character name
+### getGlyphVector() {#getGlyphVector--}
+```
+public abstract GlyphVector getGlyphVector()
+```
+
+
+Gets glyphs vectors.
+
+**Returns:**
+java.awt.font.GlyphVector - Glyphs vectors.
+### getLeftSideBearing() {#getLeftSideBearing--}
+```
+public abstract float getLeftSideBearing()
+```
+
+
+Gets left side bearing of the glyph.
+
+**Returns:**
+float - Left side bearing of the glyph.

--- a/korean/java/com.aspose.page/iinteractivedevice/_index.md
+++ b/korean/java/com.aspose.page/iinteractivedevice/_index.md
@@ -1,0 +1,75 @@
+---
+title: "IInteractiveDevice"
+second_title: "Aspose.Page용 Java API 참조"
+description: "인터랙티브 기능 처리 메서드를 정의하는 인터페이스입니다."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.page/iinteractivedevice/
+---```
+public interface IInteractiveDevice
+```
+
+The interface defining interactive features processing methods.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [addOutline(int outlineLevel, String description)](#addOutline-int-java.lang.String-) | Adds an outline item with the last object as its target. |
+| [addOutline(Point2D origin, int outlineLevel, String description)](#addOutline-java.awt.geom.Point2D-int-java.lang.String-) | Adds an outline item with the origin point as its target. |
+| [setHyperlinkTarget(int targetPageNumber)](#setHyperlinkTarget-int-) | Set the hyperlink with a page number as its target. |
+| [setHyperlinkTarget(String targetUri)](#setHyperlinkTarget-java.lang.String-) | Set the hyperlink with an external URI as its target. |
+### addOutline(int outlineLevel, String description) {#addOutline-int-java.lang.String-}
+```
+public abstract void addOutline(int outlineLevel, String description)
+```
+
+
+Adds an outline item with the last object as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| outlineLevel | int | The outline level. |
+| description | java.lang.String | The item description. |
+
+### addOutline(Point2D origin, int outlineLevel, String description) {#addOutline-java.awt.geom.Point2D-int-java.lang.String-}
+```
+public abstract void addOutline(Point2D origin, int outlineLevel, String description)
+```
+
+
+Adds an outline item with the origin point as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| origin | java.awt.geom.Point2D | The target origin. |
+| outlineLevel | int | The outline level. |
+| description | java.lang.String | The item description. |
+
+### setHyperlinkTarget(int targetPageNumber) {#setHyperlinkTarget-int-}
+```
+public abstract void setHyperlinkTarget(int targetPageNumber)
+```
+
+
+Set the hyperlink with a page number as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| targetPageNumber | int | The target page number. |
+
+### setHyperlinkTarget(String targetUri) {#setHyperlinkTarget-java.lang.String-}
+```
+public abstract void setHyperlinkTarget(String targetUri)
+```
+
+
+Set the hyperlink with an external URI as its target.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| targetUri | java.lang.String | The target external URI. |
+

--- a/korean/java/com.aspose.page/imageformat/_index.md
+++ b/korean/java/com.aspose.page/imageformat/_index.md
@@ -1,0 +1,277 @@
+---
+title: "ImageFormat"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 열거형은 PS/EPS를 이미지로 변환할 때 지원되는 이미지 형식의 가능한 이름을 포함합니다."
+type: docs
+weight: 23
+url: /ko/java/com.aspose.page/imageformat/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum ImageFormat extends Enum<ImageFormat>
+```
+
+이 열거형은 PS/EPS를 이미지로 변환할 때 지원되는 이미지 형식의 가능한 이름을 포함합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BMP](#BMP) | BMP 이미지 형식. |
+| [GIF](#GIF) | GIF 이미지 형식. |
+| [JPEG](#JPEG) | JPEG 이미지 형식. |
+| [PNG](#PNG) | PNG 이미지 형식. |
+| [TIFF](#TIFF) | TIFF 이미지 형식. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BMP {#BMP}
+```
+public static final ImageFormat BMP
+```
+
+
+BMP 이미지 형식.
+
+### GIF {#GIF}
+```
+public static final ImageFormat GIF
+```
+
+
+GIF 이미지 형식.
+
+### JPEG {#JPEG}
+```
+public static final ImageFormat JPEG
+```
+
+
+JPEG 이미지 형식.
+
+### PNG {#PNG}
+```
+public static final ImageFormat PNG
+```
+
+
+PNG 이미지 형식.
+
+### TIFF {#TIFF}
+```
+public static final ImageFormat TIFF
+```
+
+
+TIFF 이미지 형식.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static ImageFormat valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat)
+### values() {#values--}
+```
+public static ImageFormat[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.ImageFormat[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/imultipagesaveoptions/_index.md
+++ b/korean/java/com.aspose.page/imultipagesaveoptions/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IMultiPageSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "변환을 위한 페이지 번호 설정 인터페이스를 정의합니다."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.page/imultipagesaveoptions/
+---```
+public interface IMultiPageSaveOptions
+```
+
+Defines the interface for setting page numbers for conversion.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getPageNumbers()](#getPageNumbers--) | Gets the array of numbers of pages to convert. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | Sets the array of numbers of pages to convert. |
+### getPageNumbers() {#getPageNumbers--}
+```
+public abstract int[] getPageNumbers()
+```
+
+
+Gets the array of numbers of pages to convert.
+
+**Returns:**
+int[] - The array of page numbers.
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public abstract void setPageNumbers(int[] value)
+```
+
+
+Sets the array of numbers of pages to convert.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | int[] | The array of page numbers. |
+

--- a/korean/java/com.aspose.page/itrfont/_index.md
+++ b/korean/java/com.aspose.page/itrfont/_index.md
@@ -1,0 +1,247 @@
+---
+title: "ITrFont"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 인터페이스는 폰트의 주요 매개변수에 접근할 수 있게 합니다."
+type: docs
+weight: 22
+url: /ko/java/com.aspose.page/itrfont/
+---```
+public interface ITrFont
+```
+
+This interface give access to main parameters of font.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [clone()](#clone--) | Clones the font. |
+| [deriveFont(float size)](#deriveFont-float-) | Creates equivalent of this font with new size. |
+| [deriveFont(float size, int style)](#deriveFont-float-int-) | Creates equivalent of this font with new size and style. |
+| [deriveFont(int style)](#deriveFont-int-) | Creates equivalent of this font with new style. |
+| [deriveFont(AffineTransform transform)](#deriveFont-java.awt.geom.AffineTransform-) | Creates equivalent of this font with new transform. |
+| [getCharStrings()](#getCharStrings--) | Gets a mapping between character name and glyph. |
+| [getCharWidth(char charValue)](#getCharWidth-char-) | Gets a width of character. |
+| [getEncoding()](#getEncoding--) | Gets encoding array. |
+| [getEncodingTable()](#getEncodingTable--) | Gets a name of the encoding. |
+| [getFID()](#getFID--) | Returns font identifier. |
+| [getFont()](#getFont--) | Gets DrFont corresponding to this font. |
+| [getFontName()](#getFontName--) | Gets a name of font. |
+| [getFontType()](#getFontType--) | Gets a type of font in Adobe classification. |
+| [getNativeFont()](#getNativeFont--) | Gets java.awt.Font corresponding to this font. |
+| [getOutline(char charValue, float x, float y)](#getOutline-char-float-float-) | Returns an outline of glyph in specified location. |
+| [getSize()](#getSize--) | Gets font size. |
+| [getStyle()](#getStyle--) | Gets font style. |
+| [getTransform()](#getTransform--) | Gets font transformation. |
+### clone() {#clone--}
+```
+public abstract ITrFont clone()
+```
+
+
+Clones the font.
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(float size) {#deriveFont-float-}
+```
+public abstract ITrFont deriveFont(float size)
+```
+
+
+Creates equivalent of this font with new size.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| size | float | Size of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(float size, int style) {#deriveFont-float-int-}
+```
+public abstract ITrFont deriveFont(float size, int style)
+```
+
+
+Creates equivalent of this font with new size and style.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| size | float | Size of new font. |
+| style | int | Style of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(int style) {#deriveFont-int-}
+```
+public abstract ITrFont deriveFont(int style)
+```
+
+
+Creates equivalent of this font with new style.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| style | int | Style of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### deriveFont(AffineTransform transform) {#deriveFont-java.awt.geom.AffineTransform-}
+```
+public abstract ITrFont deriveFont(AffineTransform transform)
+```
+
+
+Creates equivalent of this font with new transform.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| transform | java.awt.geom.AffineTransform | Transformation of new font. |
+
+**Returns:**
+[ITrFont](../../com.aspose.page/itrfont) - A new font.
+### getCharStrings() {#getCharStrings--}
+```
+public abstract HashMap<String,IGlyph> getCharStrings()
+```
+
+
+Gets a mapping between character name and glyph.
+
+**Returns:**
+java.util.HashMap<java.lang.String,com.aspose.page.IGlyph> - A mapping between character name and glyph.
+### getCharWidth(char charValue) {#getCharWidth-char-}
+```
+public abstract float getCharWidth(char charValue)
+```
+
+
+Gets a width of character.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charValue | char | Character. |
+
+**Returns:**
+float - A width of character.
+### getEncoding() {#getEncoding--}
+```
+public abstract String[] getEncoding()
+```
+
+
+Gets encoding array.
+
+**Returns:**
+java.lang.String[] - An encoding array.
+### getEncodingTable() {#getEncodingTable--}
+```
+public abstract String getEncodingTable()
+```
+
+
+Gets a name of the encoding.
+
+**Returns:**
+java.lang.String - A name of the encoding.
+### getFID() {#getFID--}
+```
+public abstract int getFID()
+```
+
+
+Returns font identifier.
+
+**Returns:**
+int - font identifier
+### getFont() {#getFont--}
+```
+public abstract DrFont getFont()
+```
+
+
+Gets DrFont corresponding to this font.
+
+**Returns:**
+com.aspose.foundation.drawing.DrFont - DrFont.
+### getFontName() {#getFontName--}
+```
+public abstract String getFontName()
+```
+
+
+Gets a name of font.
+
+**Returns:**
+java.lang.String - Font name.
+### getFontType() {#getFontType--}
+```
+public abstract int getFontType()
+```
+
+
+Gets a type of font in Adobe classification.
+
+**Returns:**
+int - Font type.
+### getNativeFont() {#getNativeFont--}
+```
+public abstract Font getNativeFont()
+```
+
+
+Gets java.awt.Font corresponding to this font.
+
+**Returns:**
+java.awt.Font - Native font.
+### getOutline(char charValue, float x, float y) {#getOutline-char-float-float-}
+```
+public abstract Shape getOutline(char charValue, float x, float y)
+```
+
+
+Returns an outline of glyph in specified location.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| charValue | char | Character. |
+| x | float | X coordinate of the character location. |
+| y | float | Y coordinate of the character location. |
+
+**Returns:**
+java.awt.Shape - An outline of glyph.
+### getSize() {#getSize--}
+```
+public abstract float getSize()
+```
+
+
+Gets font size.
+
+**Returns:**
+float - A size of the font.
+### getStyle() {#getStyle--}
+```
+public abstract int getStyle()
+```
+
+
+Gets font style.
+
+**Returns:**
+int - A style of the font.
+### getTransform() {#getTransform--}
+```
+public abstract AffineTransform getTransform()
+```
+
+
+Gets font transformation.
+
+**Returns:**
+java.awt.geom.AffineTransform - A transformation.

--- a/korean/java/com.aspose.page/license/_index.md
+++ b/korean/java/com.aspose.page/license/_index.md
@@ -1,0 +1,222 @@
+---
+title: "라이선스"
+second_title: "Aspose.Page용 Java API 참조"
+description: "구성 요소에 대한 라이선스 부여 메서드를 제공합니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.page/license/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class License
+```
+
+구성 요소에 대한 라이선스 부여 메서드를 제공합니다.
+
+이 예제에서는 구성 요소가 포함된 폴더, 호출 어셈블리가 포함된 폴더, 진입 어셈블리 폴더에서 MyLicense.lic 라는 라이선스 파일을 찾은 다음 호출 어셈블리의 임베디드 리소스에서 찾으려고 시도합니다.
+
+License license = new License();
+license.setLicense(\"MyLicense.lic\");
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [License()](#License--) | 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isInternalFIPSSecurity()](#isInternalFIPSSecurity--) | 기본적으로 우리는 기본 JDK 보안을 사용합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setInternalFIPSSecurity(boolean internalFIPSSecurity)](#setInternalFIPSSecurity-boolean-) | 기본적으로 우리는 기본 JRE 보안을 사용합니다. |
+| [setLicense(InputStream stream)](#setLicense-java.io.InputStream-) | 구성 요소에 라이선스를 적용합니다. |
+| [setLicense(String licenseName)](#setLicense-java.lang.String-) | 구성 요소에 라이선스를 적용합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### License() {#License--}
+```
+public License()
+```
+
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+이 예제에서는 구성 요소가 포함된 폴더, 호출 어셈블리가 포함된 폴더, 진입 어셈블리 폴더에서 MyLicense.lic 라는 라이선스 파일을 찾은 다음 호출 어셈블리의 임베디드 리소스에서 찾으려고 시도합니다.
+
+License license = new License();
+license.setLicense(\"MyLicense.lic\");
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isInternalFIPSSecurity() {#isInternalFIPSSecurity--}
+```
+public static boolean isInternalFIPSSecurity()
+```
+
+
+기본적으로 우리는 기본 JDK 보안을 사용합니다. 기본값 == false. 경우에 따라 맞춤형 Java 환경이 필요한 알고리즘을 지원하지 못할 수 있으므로 내부 내장 FIPS 보안을 사용하는 것을 권장합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setInternalFIPSSecurity(boolean internalFIPSSecurity) {#setInternalFIPSSecurity-boolean-}
+```
+public static void setInternalFIPSSecurity(boolean internalFIPSSecurity)
+```
+
+
+기본적으로 우리는 기본 JRE 보안을 사용합니다. 기본값 == false. 경우에 따라 맞춤형 Java 환경이 필요한 알고리즘을 지원하지 못할 수 있으므로 내부 내장 FIPS 보안을 사용하는 것을 권장합니다.
+
+또한 참고: 일부 운영 체제에서 JVM SecureRandom 알고리즘에 따르면 /dev/random은 결과를 반환하기 전에 호스트 머신에서 일정량의 \u201cnoise\u201d가 생성되기를 기다립니다. Oracle\u2019s JVM에서 난수 생성을 위해 사용되는 라이브러리는 UNIX 플랫폼에서 기본적으로 /dev/random에 의존합니다. /dev/random이 더 안전하지만 기본 JVM 구성에서 지연이 발생하면 /dev/urandom을 사용하거나 /dev/random에 대한 엔트로피를 생성하는 장치를 추가하는 것이 권장됩니다.
+
+다음 Java 옵션은 지연을 방지하고 securerandom.source 설정을 재정의하는 데 도움이 됩니다. -Djava.security.egd=file:/dev/./urandom
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| internalFIPSSecurity | boolean | 불리언 값 |
+
+### setLicense(InputStream stream) {#setLicense-java.io.InputStream-}
+```
+public void setLicense(InputStream stream)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+라이선스를 포함하는 스트림.
+
+이 메서드를 사용하여 스트림에서 라이선스를 로드합니다.
+
+License license = new License();
+license.setLicense(myStream);
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 라이선스 스트림 |
+
+### setLicense(String licenseName) {#setLicense-java.lang.String-}
+```
+public void setLicense(String licenseName)
+```
+
+
+구성 요소에 라이선스를 적용합니다.
+
+다음 위치에서 라이선스를 찾으려고 시도합니다:
+
+1. 명시적 경로.
+
+2. 구성 요소 JAR 파일이 있는 폴더.
+
+이 예제에서는 구성 요소가 포함된 폴더, 호출 어셈블리가 포함된 폴더, 진입 어셈블리 폴더에서 MyLicense.lic 라는 라이선스 파일을 찾은 다음 호출 어셈블리의 임베디드 리소스에서 찾으려고 시도합니다.
+
+License license = new License();
+license.setLicense(\"MyLicense.lic\");
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| licenseName | java.lang.String | 전체 파일 이름이거나 짧은 파일 이름, 혹은 임베디드 리소스 이름이 될 수 있습니다. 빈 문자열을 사용하면 평가 모드로 전환됩니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/metered/_index.md
+++ b/korean/java/com.aspose.page/metered/_index.md
@@ -1,0 +1,203 @@
+---
+title: "계량식"
+second_title: "Aspose.Page용 Java API 참조"
+description: "계량 키를 설정하는 메서드를 제공합니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.page/metered/
+---
+**Inheritance:**
+java.lang.Object
+```
+public final class Metered
+```
+
+계량 키를 설정하는 메서드를 제공합니다.
+
+--------------------
+
+이 예제에서는 계량식 공개 키와 개인 키를 설정하려고 시도합니다
+
+```
+The component jar file:
+  
+ 	Metered matered = new Metered();
+ 	matered.setMeteredKey("PublicKey", "PrivateKey");
+```
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Metered()](#Metered--) | 이 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clearMeteredLicense()](#clearMeteredLicense--) | 계량식 라이선스를 정리합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [flush()](#flush--) | 서버의 카운트 데이터를 플러시합니다. |
+| [getClass()](#getClass--) |  |
+| [getConsumptionCredit()](#getConsumptionCredit--) | 소비 크레딧을 가져옵니다. |
+| [getConsumptionQuantity()](#getConsumptionQuantity--) | 소비 파일 크기를 가져옵니다 |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMeteredKey(String publicKey, String privateKey)](#setMeteredKey-java.lang.String-java.lang.String-) | 계량된 공개 및 개인 키를 설정합니다 |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Metered() {#Metered--}
+```
+public Metered()
+```
+
+
+이 클래스의 새 인스턴스를 초기화합니다.
+
+### clearMeteredLicense() {#clearMeteredLicense--}
+```
+public static void clearMeteredLicense()
+```
+
+
+계량식 라이선스를 정리합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### flush() {#flush--}
+```
+public static void flush()
+```
+
+
+서버에서 카운트 데이터를 플러시합니다. 디버그 목적으로만 사용됩니다.
+
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConsumptionCredit() {#getConsumptionCredit--}
+```
+public static double getConsumptionCredit()
+```
+
+
+소비 크레딧을 가져옵니다.
+
+**Returns:**
+double - 소비량
+### getConsumptionQuantity() {#getConsumptionQuantity--}
+```
+public static double getConsumptionQuantity()
+```
+
+
+소비 파일 크기를 가져옵니다
+
+**Returns:**
+double - 소비량
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMeteredKey(String publicKey, String privateKey) {#setMeteredKey-java.lang.String-java.lang.String-}
+```
+public void setMeteredKey(String publicKey, String privateKey)
+```
+
+
+계량된 공개 및 개인 키를 설정합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| publicKey | java.lang.String | 공개 키 |
+| privateKey | java.lang.String | 개인 키 |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/saveoptions/_index.md
+++ b/korean/java/com.aspose.page/saveoptions/_index.md
@@ -1,0 +1,341 @@
+---
+title: "SaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.page/saveoptions/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class SaveOptions
+```
+
+이 클래스는 변환 프로세스를 관리하는 데 필요한 옵션을 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [SaveOptions()](#SaveOptions--) | 새 SaveOptions 인스턴스를 초기화하고 플래그 suppressErrors (true)와 debug (false)의 기본값을 사용합니다. |
+| [SaveOptions(boolean supressErrors)](#SaveOptions-boolean-) | 새 SaveOptions 인스턴스를 초기화하고 플래그 debug (false)의 기본값을 사용합니다. |
+| [SaveOptions(Dimension size)](#SaveOptions-java.awt.Dimension-) | 지정된 크기로 새 SaveOptions 인스턴스를 초기화합니다. |
+| [SaveOptions(boolean supressErrors, Dimension size)](#SaveOptions-boolean-java.awt.Dimension-) | 플래그 debug (false)의 기본값과 지정된 크기로 새 SaveOptions 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SaveOptions() {#SaveOptions--}
+```
+public SaveOptions()
+```
+
+
+새 SaveOptions 인스턴스를 초기화하고 플래그 suppressErrors (true)와 debug (false)의 기본값을 사용합니다.
+
+### SaveOptions(boolean supressErrors) {#SaveOptions-boolean-}
+```
+public SaveOptions(boolean supressErrors)
+```
+
+
+새 SaveOptions 인스턴스를 초기화하고 플래그 debug (false)의 기본값을 사용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+
+### SaveOptions(Dimension size) {#SaveOptions-java.awt.Dimension-}
+```
+public SaveOptions(Dimension size)
+```
+
+
+지정된 크기로 새 SaveOptions 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 크기입니다. |
+
+### SaveOptions(boolean supressErrors, Dimension size) {#SaveOptions-boolean-java.awt.Dimension-}
+```
+public SaveOptions(boolean supressErrors, Dimension size)
+```
+
+
+플래그 debug (false)의 기본값과 지정된 크기로 새 SaveOptions 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | true이면 비치명적 오류에도 불구하고 변환이 계속됩니다. |
+| 크기 | java.awt.Dimension | 크기입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/textrenderingmode/_index.md
+++ b/korean/java/com.aspose.page/textrenderingmode/_index.md
@@ -1,0 +1,268 @@
+---
+title: "TextRenderingMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 열거형은 텍스트 렌더링 모드에 대한 가능한 값을 포함합니다."
+type: docs
+weight: 24
+url: /ko/java/com.aspose.page/textrenderingmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TextRenderingMode extends Enum<TextRenderingMode>
+```
+
+이 열거형은 텍스트 렌더링 모드에 대한 가능한 값을 포함합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Fill](#Fill) | 텍스트를 채웁니다. |
+| [FillAndStroke](#FillAndStroke) | 텍스트를 채우고 스트로크합니다. |
+| [No](#No) | 텍스트를 채우지도 스트로크하지도 않습니다. |
+| [Stroke](#Stroke) | 텍스트를 스트로크합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Fill {#Fill}
+```
+public static final TextRenderingMode Fill
+```
+
+
+텍스트를 채웁니다.
+
+### FillAndStroke {#FillAndStroke}
+```
+public static final TextRenderingMode FillAndStroke
+```
+
+
+텍스트를 채우고 스트로크합니다.
+
+### No {#No}
+```
+public static final TextRenderingMode No
+```
+
+
+텍스트를 채우지도 스트로크하지도 않습니다.
+
+### Stroke {#Stroke}
+```
+public static final TextRenderingMode Stroke
+```
+
+
+텍스트를 스트로크합니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TextRenderingMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[TextRenderingMode](../../com.aspose.page/textrenderingmode)
+### values() {#values--}
+```
+public static TextRenderingMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.TextRenderingMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/transformedstroke/_index.md
+++ b/korean/java/com.aspose.page/transformedstroke/_index.md
@@ -1,0 +1,184 @@
+---
+title: "TransformedStroke"
+second_title: "Aspose.Page용 Java API 참조"
+description: "변환을 포함하는 스트로크입니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.page/transformedstroke/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.awt.Stroke
+```
+public class TransformedStroke implements Stroke
+```
+
+변환을 포함하는 스트로크입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TransformedStroke(Stroke base, AffineTransform at)](#TransformedStroke-java.awt.Stroke-java.awt.geom.AffineTransform-) | 다른 Stroke와 AffineTransform을 기반으로 TransformedStroke를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createStrokedShape(Shape s)](#createStrokedShape-java.awt.Shape-) | 주어진 Shape을 이 스트로크로 스트로크하여 외곽선을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getBaseStroke()](#getBaseStroke--) | 기본 스트로크를 가져옵니다. |
+| [getClass()](#getClass--) |  |
+| [getTransform()](#getTransform--) | 변환을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TransformedStroke(Stroke base, AffineTransform at) {#TransformedStroke-java.awt.Stroke-java.awt.geom.AffineTransform-}
+```
+public TransformedStroke(Stroke base, AffineTransform at)
+```
+
+
+다른 Stroke와 AffineTransform을 기반으로 TransformedStroke를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 기본 | java.awt.Stroke | 스트로크 기본입니다. |
+| at | java.awt.geom.AffineTransform | 아핀 변환입니다. |
+
+### createStrokedShape(Shape s) {#createStrokedShape-java.awt.Shape-}
+```
+public Shape createStrokedShape(Shape s)
+```
+
+
+주어진 Shape을 이 스트로크로 스트로크하여 외곽선을 생성합니다. 이 외곽선은 기본 스트로크가 제공할 외곽선에 비해 우리의 AffineTransform에 의해 왜곡되는데, 이는 스케일링(즉, 선의 두께) 측면에서만 적용되며, 스트로크 후에 평행이동과 회전은 취소됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| s | java.awt.Shape | 외곽선을 만들 형상으로 사용합니다. |
+
+**Returns:**
+java.awt.Shape - 형상의 외곽선입니다.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getBaseStroke() {#getBaseStroke--}
+```
+public Stroke getBaseStroke()
+```
+
+
+기본 스트로크를 가져옵니다.
+
+**Returns:**
+java.awt.Stroke - 기본 스트로크입니다.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTransform() {#getTransform--}
+```
+public AffineTransform getTransform()
+```
+
+
+변환을 가져옵니다.
+
+**Returns:**
+java.awt.geom.AffineTransform - 변환입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/units/_index.md
+++ b/korean/java/com.aspose.page/units/_index.md
@@ -1,0 +1,277 @@
+---
+title: "단위"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 열거형은 크기 단위에 대한 가능한 값을 포함합니다."
+type: docs
+weight: 25
+url: /ko/java/com.aspose.page/units/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum Units extends Enum<Units>
+```
+
+이 열거형은 크기 단위에 대한 가능한 값을 포함합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Centimeters](#Centimeters) | 센티미터. |
+| [Inches](#Inches) | 인치. |
+| [Millimeters](#Millimeters) | 밀리미터. |
+| [Percents](#Percents) | 기존 크기의 백분율. |
+| [Points](#Points) | 포인트(인치의 1/72). |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Centimeters {#Centimeters}
+```
+public static final Units Centimeters
+```
+
+
+센티미터.
+
+### Inches {#Inches}
+```
+public static final Units Inches
+```
+
+
+인치.
+
+### Millimeters {#Millimeters}
+```
+public static final Units Millimeters
+```
+
+
+밀리미터.
+
+### Percents {#Percents}
+```
+public static final Units Percents
+```
+
+
+기존 크기의 백분율.
+
+### Points {#Points}
+```
+public static final Units Points
+```
+
+
+포인트(인치의 1/72).
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static Units valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[Units](../../com.aspose.page/units)
+### values() {#values--}
+```
+public static Units[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.page.Units[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.page/userproperties/_index.md
+++ b/korean/java/com.aspose.page/userproperties/_index.md
@@ -1,0 +1,1691 @@
+---
+title: "UserProperties"
+second_title: "Aspose.Page용 Java API 참조"
+description: "형식이 지정된 속성을 설정하고 반환할 수 있는 특수 속성 클래스입니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.page/userproperties/
+---
+**Inheritance:**
+java.lang.Object, java.util.Dictionary, java.util.Hashtable, java.util.Properties
+```
+public class UserProperties extends Properties
+```
+
+형식이 지정된 속성을 설정하고 반환할 수 있는 특수 속성 클래스입니다. 또한 이 속성 객체에 해당 속성이 없을 경우 검색할 두 개의 기본 속성 객체를 연결할 수 있습니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [UserProperties()](#UserProperties--) | UserProperties 클래스의 빈 인스턴스를 초기화합니다. |
+| [UserProperties(Properties defaults)](#UserProperties-java.util.Properties-) | UserProperties 클래스를 기본값으로 초기화합니다. |
+| [UserProperties(Properties defaults, Properties altDefaults)](#UserProperties-java.util.Properties-java.util.Properties-) | UserProperties를 defaults와 altDefaults 테이블로 구성하며, 해당 순서대로 검색됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clear()](#clear--) |  |
+| [clone()](#clone--) |  |
+| [compute(K arg0, BiFunction<? super K,? super V,? extends V> arg1)](#compute-K-java.util.function.BiFunction---super-K---super-V---extends-V--) |  |
+| [compute(Object arg0, BiFunction<? super Object,? super Object,?> arg1)](#compute-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [computeIfAbsent(K arg0, Function<? super K,? extends V> arg1)](#computeIfAbsent-K-java.util.function.Function---super-K---extends-V--) |  |
+| [computeIfAbsent(Object arg0, Function<? super Object,?> arg1)](#computeIfAbsent-java.lang.Object-java.util.function.Function---super-java.lang.Object----) |  |
+| [computeIfPresent(K arg0, BiFunction<? super K,? super V,? extends V> arg1)](#computeIfPresent-K-java.util.function.BiFunction---super-K---super-V---extends-V--) |  |
+| [computeIfPresent(Object arg0, BiFunction<? super Object,? super Object,?> arg1)](#computeIfPresent-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [contains(Object arg0)](#contains-java.lang.Object-) |  |
+| [containsKey(Object arg0)](#containsKey-java.lang.Object-) |  |
+| [containsValue(Object arg0)](#containsValue-java.lang.Object-) |  |
+| [elements()](#elements--) |  |
+| [entrySet()](#entrySet--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [forEach(BiConsumer<? super K,? super V> arg0)](#forEach-java.util.function.BiConsumer---super-K---super-V--) |  |
+| [forEach(BiConsumer<? super Object,? super Object> arg0)](#forEach-java.util.function.BiConsumer---super-java.lang.Object---super-java.lang.Object--) |  |
+| [get(Object arg0)](#get-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOrDefault(Object arg0, V arg1)](#getOrDefault-java.lang.Object-V-) |  |
+| [getOrDefault(Object arg0, Object arg1)](#getOrDefault-java.lang.Object-java.lang.Object-) |  |
+| [getProperty(String key)](#getProperty-java.lang.String-) | 문자열 속성 값을 가져옵니다. |
+| [getProperty(String key, String def)](#getProperty-java.lang.String-java.lang.String-) | 문자열 속성 값을 가져옵니다. |
+| [getPropertyColor(String key)](#getPropertyColor-java.lang.String-) | 색상 속성 값을 가져옵니다. |
+| [getPropertyColor(String key, Color def)](#getPropertyColor-java.lang.String-java.awt.Color-) | 색상 속성 값을 가져옵니다. |
+| [getPropertyDimension(String key)](#getPropertyDimension-java.lang.String-) | 크기 속성 값을 가져옵니다. |
+| [getPropertyDimension(String key, Dimension def)](#getPropertyDimension-java.lang.String-java.awt.Dimension-) | 크기 속성 값을 가져옵니다. |
+| [getPropertyDouble(String key)](#getPropertyDouble-java.lang.String-) | double 속성 값을 가져옵니다. |
+| [getPropertyDouble(String key, double def)](#getPropertyDouble-java.lang.String-double-) | double 속성 값을 가져옵니다. |
+| [getPropertyFloat(String key)](#getPropertyFloat-java.lang.String-) | float 속성 값을 가져옵니다. |
+| [getPropertyFloat(String key, float def)](#getPropertyFloat-java.lang.String-float-) | float 속성 값을 가져옵니다. |
+| [getPropertyInsets(String key)](#getPropertyInsets-java.lang.String-) | 인셋 속성 값을 가져옵니다. |
+| [getPropertyInsets(String key, Insets def)](#getPropertyInsets-java.lang.String-java.awt.Insets-) | 인셋 속성 값을 가져옵니다. |
+| [getPropertyInt(String key)](#getPropertyInt-java.lang.String-) | integer 속성 값을 가져옵니다. |
+| [getPropertyInt(String key, int def)](#getPropertyInt-java.lang.String-int-) | integer 속성 값을 가져옵니다. |
+| [getPropertyMatrix(String key)](#getPropertyMatrix-java.lang.String-) | float 속성 값을 가져옵니다. |
+| [getPropertyMatrix(String key, AffineTransform def)](#getPropertyMatrix-java.lang.String-java.awt.geom.AffineTransform-) | float 속성 값을 가져옵니다. |
+| [getPropertyRectangle(String key)](#getPropertyRectangle-java.lang.String-) | rectangle 속성 값을 가져옵니다. |
+| [getPropertyRectangle(String key, Rectangle def)](#getPropertyRectangle-java.lang.String-java.awt.Rectangle-) | rectangle 속성 값을 가져옵니다. |
+| [getPropertyStringArray(String key)](#getPropertyStringArray-java.lang.String-) | string 배열 속성 값을 가져옵니다. |
+| [getPropertyStringArray(String key, String[] def)](#getPropertyStringArray-java.lang.String-java.lang.String---) | string 배열 속성 값을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isEmpty()](#isEmpty--) |  |
+| [isProperty(String key)](#isProperty-java.lang.String-) | boolean 속성 값을 가져옵니다. |
+| [isProperty(String key, boolean def)](#isProperty-java.lang.String-boolean-) | boolean 속성 값을 가져옵니다. |
+| [keySet()](#keySet--) |  |
+| [keys()](#keys--) |  |
+| [list(PrintStream arg0)](#list-java.io.PrintStream-) |  |
+| [list(PrintWriter arg0)](#list-java.io.PrintWriter-) |  |
+| [load(InputStream arg0)](#load-java.io.InputStream-) |  |
+| [load(Reader arg0)](#load-java.io.Reader-) |  |
+| [loadFromXML(InputStream arg0)](#loadFromXML-java.io.InputStream-) |  |
+| [merge(K arg0, V arg1, BiFunction<? super V,? super V,? extends V> arg2)](#merge-K-V-java.util.function.BiFunction---super-V---super-V---extends-V--) |  |
+| [merge(Object arg0, Object arg1, BiFunction<? super Object,? super Object,?> arg2)](#merge-java.lang.Object-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [printProperties()](#printProperties--) | 설정된 모든 속성을 출력합니다. |
+| [propertyNames()](#propertyNames--) | 속성 이름을 반환합니다. |
+| [put(K arg0, V arg1)](#put-K-V-) |  |
+| [put(Object arg0, Object arg1)](#put-java.lang.Object-java.lang.Object-) |  |
+| [putAll(Map<? extends K,? extends V> arg0)](#putAll-java.util.Map---extends-K---extends-V--) |  |
+| [putAll(Map<?,?> arg0)](#putAll-java.util.Map------) |  |
+| [putIfAbsent(K arg0, V arg1)](#putIfAbsent-K-V-) |  |
+| [putIfAbsent(Object arg0, Object arg1)](#putIfAbsent-java.lang.Object-java.lang.Object-) |  |
+| [remove(Object arg0)](#remove-java.lang.Object-) |  |
+| [remove(Object arg0, Object arg1)](#remove-java.lang.Object-java.lang.Object-) |  |
+| [replace(K arg0, V arg1)](#replace-K-V-) |  |
+| [replace(K arg0, V arg1, V arg2)](#replace-K-V-V-) |  |
+| [replace(Object arg0, Object arg1)](#replace-java.lang.Object-java.lang.Object-) |  |
+| [replace(Object arg0, Object arg1, Object arg2)](#replace-java.lang.Object-java.lang.Object-java.lang.Object-) |  |
+| [replaceAll(BiFunction<? super K,? super V,? extends V> arg0)](#replaceAll-java.util.function.BiFunction---super-K---super-V---extends-V--) |  |
+| [replaceAll(BiFunction<? super Object,? super Object,?> arg0)](#replaceAll-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----) |  |
+| [save(OutputStream arg0, String arg1)](#save-java.io.OutputStream-java.lang.String-) |  |
+| [setProperties(Properties properties)](#setProperties-java.util.Properties-) | 기본값을 포함한 속성을 이 UserProperties에 복사합니다. |
+| [setProperty(String key, boolean value)](#setProperty-java.lang.String-boolean-) | boolean 속성 값을 설정합니다. |
+| [setProperty(String key, double value)](#setProperty-java.lang.String-double-) | double 속성 값을 설정합니다. |
+| [setProperty(String key, float value)](#setProperty-java.lang.String-float-) | float 속성 값을 설정합니다. |
+| [setProperty(String key, int value)](#setProperty-java.lang.String-int-) | integer 속성 값을 설정합니다. |
+| [setProperty(String key, Color value)](#setProperty-java.lang.String-java.awt.Color-) | 색상 속성 값을 설정합니다. |
+| [setProperty(String key, Dimension value)](#setProperty-java.lang.String-java.awt.Dimension-) | 크기 속성 값을 설정합니다. |
+| [setProperty(String key, Insets value)](#setProperty-java.lang.String-java.awt.Insets-) | 인셋 속성 값을 설정합니다. |
+| [setProperty(String key, Rectangle value)](#setProperty-java.lang.String-java.awt.Rectangle-) | rectangle 속성 값을 설정합니다. |
+| [setProperty(String key, AffineTransform value)](#setProperty-java.lang.String-java.awt.geom.AffineTransform-) | matrix 속성 값을 설정합니다. |
+| [setProperty(String key, String value)](#setProperty-java.lang.String-java.lang.String-) | string 속성 값을 설정합니다. |
+| [setProperty(String key, String[] value)](#setProperty-java.lang.String-java.lang.String---) | string 배열 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, boolean value)](#setProperty-java.util.Properties-java.lang.String-boolean-) | 지정된 속성 테이블에 boolean 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, double value)](#setProperty-java.util.Properties-java.lang.String-double-) | 지정된 속성 테이블에 double 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, float value)](#setProperty-java.util.Properties-java.lang.String-float-) | 지정된 속성 테이블에 float 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, int value)](#setProperty-java.util.Properties-java.lang.String-int-) | 지정된 속성 테이블에 integer 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, Color value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Color-) | 지정된 속성 테이블에 color 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, Dimension value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Dimension-) | 지정된 속성 테이블에 dimension 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, Insets value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Insets-) | 지정된 속성 테이블에 insets 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, Rectangle value)](#setProperty-java.util.Properties-java.lang.String-java.awt.Rectangle-) | 지정된 속성 테이블에 rectangle 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, AffineTransform value)](#setProperty-java.util.Properties-java.lang.String-java.awt.geom.AffineTransform-) | 지정된 속성 테이블에 matrix 속성 값을 설정합니다. |
+| [setProperty(Properties properties, String key, String[] value)](#setProperty-java.util.Properties-java.lang.String-java.lang.String---) | 지정된 속성 테이블에 string array 속성 값을 설정합니다. |
+| [size()](#size--) |  |
+| [store(OutputStream arg0, String arg1)](#store-java.io.OutputStream-java.lang.String-) |  |
+| [store(Writer arg0, String arg1)](#store-java.io.Writer-java.lang.String-) |  |
+| [storeToXML(OutputStream arg0, String arg1)](#storeToXML-java.io.OutputStream-java.lang.String-) |  |
+| [storeToXML(OutputStream arg0, String arg1, String arg2)](#storeToXML-java.io.OutputStream-java.lang.String-java.lang.String-) |  |
+| [storeToXML(OutputStream arg0, String arg1, Charset arg2)](#storeToXML-java.io.OutputStream-java.lang.String-java.nio.charset.Charset-) |  |
+| [stringPropertyNames()](#stringPropertyNames--) |  |
+| [toString()](#toString--) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### UserProperties() {#UserProperties--}
+```
+public UserProperties()
+```
+
+
+UserProperties 클래스의 빈 인스턴스를 초기화합니다.
+
+### UserProperties(Properties defaults) {#UserProperties-java.util.Properties-}
+```
+public UserProperties(Properties defaults)
+```
+
+
+UserProperties 클래스를 기본값으로 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 기본값 | java.util.Properties | 기본 속성 값들. |
+
+### UserProperties(Properties defaults, Properties altDefaults) {#UserProperties-java.util.Properties-java.util.Properties-}
+```
+public UserProperties(Properties defaults, Properties altDefaults)
+```
+
+
+UserProperties를 defaults와 altDefaults 테이블로 구성하며, 해당 순서대로 검색됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 기본값 | java.util.Properties | 기본 속성. |
+| altDefaults | java.util.Properties | 대체 기본 속성. |
+
+### clear() {#clear--}
+```
+public synchronized void clear()
+```
+
+
+
+
+### clone() {#clone--}
+```
+public synchronized Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### compute(K arg0, BiFunction<? super K,? super V,? extends V> arg1) {#compute-K-java.util.function.BiFunction---super-K---super-V---extends-V--}
+```
+public synchronized V compute(K arg0, BiFunction<? super K,? super V,? extends V> arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | java.util.function.BiFunction<? super K,? super V,? extends V> |  |
+
+**Returns:**
+V
+### compute(Object arg0, BiFunction<? super Object,? super Object,?> arg1) {#compute-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized Object compute(Object arg0, BiFunction<? super Object,? super Object,?> arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### computeIfAbsent(K arg0, Function<? super K,? extends V> arg1) {#computeIfAbsent-K-java.util.function.Function---super-K---extends-V--}
+```
+public synchronized V computeIfAbsent(K arg0, Function<? super K,? extends V> arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | java.util.function.Function<? super K,? extends V> |  |
+
+**Returns:**
+V
+### computeIfAbsent(Object arg0, Function<? super Object,?> arg1) {#computeIfAbsent-java.lang.Object-java.util.function.Function---super-java.lang.Object----}
+```
+public synchronized Object computeIfAbsent(Object arg0, Function<? super Object,?> arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.util.function.Function<? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### computeIfPresent(K arg0, BiFunction<? super K,? super V,? extends V> arg1) {#computeIfPresent-K-java.util.function.BiFunction---super-K---super-V---extends-V--}
+```
+public synchronized V computeIfPresent(K arg0, BiFunction<? super K,? super V,? extends V> arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | java.util.function.BiFunction<? super K,? super V,? extends V> |  |
+
+**Returns:**
+V
+### computeIfPresent(Object arg0, BiFunction<? super Object,? super Object,?> arg1) {#computeIfPresent-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized Object computeIfPresent(Object arg0, BiFunction<? super Object,? super Object,?> arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### contains(Object arg0) {#contains-java.lang.Object-}
+```
+public boolean contains(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsKey(Object arg0) {#containsKey-java.lang.Object-}
+```
+public boolean containsKey(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### containsValue(Object arg0) {#containsValue-java.lang.Object-}
+```
+public boolean containsValue(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### elements() {#elements--}
+```
+public Enumeration<Object> elements()
+```
+
+
+
+
+**Returns:**
+java.util.Enumeration<java.lang.Object>
+### entrySet() {#entrySet--}
+```
+public Set<Map.Entry<Object,Object>> entrySet()
+```
+
+
+
+
+**Returns:**
+java.util.Set<java.util.Map.Entry<java.lang.Object,java.lang.Object>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public synchronized boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### forEach(BiConsumer<? super K,? super V> arg0) {#forEach-java.util.function.BiConsumer---super-K---super-V--}
+```
+public synchronized void forEach(BiConsumer<? super K,? super V> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiConsumer<? super K,? super V> |  |
+
+### forEach(BiConsumer<? super Object,? super Object> arg0) {#forEach-java.util.function.BiConsumer---super-java.lang.Object---super-java.lang.Object--}
+```
+public synchronized void forEach(BiConsumer<? super Object,? super Object> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiConsumer<? super java.lang.Object,? super java.lang.Object> |  |
+
+### get(Object arg0) {#get-java.lang.Object-}
+```
+public Object get(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOrDefault(Object arg0, V arg1) {#getOrDefault-java.lang.Object-V-}
+```
+public synchronized V getOrDefault(Object arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### getOrDefault(Object arg0, Object arg1) {#getOrDefault-java.lang.Object-java.lang.Object-}
+```
+public Object getOrDefault(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### getProperty(String key) {#getProperty-java.lang.String-}
+```
+public String getProperty(String key)
+```
+
+
+문자열 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.lang.String - 속성 값.
+### getProperty(String key, String def) {#getProperty-java.lang.String-java.lang.String-}
+```
+public String getProperty(String key, String def)
+```
+
+
+문자열 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.lang.String | 속성의 기본값. |
+
+**Returns:**
+java.lang.String - 속성 값.
+### getPropertyColor(String key) {#getPropertyColor-java.lang.String-}
+```
+public Color getPropertyColor(String key)
+```
+
+
+색상 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Color - 속성 값.
+### getPropertyColor(String key, Color def) {#getPropertyColor-java.lang.String-java.awt.Color-}
+```
+public Color getPropertyColor(String key, Color def)
+```
+
+
+색상 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.awt.Color | 속성의 기본값. |
+
+**Returns:**
+java.awt.Color - 속성 값.
+### getPropertyDimension(String key) {#getPropertyDimension-java.lang.String-}
+```
+public Dimension getPropertyDimension(String key)
+```
+
+
+크기 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Dimension - 속성 값.
+### getPropertyDimension(String key, Dimension def) {#getPropertyDimension-java.lang.String-java.awt.Dimension-}
+```
+public Dimension getPropertyDimension(String key, Dimension def)
+```
+
+
+크기 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.awt.Dimension | 속성의 기본값. |
+
+**Returns:**
+java.awt.Dimension - 속성 값.
+### getPropertyDouble(String key) {#getPropertyDouble-java.lang.String-}
+```
+public double getPropertyDouble(String key)
+```
+
+
+double 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+double - 속성 값.
+### getPropertyDouble(String key, double def) {#getPropertyDouble-java.lang.String-double-}
+```
+public double getPropertyDouble(String key, double def)
+```
+
+
+double 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | double | 속성의 기본값. |
+
+**Returns:**
+double - 속성 값.
+### getPropertyFloat(String key) {#getPropertyFloat-java.lang.String-}
+```
+public float getPropertyFloat(String key)
+```
+
+
+float 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+float - 속성 값.
+### getPropertyFloat(String key, float def) {#getPropertyFloat-java.lang.String-float-}
+```
+public float getPropertyFloat(String key, float def)
+```
+
+
+float 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | float | 속성의 기본값. |
+
+**Returns:**
+float - 속성 값.
+### getPropertyInsets(String key) {#getPropertyInsets-java.lang.String-}
+```
+public Insets getPropertyInsets(String key)
+```
+
+
+인셋 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Insets - 속성 값.
+### getPropertyInsets(String key, Insets def) {#getPropertyInsets-java.lang.String-java.awt.Insets-}
+```
+public Insets getPropertyInsets(String key, Insets def)
+```
+
+
+인셋 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.awt.Insets | 속성의 기본값. |
+
+**Returns:**
+java.awt.Insets - 속성 값.
+### getPropertyInt(String key) {#getPropertyInt-java.lang.String-}
+```
+public int getPropertyInt(String key)
+```
+
+
+integer 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+int - 속성 값.
+### getPropertyInt(String key, int def) {#getPropertyInt-java.lang.String-int-}
+```
+public int getPropertyInt(String key, int def)
+```
+
+
+정수 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | int | 속성의 기본값. |
+
+**Returns:**
+int - 속성 값.
+### getPropertyMatrix(String key) {#getPropertyMatrix-java.lang.String-}
+```
+public AffineTransform getPropertyMatrix(String key)
+```
+
+
+float 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.geom.AffineTransform - 속성 값.
+### getPropertyMatrix(String key, AffineTransform def) {#getPropertyMatrix-java.lang.String-java.awt.geom.AffineTransform-}
+```
+public AffineTransform getPropertyMatrix(String key, AffineTransform def)
+```
+
+
+float 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.awt.geom.AffineTransform | 속성의 기본값. |
+
+**Returns:**
+java.awt.geom.AffineTransform - 속성 값.
+### getPropertyRectangle(String key) {#getPropertyRectangle-java.lang.String-}
+```
+public Rectangle getPropertyRectangle(String key)
+```
+
+
+rectangle 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.awt.Rectangle - 속성 값.
+### getPropertyRectangle(String key, Rectangle def) {#getPropertyRectangle-java.lang.String-java.awt.Rectangle-}
+```
+public Rectangle getPropertyRectangle(String key, Rectangle def)
+```
+
+
+사각형 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.awt.Rectangle | 속성의 기본값. |
+
+**Returns:**
+java.awt.Rectangle - 속성 값.
+### getPropertyStringArray(String key) {#getPropertyStringArray-java.lang.String-}
+```
+public String[] getPropertyStringArray(String key)
+```
+
+
+string 배열 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+java.lang.String[] - 속성 값.
+### getPropertyStringArray(String key, String[] def) {#getPropertyStringArray-java.lang.String-java.lang.String---}
+```
+public String[] getPropertyStringArray(String key, String[] def)
+```
+
+
+문자열 배열 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본 값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | java.lang.String[] | 속성의 기본값. |
+
+**Returns:**
+java.lang.String[] - 속성 값.
+### hashCode() {#hashCode--}
+```
+public synchronized int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isEmpty() {#isEmpty--}
+```
+public boolean isEmpty()
+```
+
+
+
+
+**Returns:**
+boolean
+### isProperty(String key) {#isProperty-java.lang.String-}
+```
+public boolean isProperty(String key)
+```
+
+
+boolean 속성 값을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+
+**Returns:**
+boolean - 속성 값.
+### isProperty(String key, boolean def) {#isProperty-java.lang.String-boolean-}
+```
+public boolean isProperty(String key, boolean def)
+```
+
+
+불리언 속성 값을 가져옵니다. 요청한 속성이 없으면 제공된 기본 값을 반환합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| def | boolean | 속성의 기본값. |
+
+**Returns:**
+boolean - 속성 값.
+### keySet() {#keySet--}
+```
+public Set<Object> keySet()
+```
+
+
+
+
+**Returns:**
+java.util.Set<java.lang.Object>
+### keys() {#keys--}
+```
+public Enumeration<Object> keys()
+```
+
+
+
+
+**Returns:**
+java.util.Enumeration<java.lang.Object>
+### list(PrintStream arg0) {#list-java.io.PrintStream-}
+```
+public void list(PrintStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintStream |  |
+
+### list(PrintWriter arg0) {#list-java.io.PrintWriter-}
+```
+public void list(PrintWriter arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.PrintWriter |  |
+
+### load(InputStream arg0) {#load-java.io.InputStream-}
+```
+public synchronized void load(InputStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.InputStream |  |
+
+### load(Reader arg0) {#load-java.io.Reader-}
+```
+public synchronized void load(Reader arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.Reader |  |
+
+### loadFromXML(InputStream arg0) {#loadFromXML-java.io.InputStream-}
+```
+public synchronized void loadFromXML(InputStream arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.InputStream |  |
+
+### merge(K arg0, V arg1, BiFunction<? super V,? super V,? extends V> arg2) {#merge-K-V-java.util.function.BiFunction---super-V---super-V---extends-V--}
+```
+public synchronized V merge(K arg0, V arg1, BiFunction<? super V,? super V,? extends V> arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+| arg2 | java.util.function.BiFunction<? super V,? super V,? extends V> |  |
+
+**Returns:**
+V
+### merge(Object arg0, Object arg1, BiFunction<? super Object,? super Object,?> arg2) {#merge-java.lang.Object-java.lang.Object-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized Object merge(Object arg0, Object arg1, BiFunction<? super Object,? super Object,?> arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+**Returns:**
+java.lang.Object
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### printProperties() {#printProperties--}
+```
+public void printProperties()
+```
+
+
+설정된 모든 속성을 출력합니다.
+
+### propertyNames() {#propertyNames--}
+```
+public Enumeration propertyNames()
+```
+
+
+속성 이름을 반환합니다.
+
+**Returns:**
+java.util.Enumeration - 속성 이름들의 열거.
+### put(K arg0, V arg1) {#put-K-V-}
+```
+public synchronized V put(K arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### put(Object arg0, Object arg1) {#put-java.lang.Object-java.lang.Object-}
+```
+public synchronized Object put(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### putAll(Map<? extends K,? extends V> arg0) {#putAll-java.util.Map---extends-K---extends-V--}
+```
+public synchronized void putAll(Map<? extends K,? extends V> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.util.Map<? extends K,? extends V> |  |
+
+### putAll(Map<?,?> arg0) {#putAll-java.util.Map------}
+```
+public synchronized void putAll(Map<?,?> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.util.Map<?,?> |  |
+
+### putIfAbsent(K arg0, V arg1) {#putIfAbsent-K-V-}
+```
+public synchronized V putIfAbsent(K arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### putIfAbsent(Object arg0, Object arg1) {#putIfAbsent-java.lang.Object-java.lang.Object-}
+```
+public synchronized Object putIfAbsent(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### remove(Object arg0) {#remove-java.lang.Object-}
+```
+public synchronized Object remove(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### remove(Object arg0, Object arg1) {#remove-java.lang.Object-java.lang.Object-}
+```
+public synchronized boolean remove(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### replace(K arg0, V arg1) {#replace-K-V-}
+```
+public synchronized V replace(K arg0, V arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+
+**Returns:**
+V
+### replace(K arg0, V arg1, V arg2) {#replace-K-V-V-}
+```
+public synchronized boolean replace(K arg0, V arg1, V arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | K |  |
+| arg1 | V |  |
+| arg2 | V |  |
+
+**Returns:**
+boolean
+### replace(Object arg0, Object arg1) {#replace-java.lang.Object-java.lang.Object-}
+```
+public synchronized Object replace(Object arg0, Object arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+
+**Returns:**
+java.lang.Object
+### replace(Object arg0, Object arg1, Object arg2) {#replace-java.lang.Object-java.lang.Object-java.lang.Object-}
+```
+public synchronized boolean replace(Object arg0, Object arg1, Object arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+| arg1 | java.lang.Object |  |
+| arg2 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### replaceAll(BiFunction<? super K,? super V,? extends V> arg0) {#replaceAll-java.util.function.BiFunction---super-K---super-V---extends-V--}
+```
+public synchronized void replaceAll(BiFunction<? super K,? super V,? extends V> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiFunction<? super K,? super V,? extends V> |  |
+
+### replaceAll(BiFunction<? super Object,? super Object,?> arg0) {#replaceAll-java.util.function.BiFunction---super-java.lang.Object---super-java.lang.Object----}
+```
+public synchronized void replaceAll(BiFunction<? super Object,? super Object,?> arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.util.function.BiFunction<? super java.lang.Object,? super java.lang.Object,?> |  |
+
+### save(OutputStream arg0, String arg1) {#save-java.io.OutputStream-java.lang.String-}
+```
+public void save(OutputStream arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+
+### setProperties(Properties properties) {#setProperties-java.util.Properties-}
+```
+public void setProperties(Properties properties)
+```
+
+
+기본값을 포함한 속성을 이 UserProperties에 복사합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성들. |
+
+### setProperty(String key, boolean value) {#setProperty-java.lang.String-boolean-}
+```
+public Object setProperty(String key, boolean value)
+```
+
+
+boolean 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | boolean | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, double value) {#setProperty-java.lang.String-double-}
+```
+public Object setProperty(String key, double value)
+```
+
+
+double 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | double | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, float value) {#setProperty-java.lang.String-float-}
+```
+public Object setProperty(String key, float value)
+```
+
+
+float 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | float | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, int value) {#setProperty-java.lang.String-int-}
+```
+public Object setProperty(String key, int value)
+```
+
+
+integer 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | int | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, Color value) {#setProperty-java.lang.String-java.awt.Color-}
+```
+public Object setProperty(String key, Color value)
+```
+
+
+색상 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Color | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, Dimension value) {#setProperty-java.lang.String-java.awt.Dimension-}
+```
+public Object setProperty(String key, Dimension value)
+```
+
+
+크기 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Dimension | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, Insets value) {#setProperty-java.lang.String-java.awt.Insets-}
+```
+public Object setProperty(String key, Insets value)
+```
+
+
+인셋 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Insets | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, Rectangle value) {#setProperty-java.lang.String-java.awt.Rectangle-}
+```
+public Object setProperty(String key, Rectangle value)
+```
+
+
+rectangle 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Rectangle | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, AffineTransform value) {#setProperty-java.lang.String-java.awt.geom.AffineTransform-}
+```
+public Object setProperty(String key, AffineTransform value)
+```
+
+
+matrix 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.geom.AffineTransform | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, String value) {#setProperty-java.lang.String-java.lang.String-}
+```
+public Object setProperty(String key, String value)
+```
+
+
+string 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.lang.String | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(String key, String[] value) {#setProperty-java.lang.String-java.lang.String---}
+```
+public Object setProperty(String key, String[] value)
+```
+
+
+string 배열 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.lang.String[] | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, boolean value) {#setProperty-java.util.Properties-java.lang.String-boolean-}
+```
+public static Object setProperty(Properties properties, String key, boolean value)
+```
+
+
+지정된 속성 테이블에 boolean 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | boolean | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, double value) {#setProperty-java.util.Properties-java.lang.String-double-}
+```
+public static Object setProperty(Properties properties, String key, double value)
+```
+
+
+지정된 속성 테이블에 double 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | double | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, float value) {#setProperty-java.util.Properties-java.lang.String-float-}
+```
+public static Object setProperty(Properties properties, String key, float value)
+```
+
+
+지정된 속성 테이블에 float 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | float | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, int value) {#setProperty-java.util.Properties-java.lang.String-int-}
+```
+public static Object setProperty(Properties properties, String key, int value)
+```
+
+
+지정된 속성 테이블에 integer 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | int | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, Color value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Color-}
+```
+public static Object setProperty(Properties properties, String key, Color value)
+```
+
+
+지정된 속성 테이블에 color 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Color | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, Dimension value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Dimension-}
+```
+public static Object setProperty(Properties properties, String key, Dimension value)
+```
+
+
+지정된 속성 테이블에 dimension 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Dimension | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, Insets value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Insets-}
+```
+public static Object setProperty(Properties properties, String key, Insets value)
+```
+
+
+지정된 속성 테이블에 insets 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Insets | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, Rectangle value) {#setProperty-java.util.Properties-java.lang.String-java.awt.Rectangle-}
+```
+public static Object setProperty(Properties properties, String key, Rectangle value)
+```
+
+
+지정된 속성 테이블에 rectangle 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.Rectangle | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, AffineTransform value) {#setProperty-java.util.Properties-java.lang.String-java.awt.geom.AffineTransform-}
+```
+public static Object setProperty(Properties properties, String key, AffineTransform value)
+```
+
+
+지정된 속성 테이블에 matrix 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.awt.geom.AffineTransform | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### setProperty(Properties properties, String key, String[] value) {#setProperty-java.util.Properties-java.lang.String-java.lang.String---}
+```
+public static Object setProperty(Properties properties, String key, String[] value)
+```
+
+
+지정된 속성 테이블에 string array 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 속성들 | java.util.Properties | 속성 테이블. |
+| 키 | java.lang.String | 속성의 이름. |
+| 값 | java.lang.String[] | 속성의 값. |
+
+**Returns:**
+java.lang.Object - 속성.
+### size() {#size--}
+```
+public int size()
+```
+
+
+
+
+**Returns:**
+int
+### store(OutputStream arg0, String arg1) {#store-java.io.OutputStream-java.lang.String-}
+```
+public void store(OutputStream arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+
+### store(Writer arg0, String arg1) {#store-java.io.Writer-java.lang.String-}
+```
+public void store(Writer arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.Writer |  |
+| arg1 | java.lang.String |  |
+
+### storeToXML(OutputStream arg0, String arg1) {#storeToXML-java.io.OutputStream-java.lang.String-}
+```
+public void storeToXML(OutputStream arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+
+### storeToXML(OutputStream arg0, String arg1, String arg2) {#storeToXML-java.io.OutputStream-java.lang.String-java.lang.String-}
+```
+public void storeToXML(OutputStream arg0, String arg1, String arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.lang.String |  |
+
+### storeToXML(OutputStream arg0, String arg1, Charset arg2) {#storeToXML-java.io.OutputStream-java.lang.String-java.nio.charset.Charset-}
+```
+public void storeToXML(OutputStream arg0, String arg1, Charset arg2)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.io.OutputStream |  |
+| arg1 | java.lang.String |  |
+| arg2 | java.nio.charset.Charset |  |
+
+### stringPropertyNames() {#stringPropertyNames--}
+```
+public Set<String> stringPropertyNames()
+```
+
+
+
+
+**Returns:**
+java.util.Set<java.lang.String>
+### toString() {#toString--}
+```
+public synchronized String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### values() {#values--}
+```
+public Collection<Object> values()
+```
+
+
+
+
+**Returns:**
+java.util.Collection<java.lang.Object>
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.features.EventBasedModifications/_index.md
+++ b/korean/java/com.aspose.xps.features.EventBasedModifications/_index.md
@@ -1,0 +1,26 @@
+---
+title: "com.aspose.xps.features.EventBasedModifications"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.xps.features.EventBasedModifications 패키지는 XPS 문서의 이벤트 기반 수정과 관련된 클래스를 제공합니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.xps.features.eventbasedmodifications/
+---
+
+**com.aspose.xps.features.EventBasedModifications** 패키지는 XPS 문서의 이벤트 기반 수정과 관련된 클래스를 제공합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [BeforePageSavingEventHandler](../com.aspose.xps.features.eventbasedmodifications/beforepagesavingeventhandler) | 페이지 저장 전 이벤트 핸들러를 위한 기본 클래스. |
+| [BeforeSavingEventArgs<T>](../com.aspose.xps.features.eventbasedmodifications/beforesavingeventargs) | 다양한 저장 전 이벤트의 인수를 위한 기본 클래스를 정의합니다. |
+| [PageAPI](../com.aspose.xps.features.eventbasedmodifications/pageapi) | 이 **Page** 요소 수정 API. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IBeforeSavingEventHandler<T>](../com.aspose.xps.features.eventbasedmodifications/ibeforesavingeventhandler) | 공통 저장 전 이벤트 핸들러 인터페이스를 정의합니다. |
+| [IModificationAPI](../com.aspose.xps.features.eventbasedmodifications/imodificationapi) | 어떤 XPS 요소의 수정 API에 대한 기본 인터페이스. |

--- a/korean/java/com.aspose.xps.features.EventBasedModifications/beforepagesavingeventhandler/_index.md
+++ b/korean/java/com.aspose.xps.features.EventBasedModifications/beforepagesavingeventhandler/_index.md
@@ -1,0 +1,154 @@
+---
+title: "BeforePageSavingEventHandler"
+second_title: "Aspose.Page용 Java API 참조"
+description: "페이지 저장 전 이벤트 핸들러를 위한 기본 클래스."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.features.eventbasedmodifications/beforepagesavingeventhandler/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+com.aspose.xps.features.EventBasedModifications.IBeforeSavingEventHandler
+```
+public abstract class BeforePageSavingEventHandler implements EventBasedModifications.IBeforeSavingEventHandler<EventBasedModifications.PageAPI>
+```
+
+페이지 저장 전 이벤트 핸들러를 위한 기본 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BeforePageSavingEventHandler()](#BeforePageSavingEventHandler--) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [handle(EventBasedModifications.BeforeSavingEventArgs<EventBasedModifications.PageAPI> args)](#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-com.aspose.xps.features.EventBasedModifications.PageAPI--) | 이벤트를 처리합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BeforePageSavingEventHandler() {#BeforePageSavingEventHandler--}
+```
+public BeforePageSavingEventHandler()
+```
+
+
+새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### handle(EventBasedModifications.BeforeSavingEventArgs<EventBasedModifications.PageAPI> args) {#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-com.aspose.xps.features.EventBasedModifications.PageAPI--}
+```
+public abstract void handle(EventBasedModifications.BeforeSavingEventArgs<EventBasedModifications.PageAPI> args)
+```
+
+
+이벤트를 처리합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| args | com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs<com.aspose.xps.features.EventBasedModifications.PageAPI> | 이벤트 인수. |
+
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.features.EventBasedModifications/beforesavingeventargs/_index.md
+++ b/korean/java/com.aspose.xps.features.EventBasedModifications/beforesavingeventargs/_index.md
@@ -1,0 +1,179 @@
+---
+title: "BeforeSavingEventArgs"
+second_title: "Aspose.Page용 Java API 참조"
+description: "다양한 저장 전 이벤트의 인수를 위한 기본 클래스를 정의합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.features.eventbasedmodifications/beforesavingeventargs/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class BeforeSavingEventArgs<T>
+```
+
+다양한 저장 전 이벤트의 인수를 위한 기본 클래스를 정의합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAbsolutePageNumber()](#getAbsolutePageNumber--) | XPS 패키지 내 모든 문서에 대한 현재 절대 페이지 번호를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getDocumentNumber()](#getDocumentNumber--) | XPS 패키지 내 현재 문서 번호를 반환합니다. |
+| [getElementAPI()](#getElementAPI--) | 저장될 요소의 수정 API를 반환합니다. |
+| [getOutputPageNumber()](#getOutputPageNumber--) | 현재 출력 번호를 반환합니다. |
+| [getRelativePageNumber()](#getRelativePageNumber--) | XPS 패키지 내 현재 문서에 상대적인 현재 페이지 번호를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAbsolutePageNumber() {#getAbsolutePageNumber--}
+```
+public int getAbsolutePageNumber()
+```
+
+
+XPS 패키지 내 모든 문서에 대한 현재 절대 페이지 번호를 반환합니다.
+
+**Returns:**
+int - XPS 패키지 내 모든 문서에 대한 현재 절대 페이지 번호.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDocumentNumber() {#getDocumentNumber--}
+```
+public int getDocumentNumber()
+```
+
+
+XPS 패키지 내 현재 문서 번호를 반환합니다.
+
+**Returns:**
+int - XPS 패키지 내 현재 문서 번호.
+### getElementAPI() {#getElementAPI--}
+```
+public T getElementAPI()
+```
+
+
+저장될 요소의 수정 API를 반환합니다.
+
+**Returns:**
+T - 저장될 요소의 수정 API.
+### getOutputPageNumber() {#getOutputPageNumber--}
+```
+public int getOutputPageNumber()
+```
+
+
+현재 출력 번호를 반환합니다. **PageNumbers** 저장 옵션이 지정된 경우 **AbsolutePageNumber**와 다릅니다.
+
+**Returns:**
+int - 현재 출력 번호.
+### getRelativePageNumber() {#getRelativePageNumber--}
+```
+public int getRelativePageNumber()
+```
+
+
+XPS 패키지 내 현재 문서에 상대적인 현재 페이지 번호를 반환합니다.
+
+**Returns:**
+int - XPS 패키지 내 현재 문서에 상대적인 현재 페이지 번호.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.features.EventBasedModifications/ibeforesavingeventhandler/_index.md
+++ b/korean/java/com.aspose.xps.features.EventBasedModifications/ibeforesavingeventhandler/_index.md
@@ -1,0 +1,30 @@
+---
+title: "IBeforeSavingEventHandler"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 저장 전 이벤트 핸들러 인터페이스를 정의합니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.features.eventbasedmodifications/ibeforesavingeventhandler/
+---```
+public interface IBeforeSavingEventHandler<T>
+```
+
+Defines the common before-saving event handler interface.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [handle(EventBasedModifications.BeforeSavingEventArgs<T> args)](#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-T--) | Handles the event. |
+### handle(EventBasedModifications.BeforeSavingEventArgs<T> args) {#handle-com.aspose.xps.features.EventBasedModifications.BeforeSavingEventArgs-T--}
+```
+public abstract void handle(EventBasedModifications.BeforeSavingEventArgs<T> args)
+```
+
+
+Handles the event.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| args | [BeforeSavingEventArgs](../../com.aspose.xps.features.eventbasedmodifications/beforesavingeventargs) | Event arguments. |
+

--- a/korean/java/com.aspose.xps.features.EventBasedModifications/imodificationapi/_index.md
+++ b/korean/java/com.aspose.xps.features.EventBasedModifications/imodificationapi/_index.md
@@ -1,0 +1,12 @@
+---
+title: "IModificationAPI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 XPS 요소 수정 API를 위한 기본 인터페이스."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.features.eventbasedmodifications/imodificationapi/
+---```
+public interface IModificationAPI
+```
+
+The basic interface for any XPS element's modification API.

--- a/korean/java/com.aspose.xps.features.EventBasedModifications/pageapi/_index.md
+++ b/korean/java/com.aspose.xps.features.EventBasedModifications/pageapi/_index.md
@@ -1,0 +1,1093 @@
+---
+title: "PageAPI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Page 요소 수정 API."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.features.eventbasedmodifications/pageapi/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.xps.features.EventBasedModifications.IModificationAPI](../../com.aspose.xps.features.eventbasedmodifications/imodificationapi)
+```
+public class PageAPI implements EventBasedModifications.IModificationAPI
+```
+
+이 **Page** 요소 수정 API.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>add(T element)](#-T-add-T-) | 콘텐츠 요소 (Canvas, Path, 또는 Glyphs)를 추가합니다 |
+| [<T>insert(int index, T element)](#-T-insert-int-T-) | 페이지에 요소 (Canvas, Path, 또는 Glyphs)를 인덱스 위치에 삽입합니다 |
+| [<T>remove(T element)](#-T-remove-T-) | 페이지에서 요소를 제거합니다 |
+| [addCanvas()](#addCanvas--) | 페이지에 새 canvas를 추가합니다 |
+| [addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 페이지에 새 glyphs를 추가합니다 |
+| [addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 페이지에 새 glyphs를 추가합니다 |
+| [addOutlineEntry(String description, int outlineLevel, int targetPageNumber)](#addOutlineEntry-java.lang.String-int-int-) | 문서에 개요 항목을 추가합니다 |
+| [addPath(XpsPathGeometry data)](#addPath-com.aspose.xps.XpsPathGeometry-) | 페이지에 새 path를 추가합니다 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-) | 새 스트로크된 타원 호 세그먼트를 생성합니다 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-) | 새 타원 호 세그먼트를 생성합니다 |
+| [createCanvas()](#createCanvas--) | 새 canvas를 생성합니다 |
+| [createColor(XpsIccProfile iccProfile, float[] components)](#createColor-com.aspose.xps.XpsIccProfile-float...-) | ICC 기반 색 공간에서 새 색을 생성합니다 |
+| [createColor(float r, float g, float b)](#createColor-float-float-float-) | scRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(float a, float r, float g, float b)](#createColor-float-float-float-float-) | scRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(int r, int g, int b)](#createColor-int-int-int-) | sRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(int a, int r, int g, int b)](#createColor-int-int-int-int-) | sRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(Color color)](#createColor-java.awt.Color-) | 새 색을 생성합니다 |
+| [createColor(String path, float[] components)](#createColor-java.lang.String-float...-) | ICC 기반 색 공간에서 새 색을 생성합니다 |
+| [createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 새 glyphs를 생성합니다 |
+| [createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 새 glyphs를 생성합니다 |
+| [createGradientStop(XpsColor color, float offset)](#createGradientStop-com.aspose.xps.XpsColor-float-) | 새 그라디언트 스톱을 생성합니다 |
+| [createGradientStop(Color color, float offset)](#createGradientStop-java.awt.Color-float-) | 새 그라디언트 스톱을 생성합니다 |
+| [createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 새 이미지 브러시를 생성합니다 |
+| [createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 새 이미지 브러시를 생성합니다 |
+| [createLinearGradientBrush(Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-) | 새 선형 그라디언트 브러시를 생성합니다 |
+| [createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-) | 새 선형 그라디언트 브러시를 생성합니다 |
+| [createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)](#createMatrix-float-float-float-float-float-float-) | 새 어파인 변환 행렬을 생성합니다 |
+| [createPath(XpsPathGeometry data)](#createPath-com.aspose.xps.XpsPathGeometry-) | 새 path를 생성합니다 |
+| [createPathFigure(Point2D startPoint)](#createPathFigure-java.awt.geom.Point2D-) | 새 열린 path 피규어를 생성합니다 |
+| [createPathFigure(Point2D startPoint, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-boolean-) | 새 path 피규어를 생성합니다 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--) | 새 열린 path 피규어를 생성합니다 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-) | 새 path 피규어를 생성합니다 |
+| [createPathGeometry()](#createPathGeometry--) | 새 path 기하학을 생성합니다 |
+| [createPathGeometry(String abbreviatedGeometry)](#createPathGeometry-java.lang.String-) | 축약형으로 지정된 새로운 경로 기하학을 생성합니다. |
+| [createPathGeometry(List<XpsPathFigure> pathFigures)](#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--) | 지정된 경로 도형 목록으로 새로운 경로 기하학을 생성합니다. |
+| [createPolyBezierSegment(Point2D[] points)](#createPolyBezierSegment-java.awt.geom.Point2D---) | 새로운 스트로크된 3차 베지어 곡선 집합을 생성합니다. |
+| [createPolyBezierSegment(Point2D[] points, boolean isStroked)](#createPolyBezierSegment-java.awt.geom.Point2D---boolean-) | 새로운 3차 베지어 곡선 집합을 생성합니다. |
+| [createPolyLineSegment(Point2D[] points)](#createPolyLineSegment-java.awt.geom.Point2D---) | 임의 개수의 개별 정점을 포함하는 새로운 스트로크된 다각형 그리기를 생성합니다. |
+| [createPolyLineSegment(Point2D[] points, boolean isStroked)](#createPolyLineSegment-java.awt.geom.Point2D---boolean-) | 임의 개수의 개별 정점을 포함하는 새로운 다각형 그리기를 생성합니다. |
+| [createPolyQuadraticBezierSegment(Point2D[] points)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---) | 지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 스트로크된 2차 베지어 곡선 집합을 생성합니다. |
+| [createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-) | 지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 2차 베지어 곡선 집합을 생성합니다. |
+| [createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 새로운 방사형 그라디언트 브러시를 생성합니다. |
+| [createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 새로운 방사형 그라디언트 브러시를 생성합니다. |
+| [createSolidColorBrush(XpsColor color)](#createSolidColorBrush-com.aspose.xps.XpsColor-) | 새로운 단색 브러시를 생성합니다. |
+| [createSolidColorBrush(Color color)](#createSolidColorBrush-java.awt.Color-) | 새로운 단색 브러시를 생성합니다. |
+| [createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)](#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 새로운 비주얼 브러시를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | 페이지의 높이를 반환합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [getPageCount()](#getPageCount--) | 활성 문서의 페이지 수를 반환합니다. |
+| [getTotalPageCount()](#getTotalPageCount--) | XPS 문서 내부 모든 문서의 전체 페이지 수를 반환합니다. |
+| [getUtils()](#getUtils--) | 공식 XPS 조작 API를 넘어서는 유틸리티를 제공하는 객체를 가져옵니다. |
+| [getWidth()](#getWidth--) | 페이지의 너비를 반환합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [hashCode()](#hashCode--) |  |
+| [insertCanvas(int index)](#insertCanvas-int-) | 페이지의  index  위치에 새로운 캔버스를 삽입합니다. |
+| [insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)](#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 페이지의  index  위치에 새로운 글리프를 삽입합니다. |
+| [insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 페이지의  index  위치에 새로운 글리프를 삽입합니다. |
+| [insertPath(int index, XpsPathGeometry data)](#insertPath-int-com.aspose.xps.XpsPathGeometry-) | 페이지의  index  위치에 새로운 경로를 삽입합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | 페이지에서  index  위치에 있는 요소를 제거합니다. |
+| [setHeight(float value)](#setHeight-float-) | 페이지의 높이를 설정합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [setWidth(float value)](#setWidth-float-) | 페이지의 너비를 설정합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>add(T element) {#-T-add-T-}
+```
+public T <T>add(T element)
+```
+
+
+콘텐츠 요소 (Canvas, Path, 또는 Glyphs)를 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 요소 | T | 추가할 요소입니다. |
+
+**Returns:**
+T - 추가된 요소.
+### <T>insert(int index, T element) {#-T-insert-int-T-}
+```
+public T <T>insert(int index, T element)
+```
+
+
+페이지에 요소 (Canvas, Path, 또는 Glyphs)를 인덱스 위치에 삽입합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소를 삽입해야 하는 위치. |
+| 요소 | T | 삽입할 요소. |
+
+**Returns:**
+T - 삽입된 요소.
+### <T>remove(T element) {#-T-remove-T-}
+```
+public T <T>remove(T element)
+```
+
+
+페이지에서 요소를 제거합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 요소 | T | 제거할 요소. |
+
+**Returns:**
+T - 제거된 요소.
+### addCanvas() {#addCanvas--}
+```
+public XpsCanvas addCanvas()
+```
+
+
+페이지에 새 canvas를 추가합니다
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Added canvas.
+### addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+페이지에 새 glyphs를 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | 폰트 리소스. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+페이지에 새 glyphs를 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addOutlineEntry(String description, int outlineLevel, int targetPageNumber) {#addOutlineEntry-java.lang.String-int-int-}
+```
+public void addOutlineEntry(String description, int outlineLevel, int targetPageNumber)
+```
+
+
+문서에 개요 항목을 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 설명 | java.lang.String | 항목 설명. |
+| outlineLevel | int | 개요 수준. |
+| targetPageNumber | int | 대상 페이지 번호. |
+
+### addPath(XpsPathGeometry data) {#addPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath addPath(XpsPathGeometry data)
+```
+
+
+페이지에 새 path를 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Added path.
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)
+```
+
+
+새 스트로크된 타원 호 세그먼트를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | java.awt.geom.Point2D | 타원 호의 끝점. |
+| 크기 | java.awt.geom.Dimension2D | 타원 호의 x와 y 반지름을 x,y 쌍으로 나타냅니다. |
+| rotationAngle | float | 현재 좌표계에 대해 타원이 어떻게 회전되는지를 나타냅니다. |
+| isLargeArc | boolean | 호가 180도 이상을 휘어 그려지는지 여부를 결정합니다. |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 호가 그려지는 방향입니다. |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)
+```
+
+
+새 타원 호 세그먼트를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | java.awt.geom.Point2D | 타원 호의 끝점. |
+| 크기 | java.awt.geom.Dimension2D | 타원 호의 x와 y 반지름을 x,y 쌍으로 나타냅니다. |
+| rotationAngle | float | 현재 좌표계에 대해 타원이 어떻게 회전되는지를 나타냅니다. |
+| isLargeArc | boolean | 호가 180도 이상을 휘어 그려지는지 여부를 결정합니다. |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 호가 그려지는 방향입니다. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createCanvas() {#createCanvas--}
+```
+public XpsCanvas createCanvas()
+```
+
+
+새 canvas를 생성합니다
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - New canvas.
+### createColor(XpsIccProfile iccProfile, float[] components) {#createColor-com.aspose.xps.XpsIccProfile-float...-}
+```
+public XpsColor createColor(XpsIccProfile iccProfile, float[] components)
+```
+
+
+ICC 기반 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| iccProfile | [XpsIccProfile](../../com.aspose.xps/xpsiccprofile) | ICC 프로파일 리소스입니다. |
+| components | float[] | 색상 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float r, float g, float b) {#createColor-float-float-float-}
+```
+public XpsColor createColor(float r, float g, float b)
+```
+
+
+scRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| r | float | 빨간색 구성 요소입니다. |
+| g | float | 녹색 구성 요소입니다. |
+| b | float | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float a, float r, float g, float b) {#createColor-float-float-float-float-}
+```
+public XpsColor createColor(float a, float r, float g, float b)
+```
+
+
+scRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | float | 알파 색상 구성 요소입니다. |
+| r | float | 빨간색 구성 요소입니다. |
+| g | float | 녹색 구성 요소입니다. |
+| b | float | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int r, int g, int b) {#createColor-int-int-int-}
+```
+public XpsColor createColor(int r, int g, int b)
+```
+
+
+sRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| r | int | 빨간색 구성 요소입니다. |
+| g | int | 녹색 구성 요소입니다. |
+| b | int | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int a, int r, int g, int b) {#createColor-int-int-int-int-}
+```
+public XpsColor createColor(int a, int r, int g, int b)
+```
+
+
+sRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | int | 알파 색상 구성 요소입니다. |
+| r | int | 빨간색 구성 요소입니다. |
+| g | int | 녹색 구성 요소입니다. |
+| b | int | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(Color color) {#createColor-java.awt.Color-}
+```
+public XpsColor createColor(Color color)
+```
+
+
+새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | java.awt.Color | RGB 색상에 대한 네이티브 색상 인스턴스입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(String path, float[] components) {#createColor-java.lang.String-float...-}
+```
+public XpsColor createColor(String path, float[] components)
+```
+
+
+ICC 기반 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.lang.String | ICC 프로파일 경로입니다. |
+| components | float[] | 색상 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+새 glyphs를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | 폰트 리소스. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+새 glyphs를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGradientStop(XpsColor color, float offset) {#createGradientStop-com.aspose.xps.XpsColor-float-}
+```
+public XpsGradientStop createGradientStop(XpsColor color, float offset)
+```
+
+
+새 그라디언트 스톱을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | 그라디언트 정지 색상입니다. |
+| 오프셋 | float | 그라디언트 오프셋. |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createGradientStop(Color color, float offset) {#createGradientStop-java.awt.Color-float-}
+```
+public XpsGradientStop createGradientStop(Color color, float offset)
+```
+
+
+새 그라디언트 스톱을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | java.awt.Color | 그라디언트 정지 색상입니다. |
+| 오프셋 | float | 그라디언트 오프셋. |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+새 이미지 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | [XpsImage](../../com.aspose.xps/xpsimage) | 이미지 리소스입니다. |
+| 뷰박스 | java.awt.geom.Rectangle2D | 브러시 소스 콘텐츠의 위치와 차원입니다. |
+| 뷰포트 | java.awt.geom.Rectangle2D | 프라임 브러시 타일이 포함된 좌표 공간에서 (반복적으로) 적용되어 브러시가 적용되는 영역을 채우는 영역. |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+새 이미지 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imagePath | java.lang.String | 브러시 타일로 사용할 이미지의 경로입니다. |
+| 뷰박스 | java.awt.geom.Rectangle2D | 브러시 소스 콘텐츠의 위치와 차원입니다. |
+| 뷰포트 | java.awt.geom.Rectangle2D | 프라임 브러시 타일이 포함된 좌표 공간에서 (반복적으로) 적용되어 브러시가 적용되는 영역을 채우는 영역. |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createLinearGradientBrush(Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(Point2D startPoint, Point2D endPoint)
+```
+
+
+새 선형 그라디언트 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 선형 그라디언트의 시작점입니다. |
+| endPoint | java.awt.geom.Point2D | 선형 그라디언트의 끝점입니다. |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)
+```
+
+
+새 선형 그라디언트 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| gradientStops | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트 스톱 목록입니다. |
+| startPoint | java.awt.geom.Point2D | 선형 그라디언트의 시작점입니다. |
+| endPoint | java.awt.geom.Point2D | 선형 그라디언트의 끝점입니다. |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createMatrix(float m11, float m12, float m21, float m22, float m31, float m32) {#createMatrix-float-float-float-float-float-float-}
+```
+public XpsMatrix createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)
+```
+
+
+새 어파인 변환 행렬을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| m11 | float | 요소 11. |
+| m12 | float | 요소 12. |
+| m21 | float | 요소 21. |
+| m22 | float | 요소 22. |
+| m31 | float | 요소 31. |
+| m32 | float | 요소 32. |
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - New affine transformation matrix.
+### createPath(XpsPathGeometry data) {#createPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath createPath(XpsPathGeometry data)
+```
+
+
+새 path를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - New path.
+### createPathFigure(Point2D startPoint) {#createPathFigure-java.awt.geom.Point2D-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint)
+```
+
+
+새 열린 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, boolean isClosed)
+```
+
+
+새 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+| isClosed | boolean | 경로가 닫혀 있는지 여부를 지정합니다. true로 설정하면 스트로크가 "closed"로 그려지며, 즉 경로 도형의 마지막 세그먼트의 마지막 점이 StartPoint 속성에 지정된 점과 연결됩니다. 그렇지 않으면 스트로크가 "open"으로 그려지고 마지막 점이 시작점과 연결되지 않습니다. 이 속성은 스트로크를 지정하는 Path 요소에서 경로 도형이 사용될 때만 적용됩니다. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)
+```
+
+
+새 열린 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | 경로 세그먼트 목록. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)
+```
+
+
+새 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | 경로 세그먼트 목록. |
+| isClosed | boolean | 경로가 닫혀 있는지 여부를 지정합니다. true로 설정하면 스트로크가 "closed"로 그려지며, 즉 경로 도형의 마지막 세그먼트의 마지막 점이 StartPoint 속성에 지정된 점과 연결됩니다. 그렇지 않으면 스트로크가 "open"으로 그려지고 마지막 점이 시작점과 연결되지 않습니다. 이 속성은 스트로크를 지정하는 Path 요소에서 경로 도형이 사용될 때만 적용됩니다. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathGeometry() {#createPathGeometry--}
+```
+public XpsPathGeometry createPathGeometry()
+```
+
+
+새 path 기하학을 생성합니다
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(String abbreviatedGeometry) {#createPathGeometry-java.lang.String-}
+```
+public XpsPathGeometry createPathGeometry(String abbreviatedGeometry)
+```
+
+
+축약형으로 지정된 새로운 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| abbreviatedGeometry | java.lang.String | 경로 기하학의 축약형. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(List<XpsPathFigure> pathFigures) {#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--}
+```
+public XpsPathGeometry createPathGeometry(List<XpsPathFigure> pathFigures)
+```
+
+
+지정된 경로 도형 목록으로 새로운 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pathFigures | java.util.List<com.aspose.xps.XpsPathFigure> | 경로 도형 목록. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPolyBezierSegment(Point2D[] points) {#createPolyBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points)
+```
+
+
+새로운 스트로크된 3차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 B?베지어 세그먼트에 대한 제어점. |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyBezierSegment(Point2D[] points, boolean isStroked) {#createPolyBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+새로운 3차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 B?베지어 세그먼트에 대한 제어점. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyLineSegment(Point2D[] points) {#createPolyLineSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points)
+```
+
+
+임의 개수의 개별 정점을 포함하는 새로운 스트로크된 다각형 그리기를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 폴리라인 세그먼트를 정의하는 다중 세그먼트에 대한 좌표 집합. |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyLineSegment(Point2D[] points, boolean isStroked) {#createPolyLineSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points, boolean isStroked)
+```
+
+
+임의 개수의 개별 정점을 포함하는 새로운 다각형 그리기를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 폴리라인 세그먼트를 정의하는 다중 세그먼트에 대한 좌표 집합. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyQuadraticBezierSegment(Point2D[] points) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points)
+```
+
+
+지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 스트로크된 2차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 2차 B?베지어 세그먼트에 대한 제어점. |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 2차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 2차 B?베지어 세그먼트에 대한 제어점. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+새로운 방사형 그라디언트 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 방사형 그라디언트의 중심점(즉, 타원의 중심). |
+| gradientOrigin | java.awt.geom.Point2D | 방사형 그라디언트의 원점. |
+| radiusX | float | 방사형 그라디언트를 정의하는 타원의 x 차원 반경. |
+| radiusY | float | 방사형 그라디언트를 정의하는 타원의 y 차원 반경. |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+새로운 방사형 그라디언트 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| gradientStops | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트 스톱 목록입니다. |
+| center | java.awt.geom.Point2D | 방사형 그라디언트의 중심점(즉, 타원의 중심). |
+| gradientOrigin | java.awt.geom.Point2D | 방사형 그라디언트의 원점. |
+| radiusX | float | 방사형 그라디언트를 정의하는 타원의 x 차원 반경. |
+| radiusY | float | 방사형 그라디언트를 정의하는 타원의 y 차원 반경. |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createSolidColorBrush(XpsColor color) {#createSolidColorBrush-com.aspose.xps.XpsColor-}
+```
+public XpsSolidColorBrush createSolidColorBrush(XpsColor color)
+```
+
+
+새로운 단색 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | 채워진 요소의 색상. |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createSolidColorBrush(Color color) {#createSolidColorBrush-java.awt.Color-}
+```
+public XpsSolidColorBrush createSolidColorBrush(Color color)
+```
+
+
+새로운 단색 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | java.awt.Color | 채워진 요소의 색상. |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport) {#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsVisualBrush createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+새로운 비주얼 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| element | [XpsContentElement](../../com.aspose.xps/xpscontentelement) | 시각적 브러시의 Visual 속성을 위한 XPS 요소 (Canvas, Path, 또는 Glyphs). |
+| 뷰박스 | java.awt.geom.Rectangle2D | 브러시 소스 콘텐츠의 위치와 차원입니다. |
+| 뷰포트 | java.awt.geom.Rectangle2D | 프라임 브러시 타일이 포함된 좌표 공간에서 (반복적으로) 적용되어 브러시가 적용되는 영역을 채우는 영역. |
+
+**Returns:**
+[XpsVisualBrush](../../com.aspose.xps/xpsvisualbrush) - New visual brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+페이지의 높이를 반환합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Returns:**
+float - 페이지의 높이.
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+활성 문서의 페이지 수를 반환합니다.
+
+**Returns:**
+int - 활성 문서의 페이지 수.
+### getTotalPageCount() {#getTotalPageCount--}
+```
+public int getTotalPageCount()
+```
+
+
+XPS 문서 내부 모든 문서의 전체 페이지 수를 반환합니다.
+
+**Returns:**
+int - XPS 문서 내 모든 문서의 총 페이지 수.
+### getUtils() {#getUtils--}
+```
+public DocumentUtils getUtils()
+```
+
+
+공식 XPS 조작 API를 넘어서는 유틸리티를 제공하는 객체를 가져옵니다.
+
+**Returns:**
+[DocumentUtils](../../com.aspose.xps/documentutils) - The object that provides utilities beyond the formal XPS manipulation API.
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+페이지의 너비를 반환합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Returns:**
+float - 페이지의 너비.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insertCanvas(int index) {#insertCanvas-int-}
+```
+public XpsCanvas insertCanvas(int index)
+```
+
+
+페이지의  index  위치에 새로운 캔버스를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 캔버스를 삽입해야 하는 위치. |
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Inserted canvas.
+### insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString) {#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)
+```
+
+
+페이지의  index  위치에 새로운 글리프를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 글리프를 삽입해야 하는 위치. |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | 폰트 리소스. |
+| fontSize | float | 폰트 크기. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+페이지의  index  위치에 새로운 글리프를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 글리프를 삽입해야 하는 위치. |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertPath(int index, XpsPathGeometry data) {#insertPath-int-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath insertPath(int index, XpsPathGeometry data)
+```
+
+
+페이지의  index  위치에 새로운 경로를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 경로를 삽입해야 하는 위치. |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Inserted path.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public XpsContentElement removeAt(int index)
+```
+
+
+페이지에서  index  위치에 있는 요소를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소를 제거해야 하는 위치. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Removed element.
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+페이지의 높이를 설정합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 페이지의 높이. |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+페이지의 너비를 설정합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 페이지의 너비. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.features.HyperlinkCollector/_index.md
+++ b/korean/java/com.aspose.xps.features.HyperlinkCollector/_index.md
@@ -1,0 +1,17 @@
+---
+title: "com.aspose.xps.features.HyperlinkCollector"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.xps.features.HyperlinkCollector 패키지는 하이퍼링크를 포함하는 XPS 요소를 수집하는 클래스를 제공합니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.xps.features.hyperlinkcollector/
+---
+
+**com.aspose.xps.features.HyperlinkCollector** 패키지는 하이퍼링크를 포함하는 XPS 요소를 수집하기 위한 클래스를 제공합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [HyperlinkCollector](../com.aspose.xps.features.hyperlinkcollector/hyperlinkcollector) | 이 클래스는 XPS 문서의 현재 페이지에서 하이퍼링크가 포함된 XPS 요소를 수집합니다. |

--- a/korean/java/com.aspose.xps.features.HyperlinkCollector/hyperlinkcollector/_index.md
+++ b/korean/java/com.aspose.xps.features.HyperlinkCollector/hyperlinkcollector/_index.md
@@ -1,0 +1,157 @@
+---
+title: "HyperlinkCollector"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 XPS 문서의 현재 페이지에서 하이퍼링크가 포함된 XPS 요소를 수집합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.features.hyperlinkcollector/hyperlinkcollector/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class HyperlinkCollector
+```
+
+이 클래스는 XPS 문서의 현재 페이지에서 하이퍼링크가 포함된 XPS 요소를 수집합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>collectHyperlinks(XpsDocument document, Class<T> cls)](#-T-collectHyperlinks-com.aspose.xps.XpsDocument-java.lang.Class-T--) | 특정 유형의 하이퍼링크가 있는 XPS 요소를 수집합니다. |
+| [collectHyperlinks(XpsDocument document)](#collectHyperlinks-com.aspose.xps.XpsDocument-) | 모든 유형의 하이퍼링크가 있는 XPS 요소를 수집합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>collectHyperlinks(XpsDocument document, Class<T> cls) {#-T-collectHyperlinks-com.aspose.xps.XpsDocument-java.lang.Class-T--}
+```
+public static Collection<XpsHyperlinkElement> <T>collectHyperlinks(XpsDocument document, Class<T> cls)
+```
+
+
+특정 유형의 하이퍼링크가 있는 XPS 요소를 수집합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| document | [XpsDocument](../../com.aspose.xps/xpsdocument) | XPS 문서입니다. |
+| cls | java.lang.Class<T> | 필터링할 하이퍼링크 대상 유형에 해당하는 클래스 객체입니다. |
+
+**Returns:**
+java.util.Collection<com.aspose.xps.XpsHyperlinkElement> - 하이퍼링크된 XPS 요소를 포함하는 컬렉션입니다.
+### collectHyperlinks(XpsDocument document) {#collectHyperlinks-com.aspose.xps.XpsDocument-}
+```
+public static Collection<XpsHyperlinkElement> collectHyperlinks(XpsDocument document)
+```
+
+
+모든 유형의 하이퍼링크가 있는 XPS 요소를 수집합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| document | [XpsDocument](../../com.aspose.xps/xpsdocument) | XPS 문서입니다. |
+
+**Returns:**
+java.util.Collection<com.aspose.xps.XpsHyperlinkElement> - 하이퍼링크된 XPS 요소를 포함하는 컬렉션입니다.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/_index.md
+++ b/korean/java/com.aspose.xps.metadata/_index.md
@@ -1,0 +1,248 @@
+---
+title: "com.aspose.xps.metadata"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.xps.metadata 패키지는 XPS 문서의 메타데이터를 설명하는 클래스를 제공합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.xps.metadata/
+---
+
+**com.aspose.xps.metadata** 패키지는 XPS 문서의 메타데이터를 설명하는 클래스를 제공합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [Collate](../com.aspose.xps.metadata/collate) | DocumentCollate 및 JobCollateAllDocuments 기능 클래스의 기본 클래스입니다. |
+| [Collate.CollateOption](../com.aspose.xps.metadata/collate.collateoption) | DocumentCollate 및 JobCollateAllDocuments 기능 옵션을 설명합니다. |
+| [CompositePrintTicketElement](../com.aspose.xps.metadata/compositeprintticketelement) | 다른 요소를 포함할 수 있는 복합 Print Schema 요소가 될 수 있는 클래스들의 기본 클래스입니다. |
+| [DecimalValue](../com.aspose.xps.metadata/decimalvalue) | PrintTicket 문서에서 Decimal 값을 캡슐화하는 클래스입니다. |
+| [DocumentBannerSheet](../com.aspose.xps.metadata/documentbannersheet) | 특정 문서에 출력될 배너 시트를 설명합니다. |
+| [DocumentBannerSheet.BannerSheetOption](../com.aspose.xps.metadata/documentbannersheet.bannersheetoption) | DocumentBannerSheet 기능의 옵션을 나타냅니다. |
+| [DocumentBannerSheetSource](../com.aspose.xps.metadata/documentbannersheetsource) | 사용자 정의 배너 시트의 소스를 지정합니다. |
+| [DocumentBinding](../com.aspose.xps.metadata/documentbinding) | 제본 방법을 설명합니다. |
+| [DocumentBinding.BindingGutter](../com.aspose.xps.metadata/documentbinding.bindinggutter) | BindingGutter 점수 속성 값을 정수값으로 지정하거나 DocumentBindingGutter 매개변수를 참조하여 지정하는 방법을 설명합니다. |
+| [DocumentBinding.BindingOption](../com.aspose.xps.metadata/documentbinding.bindingoption) | DocumentBinding 기능의 옵션을 나타냅니다. |
+| [DocumentBindingGutter](../com.aspose.xps.metadata/documentbindinggutter) | 제본 여백의 너비를 지정합니다. |
+| [DocumentCollate](../com.aspose.xps.metadata/documentcollate) | 출력의 정렬 특성을 설명합니다. |
+| [DocumentCopiesAllPages](../com.aspose.xps.metadata/documentcopiesallpages) | 문서 복사본 수를 지정합니다. |
+| [DocumentCoverBack](../com.aspose.xps.metadata/documentcoverback) | 뒷표지(끝) 시트를 설명합니다. |
+| [DocumentCoverBack.CoverBackOption](../com.aspose.xps.metadata/documentcoverback.coverbackoption) | DocumentCoverBack 기능 옵션을 설명합니다. |
+| [DocumentCoverBackSource](../com.aspose.xps.metadata/documentcoverbacksource) | 사용자 정의 뒷표지 시트의 소스를 지정합니다. |
+| [DocumentCoverFront](../com.aspose.xps.metadata/documentcoverfront) | 앞표지(시작) 시트를 설명합니다. |
+| [DocumentCoverFront.CoverFrontOption](../com.aspose.xps.metadata/documentcoverfront.coverfrontoption) | DocumentCoverFront 기능 옵션을 설명합니다. |
+| [DocumentCoverFrontSource](../com.aspose.xps.metadata/documentcoverfrontsource) | 사용자 정의 앞표지 시트의 소스를 지정합니다. |
+| [DocumentDuplex](../com.aspose.xps.metadata/documentduplex) | 출력의 양면 인쇄 특성을 설명합니다. |
+| [DocumentHolePunch](../com.aspose.xps.metadata/documentholepunch) | 출력의 구멍 뚫기 특성을 설명합니다. |
+| [DocumentID](../com.aspose.xps.metadata/documentid) | 문서에 대한 고유 ID를 지정합니다. |
+| [DocumentImpositionColor](../com.aspose.xps.metadata/documentimpositioncolor) | 지정된 명명된 색상으로 라벨링된 애플리케이션 콘텐츠는 모든 색상 분리에서 반드시 표시되어야 합니다. |
+| [DocumentInputBin](../com.aspose.xps.metadata/documentinputbin) | 장치에 설치된 입력 빈 또는 장치가 지원하는 전체 빈 목록을 설명합니다. |
+| [DocumentNUp](../com.aspose.xps.metadata/documentnup) | 여러 논리 페이지를 하나의 물리 시트에 출력하고 포맷하는 방식을 설명합니다. |
+| [DocumentName](../com.aspose.xps.metadata/documentname) | 문서에 대한 설명 이름을 지정합니다. |
+| [DocumentOutputBin](../com.aspose.xps.metadata/documentoutputbin) | 장치에서 지원되는 모든 빈 목록을 설명합니다. |
+| [DocumentPageRanges](../com.aspose.xps.metadata/documentpageranges) | 문서의 출력 범위를 페이지 단위로 설명합니다. |
+| [DocumentPrintTicket](../com.aspose.xps.metadata/documentprintticket) | 문서 수준 인쇄 티켓을 캡슐화하는 클래스입니다. |
+| [DocumentRollCut](../com.aspose.xps.metadata/documentrollcut) | 롤 용지에 대한 절단 방법을 설명합니다. |
+| [DocumentSeparatorSheet](../com.aspose.xps.metadata/documentseparatorsheet) | 문서에 대한 분리 시트 사용을 설명합니다. |
+| [DocumentSeparatorSheet.DocumentSeparatorSheetOption](../com.aspose.xps.metadata/documentseparatorsheet.documentseparatorsheetoption) | DocumentSeparatorSheet 기능 옵션을 설명합니다. |
+| [DocumentStaple](../com.aspose.xps.metadata/documentstaple) | 출력의 스테이플링 특성을 설명합니다. |
+| [DocumentURI](../com.aspose.xps.metadata/documenturi) | 문서에 대한 통합 자원 식별자(URI)를 지정합니다. |
+| [Duplex](../com.aspose.xps.metadata/duplex) | JobDuplexAllDocumentsContiguously 및 DocumentDuplex 기능 클래스의 기본 클래스입니다. |
+| [Duplex.DuplexMode](../com.aspose.xps.metadata/duplex.duplexmode) | DuplexOption의 DuplexMode 점수 속성에 대한 가능한 값을 정의합니다. |
+| [Duplex.DuplexOption](../com.aspose.xps.metadata/duplex.duplexoption) | JobDuplexAllDocumentsContiguously 및 DocumentDuplex 기능 옵션을 설명합니다. |
+| [Feature](../com.aspose.xps.metadata/feature) | 공통 Print Schema 기능을 캡슐화하는 클래스입니다. |
+| [HolePunch](../com.aspose.xps.metadata/holepunch) | JobHolePunch 및 DocumentHolePunch 기능 클래스의 기본 클래스입니다. |
+| [HolePunch.HolePunchOption](../com.aspose.xps.metadata/holepunch.holepunchoption) | HolePunch 기능 옵션을 설명합니다. |
+| [IDProperty](../com.aspose.xps.metadata/idproperty) | JobID 및 DocumentID 속성 클래스의 기본 클래스입니다. |
+| [InputBin](../com.aspose.xps.metadata/inputbin) | JobInputBin, DocumentInputBin 및 PageInputBin 기능 클래스의 기본 클래스입니다. |
+| [InputBin.BinType](../com.aspose.xps.metadata/inputbin.bintype) | BinType 점수 속성 값에 대한 상수를 정의합니다. |
+| [InputBin.FeedDirection](../com.aspose.xps.metadata/inputbin.feeddirection) | FeedDirection 점수 속성 값에 대한 상수를 정의합니다. |
+| [InputBin.FeedFace](../com.aspose.xps.metadata/inputbin.feedface) | FeedFace 점수 속성 값에 대한 상수를 정의합니다. |
+| [InputBin.FeedType](../com.aspose.xps.metadata/inputbin.feedtype) | FeedType 점수 속성 값에 대한 상수를 정의합니다. |
+| [InputBin.InputBinOption](../com.aspose.xps.metadata/inputbin.inputbinoption) | JobInputBin, DocumentInputBin 및 PageInputBin 기능 옵션을 설명합니다. |
+| [InputBin.MediaCapacity](../com.aspose.xps.metadata/inputbin.mediacapacity) | MediaCapacity 점수 속성 값에 대한 상수를 정의하며, 해당 빈이 고용량 빈인지 여부를 지정합니다 (정성적). |
+| [InputBin.MediaPath](../com.aspose.xps.metadata/inputbin.mediapath) | MediaPath 점수 속성 값에 대한 상수를 정의합니다. |
+| [InputBin.MediaSheetCapacity](../com.aspose.xps.metadata/inputbin.mediasheetcapacity) | MediaSheetCapacity 점수 속성 값을 정의하며, 빈의 페이지 수(전체 수준)로 미디어 용량을 지정합니다. |
+| [InputBin.MediaSizeAutoSense](../com.aspose.xps.metadata/inputbin.mediasizeautosense) | MediaSizeAutoSense 점수 속성 값에 대한 상수를 정의합니다. |
+| [InputBin.MediaTypeAutoSense](../com.aspose.xps.metadata/inputbin.mediatypeautosense) | MediaTypeAutoSense 점수 속성 값에 대한 상수를 정의합니다. |
+| [IntegerParameterInit](../com.aspose.xps.metadata/integerparameterinit) | 모든 정수 매개변수 초기화기의 기본 클래스입니다. |
+| [IntegerValue](../com.aspose.xps.metadata/integervalue) | PrintTicket 문서에서 정수 값을 캡슐화하는 클래스입니다. |
+| [JobAccountingSheet](../com.aspose.xps.metadata/jobaccountingsheet) | 작업에 대해 출력될 회계 시트를 설명합니다. |
+| [JobAccountingSheet.JobAccountingSheetOption](../com.aspose.xps.metadata/jobaccountingsheet.jobaccountingsheetoption) | JobAccountingSheet 기능 옵션을 설명합니다. |
+| [JobBindAllDocuments](../com.aspose.xps.metadata/jobbindalldocuments) | 제본 방법을 설명합니다. |
+| [JobBindAllDocuments.BindingGutter](../com.aspose.xps.metadata/jobbindalldocuments.bindinggutter) | BindingGutter 점수 속성 값을 정수값으로 지정하거나 DocumentBindingGutter 매개변수를 참조하여 지정하는 방법을 설명합니다. |
+| [JobBindAllDocuments.BindingOption](../com.aspose.xps.metadata/jobbindalldocuments.bindingoption) | JobBindAllDocuments 기능 옵션을 설명합니다. |
+| [JobBindAllDocumentsGutter](../com.aspose.xps.metadata/jobbindalldocumentsgutter) | 제본 여백의 너비를 지정합니다. |
+| [JobCollateAllDocuments](../com.aspose.xps.metadata/jobcollatealldocuments) | 출력의 정렬 특성을 설명합니다. |
+| [JobComment](../com.aspose.xps.metadata/jobcomment) | 작업과 연결된 주석을 지정합니다. |
+| [JobCopiesAllDocuments](../com.aspose.xps.metadata/jobcopiesalldocuments) | 작업의 복사본 수를 지정합니다. |
+| [JobDeviceLanguage](../com.aspose.xps.metadata/jobdevicelanguage) | 드라이버에서 물리적 장치로 데이터를 전송하기 위해 지원되는 장치 언어를 설명합니다. |
+| [JobDeviceLanguage.JobDeviceLanguageOption](../com.aspose.xps.metadata/jobdevicelanguage.jobdevicelanguageoption) | JobDeviceLanguage 기능 옵션을 설명합니다. |
+| [JobDigitalSignatureProcessing](../com.aspose.xps.metadata/jobdigitalsignatureprocessing) | 전체 작업에 대한 디지털 서명 처리를 구성하는 방법을 설명합니다. |
+| [JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption](../com.aspose.xps.metadata/jobdigitalsignatureprocessing.jobdigitalsignatureprocessingoption) | JobDigitalSignatureProcessing 기능 옵션을 설명합니다. |
+| [JobDuplexAllDocumentsContiguously](../com.aspose.xps.metadata/jobduplexalldocumentscontiguously) | 출력의 양면 인쇄 특성을 설명합니다. |
+| [JobErrorSheet](../com.aspose.xps.metadata/joberrorsheet) | 오류 시트 출력에 대해 설명합니다. |
+| [JobErrorSheet.ErrorSheetOption](../com.aspose.xps.metadata/joberrorsheet.errorsheetoption) | JobErrorSheet 기능 옵션을 설명합니다. |
+| [JobErrorSheet.ErrorSheetWhen](../com.aspose.xps.metadata/joberrorsheet.errorsheetwhen) | ErrorSheetWhen 내부 기능을 설명합니다. |
+| [JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption](../com.aspose.xps.metadata/joberrorsheet.errorsheetwhen.errorsheetwhenoption) | ErrorSheetWhen 기능 옵션을 설명합니다. |
+| [JobErrorSheetSource](../com.aspose.xps.metadata/joberrorsheetsource) | 맞춤 오류 시트의 소스를 지정합니다. |
+| [JobHolePunch](../com.aspose.xps.metadata/jobholepunch) | 출력의 구멍 뚫기 특성을 설명합니다. |
+| [JobID](../com.aspose.xps.metadata/jobid) | 작업에 대한 고유 ID를 지정합니다. |
+| [JobInputBin](../com.aspose.xps.metadata/jobinputbin) | 장치에 설치된 입력 빈 또는 장치가 지원하는 전체 빈 목록을 설명합니다. |
+| [JobNUpAllDocumentsContiguously](../com.aspose.xps.metadata/jobnupalldocumentscontiguously) | 여러 논리 페이지를 하나의 물리적 시트에 출력하는 방법을 설명합니다. |
+| [JobName](../com.aspose.xps.metadata/jobname) | 작업에 대한 설명 이름을 지정합니다. |
+| [JobOptimalDestinationColorProfile](../com.aspose.xps.metadata/joboptimaldestinationcolorprofile) | 현재 장치 구성에 따라 최적의 색상 프로파일을 지정합니다. |
+| [JobOptimalDestinationColorProfile.Profile](../com.aspose.xps.metadata/joboptimaldestinationcolorprofile.profile) | 사용 가능한 색상 프로파일을 설명합니다. |
+| [JobOutputBin](../com.aspose.xps.metadata/joboutputbin) | 장치에 설치된 출력 함 또는 장치가 지원하는 함의 전체 목록을 설명합니다. |
+| [JobOutputOptimization](../com.aspose.xps.metadata/joboutputoptimization) | 지정된 옵션에 따라 특정 사용 시나리오에 맞게 출력을 최적화하도록 설계된 작업 처리를 설명합니다. |
+| [JobOutputOptimization.JobOutputOptimizationOption](../com.aspose.xps.metadata/joboutputoptimization.joboutputoptimizationoption) | **JobOutputOptimization** 기능 옵션을 설명합니다. |
+| [JobPageOrder](../com.aspose.xps.metadata/jobpageorder) | 출력에 대한 물리 페이지 순서를 정의합니다. |
+| [JobPageOrder.JobPageOrderOption](../com.aspose.xps.metadata/jobpageorder.jobpageorderoption) | **JobPageOrder** 기능 옵션을 설명합니다. |
+| [JobPrimaryBannerSheet](../com.aspose.xps.metadata/jobprimarybannersheet) | 작업에 대해 출력될 배너 시트를 설명합니다. |
+| [JobPrimaryBannerSheet.BannerSheetOption](../com.aspose.xps.metadata/jobprimarybannersheet.bannersheetoption) | **JobPrimaryBannerSheet** 기능의 옵션을 나타냅니다. |
+| [JobPrimaryBannerSheetSource](../com.aspose.xps.metadata/jobprimarybannersheetsource) | 작업에 대한 기본 사용자 정의 배너 시트의 소스를 지정합니다. |
+| [JobPrimaryCoverBack](../com.aspose.xps.metadata/jobprimarycoverback) | 뒷표지(끝) 시트를 설명합니다. |
+| [JobPrimaryCoverBack.CoverBackOption](../com.aspose.xps.metadata/jobprimarycoverback.coverbackoption) | **JobPrimaryCoverBack** 기능 옵션을 설명합니다. |
+| [JobPrimaryCoverBackSource](../com.aspose.xps.metadata/jobprimarycoverbacksource) | 작업에 대한 사용자 정의 뒷표지 기본 시트의 소스를 지정합니다. |
+| [JobPrimaryCoverFront](../com.aspose.xps.metadata/jobprimarycoverfront) | 앞표지(시작) 시트를 설명합니다. |
+| [JobPrimaryCoverFront.CoverFrontOption](../com.aspose.xps.metadata/jobprimarycoverfront.coverfrontoption) | **JobPrimaryCoverFront** 기능 옵션을 설명합니다. |
+| [JobPrimaryCoverFrontSource](../com.aspose.xps.metadata/jobprimarycoverfrontsource) | 작업에 대한 사용자 정의 앞표지 기본 시트의 소스를 지정합니다. |
+| [JobPrintTicket](../com.aspose.xps.metadata/jobprintticket) | 작업 수준 인쇄 티켓을 캡슐화하는 클래스입니다. |
+| [JobRollCutAtEndOfJob](../com.aspose.xps.metadata/jobrollcutatendofjob) | 롤 용지에 대한 절단 방법을 설명합니다. |
+| [JobStapleAllDocuments](../com.aspose.xps.metadata/jobstaplealldocuments) | 출력의 스테이플링 특성을 설명합니다. |
+| [JobURI](../com.aspose.xps.metadata/joburi) | 문서에 대한 통합 자원 식별자(URI)를 지정합니다. |
+| [NUp](../com.aspose.xps.metadata/nup) | JobNUpAllDocumentsContiguously 및 DocumentNUp 기능 클래스의 기본 클래스입니다. |
+| [NUp.PresentationDirection](../com.aspose.xps.metadata/nup.presentationdirection) | 내부 **PresentationDirection** 기능을 설명합니다. |
+| [NUp.PresentationDirection.PresentationDirectionOption](../com.aspose.xps.metadata/nup.presentationdirection.presentationdirectionoption) | **PresentationDirection** 기능 옵션을 설명합니다. |
+| [NameProperty](../com.aspose.xps.metadata/nameproperty) | JobName 및 DocumentName 속성 클래스의 기본 클래스입니다. |
+| [Option](../com.aspose.xps.metadata/option) | 공통 PrintTicket 옵션을 구현하는 클래스입니다. |
+| [OutputBin](../com.aspose.xps.metadata/outputbin) | JobOutputBin, DocumentOutputBin 및 PageOutputBin 기능 클래스의 기본 클래스입니다. |
+| [OutputBin.BinType](../com.aspose.xps.metadata/outputbin.bintype) | BinType 점수 속성 값에 대한 상수를 정의합니다. |
+| [OutputBin.MediaSheetCapacity](../com.aspose.xps.metadata/outputbin.mediasheetcapacity) | MediaSheetCapacity 점수 속성 값을 정의하며, 빈의 페이지 수(전체 수준)로 미디어 용량을 지정합니다. |
+| [OutputBin.OutputBinOption](../com.aspose.xps.metadata/outputbin.outputbinoption) | **JobOutputBin**, **DocumentOutputBin** 및 **PageOutputBin** 기능 옵션을 설명합니다. |
+| [PageBlackGenerationProcessing](../com.aspose.xps.metadata/pageblackgenerationprocessing) | CMYK 분리에서 검정 생성 동작을 지정합니다. |
+| [PageBlackGenerationProcessing.PageBlackGenerationProcessingOption](../com.aspose.xps.metadata/pageblackgenerationprocessing.pageblackgenerationprocessingoption) | **PageBlackGenerationProcessing** 기능 옵션을 설명합니다. |
+| [PageBlackGenerationProcessingBlackInkLimit](../com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit) | 지정된 명명된 색상으로 라벨링된 애플리케이션 콘텐츠는 모든 색상 분리에서 반드시 표시되어야 합니다. |
+| [PageBlackGenerationProcessingGrayComponentReplacementExtent](../com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent) | GCR이 적용되는 중성 색상(색채 색상) 너머의 확장 범위를 설명합니다. 0% = 균일 구성 요소 교체, 100% = 회색 구성 요소 교체. |
+| [PageBlackGenerationProcessingGrayComponentReplacementLevel](../com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel) | 수행할 회색 구성 요소 교체 비율을 지정합니다. |
+| [PageBlackGenerationProcessingGrayComponentReplacementStart](../com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart) | "하이라이트에서 섀도우" 범위에서 GCR이 시작해야 하는 지점을 설명합니다 (100% 가장 어두운 섀도우). |
+| [PageBlackGenerationProcessingTotalInkCoverageLimit](../com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit) | 이미지 어디에서든 허용되는 네 가지 잉크 커버리지의 최대 합계를 지정합니다. |
+| [PageBlackGenerationProcessingUnderColorAdditionLevel](../com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel) | GCR/UCR이 어두운 중성 및 근중성 영역에서 "BlackInkLimit"(또는 지정된 경우 UCAStart)를 생성한 영역에 추가할 색채 잉크(회색 구성 요소 비율)의 양을 설명합니다. |
+| [PageBlackGenerationProcessingUnderColorAdditionStart](../com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart) | UCA가 적용되는 그림자 수준 이하를 설명합니다. |
+| [PageBlendColorSpace](../com.aspose.xps.metadata/pageblendcolorspace) | 블렌딩 작업에 사용되어야 하는 색 공간을 설명합니다. |
+| [PageBlendColorSpace.PageBlendColorSpaceOption](../com.aspose.xps.metadata/pageblendcolorspace.pageblendcolorspaceoption) | PageBlendColorSpace 기능 옵션을 설명합니다. |
+| [PageBlendColorSpaceICCProfileURI](../com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri) | 블렌딩에 사용되어야 하는 색 공간을 정의하는 ICC 프로파일에 대한 상대 URI 참조를 지정합니다. |
+| [PageBorderless](../com.aspose.xps.metadata/pageborderless) | 이미지 콘텐츠를 매체의 물리적 가장자리에 인쇄해야 하는 시점을 설명합니다. |
+| [PageBorderless.PageBorderlessOption](../com.aspose.xps.metadata/pageborderless.pageborderlessoption) | PageBorderless 기능 옵션을 설명합니다. |
+| [PageColorManagement](../com.aspose.xps.metadata/pagecolormanagement) | 현재 페이지에 대한 색 관리 구성을 설정합니다. |
+| [PageColorManagement.PageColorManagementOption](../com.aspose.xps.metadata/pagecolormanagement.pagecolormanagementoption) | PageColorManagement 기능 옵션을 설명합니다. |
+| [PageCopies](../com.aspose.xps.metadata/pagecopies) | 페이지 복사본 수를 지정합니다. |
+| [PageDestinationColorProfile](../com.aspose.xps.metadata/pagedestinationcolorprofile) | 대상 색 프로파일의 특성을 정의합니다. |
+| [PageDestinationColorProfile.PageDestinationColorProfileOption](../com.aspose.xps.metadata/pagedestinationcolorprofile.pagedestinationcolorprofileoption) | PageDestinationColorProfile 기능 옵션을 설명합니다. |
+| [PageDestinationColorProfileEmbedded](../com.aspose.xps.metadata/pagedestinationcolorprofileembedded) | 내장된 대상 색 프로파일을 지정합니다. |
+| [PageDestinationColorProfileURI](../com.aspose.xps.metadata/pagedestinationcolorprofileuri) | XPS 문서에 포함된 ICC 프로파일에 대한 상대 URI 참조를 지정합니다. |
+| [PageDeviceColorSpaceProfileURI](../com.aspose.xps.metadata/pagedevicecolorspaceprofileuri) | XPS 문서에 포함된 ICC 프로파일에 대한 패키지 루트의 상대 URI를 지정합니다. |
+| [PageDeviceColorSpaceUsage](../com.aspose.xps.metadata/pagedevicecolorspaceusage) | PageDeviceColorSpaceProfileURI 매개변수와 함께, 이 매개변수는 장치 색 공간에 표시되는 요소들의 렌더링 동작을 정의합니다. |
+| [PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption](../com.aspose.xps.metadata/pagedevicecolorspaceusage.pagedevicecolorspaceusageoption) | PageDeviceColorSpaceUsage 기능 옵션을 설명합니다. |
+| [PageDeviceFontSubstitution](../com.aspose.xps.metadata/pagedevicefontsubstitution) | 장치 글꼴 대체의 활성화/비활성화 상태를 설명합니다. |
+| [PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption](../com.aspose.xps.metadata/pagedevicefontsubstitution.pagedevicefontsubstitutionoption) | PageDeviceFontSubstitution 기능 옵션을 설명합니다. |
+| [PageForceFrontSide](../com.aspose.xps.metadata/pageforcefrontside) | 출력이 매체 시트의 앞면에 나타나도록 강제합니다. |
+| [PageForceFrontSide.PageForceFrontSideOption](../com.aspose.xps.metadata/pageforcefrontside.pageforcefrontsideoption) | PageForceFrontSide 기능 옵션을 설명합니다. |
+| [PageICMRenderingIntent](../com.aspose.xps.metadata/pageicmrenderingintent) | ICC v2 사양에 정의된 렌더링 의도를 설명합니다. |
+| [PageICMRenderingIntent.PageICMRenderingIntentOption](../com.aspose.xps.metadata/pageicmrenderingintent.pageicmrenderingintentoption) | PageICMRenderingIntent 기능 옵션을 설명합니다. |
+| [PageImageableSize](../com.aspose.xps.metadata/pageimageablesize) | 레이아웃 및 렌더링을 위한 이미지 캔버스를 설명합니다. |
+| [PageInputBin](../com.aspose.xps.metadata/pageinputbin) | 장치에 설치된 입력 빈 또는 장치가 지원하는 전체 빈 목록을 설명합니다. |
+| [PageMediaColor](../com.aspose.xps.metadata/pagemediacolor) | Media Color 옵션 및 각 옵션의 특성을 설명합니다. |
+| [PageMediaColor.PageMediaColorOption](../com.aspose.xps.metadata/pagemediacolor.pagemediacoloroption) | PageMediaColor 기능 옵션을 설명합니다. |
+| [PageMediaSize](../com.aspose.xps.metadata/pagemediasize) | 출력에 사용되는 물리적 매체 차원을 설명합니다. |
+| [PageMediaSize.PageMediaSizeOption](../com.aspose.xps.metadata/pagemediasize.pagemediasizeoption) | PageMediaSize 기능 옵션을 설명합니다. |
+| [PageMediaSizeMediaSizeHeight](../com.aspose.xps.metadata/pagemediasizemediasizeheight) | Custom MediaSize 옵션에 대한 MediaSizeWidth 차원 방향을 지정합니다. |
+| [PageMediaSizeMediaSizeWidth](../com.aspose.xps.metadata/pagemediasizemediasizewidth) | Custom MediaSize 옵션에 대한 MediaSizeHeight 차원 방향을 지정합니다. |
+| [PageMediaSizePSHeight](../com.aspose.xps.metadata/pagemediasizepsheight) | 피드 방향과 평행한 페이지의 높이를 지정합니다. |
+| [PageMediaSizePSHeightOffset](../com.aspose.xps.metadata/pagemediasizepsheightoffset) | 피드 방향과 평행한 오프셋을 지정합니다. |
+| [PageMediaSizePSOrientation](../com.aspose.xps.metadata/pagemediasizepsorientation) | 피드 방향에 상대적인 방향을 지정합니다 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsorientation |
+| [PageMediaSizePSWidth](../com.aspose.xps.metadata/pagemediasizepswidth) | 피드 방향에 수직인 페이지의 너비를 지정합니다. |
+| [PageMediaSizePSWidthOffset](../com.aspose.xps.metadata/pagemediasizepswidthoffset) | 피드 방향에 수직인 오프셋을 지정합니다. |
+| [PageMediaType](../com.aspose.xps.metadata/pagemediatype) | MediaType 옵션 및 각 옵션의 특성을 설명합니다. |
+| [PageMediaType.BackCoating](../com.aspose.xps.metadata/pagemediatype.backcoating) | BackCoating 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageMediaType.FrontCoating](../com.aspose.xps.metadata/pagemediatype.frontcoating) | FrontCoating 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageMediaType.Material](../com.aspose.xps.metadata/pagemediatype.material) | Material 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageMediaType.PageMediaTypeOption](../com.aspose.xps.metadata/pagemediatype.pagemediatypeoption) | PageMediaType 기능 옵션을 설명합니다. |
+| [PageMediaType.PrePrinted](../com.aspose.xps.metadata/pagemediatype.preprinted) | PrePrinted 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageMediaType.PrePunched](../com.aspose.xps.metadata/pagemediatype.prepunched) | PrePunched 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageMediaType.Recycled](../com.aspose.xps.metadata/pagemediatype.recycled) | Recycled 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageMirrorImage](../com.aspose.xps.metadata/pagemirrorimage) | 출력의 미러링 설정을 설명합니다. |
+| [PageMirrorImage.PageMirrorImageOption](../com.aspose.xps.metadata/pagemirrorimage.pagemirrorimageoption) | PageMirrorImage 기능 옵션을 정의합니다. |
+| [PageNegativeImage](../com.aspose.xps.metadata/pagenegativeimage) | 출력의 네거티브 설정을 설명합니다. |
+| [PageNegativeImage.PageNegativeImageOption](../com.aspose.xps.metadata/pagenegativeimage.pagenegativeimageoption) | PageNegativeImage 기능 옵션을 정의합니다. |
+| [PageOrientation](../com.aspose.xps.metadata/pageorientation) | 물리적 매체 시트의 방향을 설명합니다. |
+| [PageOrientation.PageOrientationOption](../com.aspose.xps.metadata/pageorientation.pageorientationoption) | PageOrientation 기능 옵션을 설명합니다. |
+| [PageOutputBin](../com.aspose.xps.metadata/pageoutputbin) | 장치에서 지원되는 모든 빈 목록을 설명합니다. |
+| [PageOutputColor](../com.aspose.xps.metadata/pageoutputcolor) | 출력에 대한 색상 설정의 특성을 설명합니다. |
+| [PageOutputColor.PageOutputColorOption](../com.aspose.xps.metadata/pageoutputcolor.pageoutputcoloroption) | PageOutputColor 기능 옵션을 설명합니다. |
+| [PageOutputQuality](../com.aspose.xps.metadata/pageoutputquality) | 출력의 네거티브 설정을 설명합니다. |
+| [PageOutputQuality.PageOutputQualityOption](../com.aspose.xps.metadata/pageoutputquality.pageoutputqualityoption) | PageOutputQuality 기능 옵션을 정의합니다. |
+| [PagePhotoPrintingIntent](../com.aspose.xps.metadata/pagephotoprintingintent) | 사진 인쇄 설정을 채우기 위해 드라이버에 고수준 의도를 표시합니다. |
+| [PagePhotoPrintingIntent.PagePhotoPrintingIntentOption](../com.aspose.xps.metadata/pagephotoprintingintent.pagephotoprintingintentoption) | PagePhotoPrintingIntent 기능 옵션을 정의합니다. |
+| [PagePoster](../com.aspose.xps.metadata/pageposter) | 단일 페이지의 출력을 여러 물리적 매체 시트에 설명합니다. |
+| [PagePrintTicket](../com.aspose.xps.metadata/pageprintticket) | 페이지 수준 인쇄 티켓을 캡슐화하는 클래스입니다. |
+| [PageResolution](../com.aspose.xps.metadata/pageresolution) | 인쇄된 출력의 페이지 해상도를 정성적 값 또는 인치당 도트 수, 혹은 둘 다로 정의합니다. |
+| [PageResolution.PageResolutionOption](../com.aspose.xps.metadata/pageresolution.pageresolutionoption) | PageResolution 기능 옵션을 설명합니다. |
+| [PageResolution.QualitativeResolution](../com.aspose.xps.metadata/pageresolution.qualitativeresolution) | QualitativeResolution 점수 속성 값에 대한 상수를 정의합니다. |
+| [PageScaling](../com.aspose.xps.metadata/pagescaling) | 출력의 스케일링 특성을 설명합니다. |
+| [PageScaling.PageScalingOption](../com.aspose.xps.metadata/pagescaling.pagescalingoption) | PageScaling 기능 옵션을 설명합니다. |
+| [PageScaling.ScaleOffsetAlignment](../com.aspose.xps.metadata/pagescaling.scaleoffsetalignment) | 내부 ScaleOffsetAlignment 기능을 설명합니다. |
+| [PageScaling.ScaleOffsetAlignmentOption](../com.aspose.xps.metadata/pagescaling.scaleoffsetalignmentoption) | ScaleOffsetAlignment 기능 옵션을 설명합니다. |
+| [PageScalingOffsetHeight](../com.aspose.xps.metadata/pagescalingoffsetheight) | 맞춤 스케일링을 위해 ImageableSizeWidth 방향의 스케일링 오프셋을 지정합니다. |
+| [PageScalingOffsetWidth](../com.aspose.xps.metadata/pagescalingoffsetwidth) | 맞춤 스케일링을 위해 ImageableSizeWidth 방향의 스케일링 오프셋을 지정합니다. |
+| [PageScalingScale](../com.aspose.xps.metadata/pagescalingscale) | 맞춤 정사각형 스케일링을 위한 스케일링 계수를 지정합니다. |
+| [PageScalingScaleHeight](../com.aspose.xps.metadata/pagescalingscaleheight) | 맞춤 스케일링을 위해 ImageableSizeHeight 방향의 스케일링 계수를 지정합니다. |
+| [PageScalingScaleWidth](../com.aspose.xps.metadata/pagescalingscalewidth) | 맞춤 스케일링을 위해 ImageableSizeWidth 방향의 스케일링 계수를 지정합니다. |
+| [PageSourceColorProfile](../com.aspose.xps.metadata/pagesourcecolorprofile) | 소스 색상 프로파일의 특성을 정의합니다. |
+| [PageSourceColorProfile.PageSourceColorProfileOption](../com.aspose.xps.metadata/pagesourcecolorprofile.pagesourcecolorprofileoption) | PageSourceColorProfile 기능 옵션을 설명합니다. |
+| [PageSourceColorProfileEmbedded](../com.aspose.xps.metadata/pagesourcecolorprofileembedded) | 내장된 소스 색상 프로파일을 지정합니다. |
+| [PageSourceColorProfileURI](../com.aspose.xps.metadata/pagesourcecolorprofileuri) | 색상 프로파일의 소스를 지정합니다. |
+| [PageTrueTypeFontMode](../com.aspose.xps.metadata/pagetruetypefontmode) | 사용될 TrueType 글꼴 처리 방법을 설명합니다. |
+| [PageTrueTypeFontMode.PageTrueTypeFontModeOption](../com.aspose.xps.metadata/pagetruetypefontmode.pagetruetypefontmodeoption) | PageTrueTypeFontMode 기능 옵션을 설명합니다. |
+| [PageWatermark](../com.aspose.xps.metadata/pagewatermark) | 출력의 워터마크 설정 및 워터마크 특성을 설명합니다. |
+| [PageWatermark.Layering](../com.aspose.xps.metadata/pagewatermark.layering) | 내부 Layering 기능을 설명합니다. |
+| [PageWatermark.LayeringOption](../com.aspose.xps.metadata/pagewatermark.layeringoption) | Layering 기능 옵션을 설명합니다. |
+| [PageWatermark.PageWatermarkOption](../com.aspose.xps.metadata/pagewatermark.pagewatermarkoption) | PageWatermark 기능 옵션을 설명합니다. |
+| [PageWatermarkOriginHeight](../com.aspose.xps.metadata/pagewatermarkoriginheight) | 워터마크의 원점을 PageImageableSize의 원점에 상대적으로 지정합니다. |
+| [PageWatermarkOriginWidth](../com.aspose.xps.metadata/pagewatermarkoriginwidth) | 워터마크의 원점을 PageImageableSize의 원점에 상대적으로 지정합니다. |
+| [PageWatermarkTextAngle](../com.aspose.xps.metadata/pagewatermarktextangle) | 워터마크 텍스트의 각도를 PageImageableSizeWidth 방향에 상대적으로 지정합니다. |
+| [PageWatermarkTextColor](../com.aspose.xps.metadata/pagewatermarktextcolor) | 워터마크 텍스트의 sRGB 색상을 정의합니다. |
+| [PageWatermarkTextFontSize](../com.aspose.xps.metadata/pagewatermarktextfontsize) | 워터마크 텍스트에 사용할 수 있는 글꼴 크기를 정의합니다. |
+| [PageWatermarkTextText](../com.aspose.xps.metadata/pagewatermarktexttext) | 워터마크의 텍스트를 지정합니다. |
+| [PageWatermarkTransparency](../com.aspose.xps.metadata/pagewatermarktransparency) | 워터마크의 투명도를 지정합니다. |
+| [ParameterInit](../com.aspose.xps.metadata/parameterinit) | 인쇄 티켓 매개변수 초기화기를 구현하는 클래스. |
+| [ParameterRef](../com.aspose.xps.metadata/parameterref) | 공통 PrintTicket 매개변수 참조를 구현하는 클래스. |
+| [PrintTicket](../com.aspose.xps.metadata/printticket) | 어떤 범위든 공통 PrintTicket을 구현하는 클래스. |
+| [PrintTicketElement](../com.aspose.xps.metadata/printticketelement) | Print Schema 요소가 될 수 있는 클래스들의 기본 클래스. |
+| [Property](../com.aspose.xps.metadata/property) | 인쇄 티켓 속성을 구현하는 클래스. |
+| [QNameValue](../com.aspose.xps.metadata/qnamevalue) | PrintTicket 문서에서 QName 값을 캡슐화하는 클래스. |
+| [RollCut](../com.aspose.xps.metadata/rollcut) | JobRollCutAtEndOfJob 및 DocumentRollCut 기능 클래스들의 기본 클래스. |
+| [RollCut.RollCutOption](../com.aspose.xps.metadata/rollcut.rollcutoption) | JobRollCutAtEndOfJob 및 DocumentRollCut 기능 옵션을 설명합니다. |
+| [ScoredProperty](../com.aspose.xps.metadata/scoredproperty) | 공통 PrintTicket ScoredProperty를 구현하는 클래스. |
+| [SelectionType](../com.aspose.xps.metadata/selectiontype) | SelectionType PrintTicket 속성을 위한 편의 클래스. |
+| [Staple](../com.aspose.xps.metadata/staple) | JobStapleAllDocuments 및 DocumentStaple 기능 클래스들의 기본 클래스. |
+| [Staple.StapleOption](../com.aspose.xps.metadata/staple.stapleoption) | JobStapleAllDocuments 및 DocumentStaple 기능 옵션을 설명합니다. |
+| [StringParameterInit](../com.aspose.xps.metadata/stringparameterinit) | 모든 문자열 매개변수 초기화기의 기본 클래스. |
+| [StringValue](../com.aspose.xps.metadata/stringvalue) | PrintTicket 문서에서 문자열 값을 캡슐화하는 클래스. |
+| [URIProperty](../com.aspose.xps.metadata/uriproperty) | JobURI 및 DocumentURI 속성 클래스들의 기본 클래스. |
+| [Value](../com.aspose.xps.metadata/value) | PrintTicket 문서에서 Property 또는 ScoredProperty 값을 캡슐화하는 기본 클래스. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IDocumentPrintTicketItem](../com.aspose.xps.metadata/idocumentprintticketitem) | 문서 접두사가 붙은 인쇄 티켓 항목의 인터페이스. |
+| [IFeatureItem](../com.aspose.xps.metadata/ifeatureitem) | Print Schema Feature 항목이 될 수 있는 클래스들의 기본 인터페이스. |
+| [IJobPrintTicketItem](../com.aspose.xps.metadata/ijobprintticketitem) | 작업 접두사가 붙은 인쇄 티켓 항목의 인터페이스입니다. |
+| [IOptionItem](../com.aspose.xps.metadata/ioptionitem) | Print Schema  Option  항목이 될 수 있는 클래스들의 인터페이스입니다. |
+| [IPagePrintTicketItem](../com.aspose.xps.metadata/ipageprintticketitem) | 페이지 접두사가 붙은 인쇄 티켓 항목의 인터페이스입니다. |
+| [IPrintTicketElementChild](../com.aspose.xps.metadata/iprintticketelementchild) | 모든 Print Schema 요소의 자식 요소에 대한 기본 인터페이스입니다. |
+| [IPrintTicketItem](../com.aspose.xps.metadata/iprintticketitem) | PrintTicket  루트 요소 항목이 될 수 있는 클래스들의 기본 인터페이스입니다. |
+| [IPropertyItem](../com.aspose.xps.metadata/ipropertyitem) | PrintTicket  Property  항목이 될 수 있는 클래스들의 기본 인터페이스입니다. |
+| [IScoredPropertyItem](../com.aspose.xps.metadata/iscoredpropertyitem) | PrintTicket  ScoredProperty  항목이 될 수 있는 클래스들의 기본 인터페이스입니다. |

--- a/korean/java/com.aspose.xps.metadata/backcoating/_index.md
+++ b/korean/java/com.aspose.xps.metadata/backcoating/_index.md
@@ -1,0 +1,196 @@
+---
+title: "PageMediaType.BackCoating"
+second_title: "Aspose.Page용 Java API 참조"
+description: "BackCoating 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.backcoating/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.BackCoating extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+BackCoating 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Glossy](#Glossy) | Glossy value. |
+| [HighGloss](#HighGloss) | HighGloss value. |
+| [Matte](#Matte) | Matte value. |
+| [None](#None) | None 값. |
+| [Satin](#Satin) | Satin value. |
+| [SemiGloss](#SemiGloss) | SemiGloss value. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Glossy {#Glossy}
+```
+public static PageMediaType.BackCoating Glossy
+```
+
+
+Glossy value.
+
+### HighGloss {#HighGloss}
+```
+public static PageMediaType.BackCoating HighGloss
+```
+
+
+HighGloss value.
+
+### Matte {#Matte}
+```
+public static PageMediaType.BackCoating Matte
+```
+
+
+Matte value.
+
+### None {#None}
+```
+public static PageMediaType.BackCoating None
+```
+
+
+None 값.
+
+### Satin {#Satin}
+```
+public static PageMediaType.BackCoating Satin
+```
+
+
+Satin value.
+
+### SemiGloss {#SemiGloss}
+```
+public static PageMediaType.BackCoating SemiGloss
+```
+
+
+SemiGloss value.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/bannersheetoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/bannersheetoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "JobPrimaryBannerSheet.BannerSheetOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobPrimaryBannerSheet 기능의 옵션을 나타냅니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobprimarybannersheet.bannersheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPrimaryBannerSheet.BannerSheetOption extends Option
+```
+
+**JobPrimaryBannerSheet** 기능의 옵션을 나타냅니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Custom](#Custom) | 사용자 정의 배너 시트를 출력하도록 지정합니다. |
+| [None](#None) | 배너 시트를 출력하지 않도록 지정합니다. |
+| [Standard](#Standard) | 표준(장치 정의) 배너 시트를 출력하도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Custom {#Custom}
+```
+public static final JobPrimaryBannerSheet.BannerSheetOption Custom
+```
+
+
+사용자 정의 배너 시트를 출력하도록 지정합니다. JobPrimaryBannerSheetSource ParameterInit 요소가 지정되지 않은 경우, 이 Option은 무시되어야 합니다.
+
+### None {#None}
+```
+public static final JobPrimaryBannerSheet.BannerSheetOption None
+```
+
+
+배너 시트를 출력하지 않도록 지정합니다.
+
+### Standard {#Standard}
+```
+public static final JobPrimaryBannerSheet.BannerSheetOption Standard
+```
+
+
+표준(장치 정의) 배너 시트를 출력하도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/bindinggutter/_index.md
+++ b/korean/java/com.aspose.xps.metadata/bindinggutter/_index.md
@@ -1,0 +1,169 @@
+---
+title: "JobBindAllDocuments.BindingGutter"
+second_title: "Aspose.Page용 Java API 참조"
+description: "BindingGutter 점수 속성 값을 정수 값으로 지정하거나 DocumentBindingGutter 매개변수에 대한 참조로 지정하는 방법을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobbindalldocuments.bindinggutter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.JobBindAllDocuments.IBindingOptionItem](../../com.aspose.xps.metadata/ibindingoptionitem)
+```
+public static final class JobBindAllDocuments.BindingGutter extends ScoredProperty implements JobBindAllDocuments.IBindingOptionItem
+```
+
+BindingGutter 점수 속성 값을 정수값으로 지정하거나 DocumentBindingGutter 매개변수를 참조하여 지정하는 방법을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BindingGutter(int value)](#BindingGutter-int-) | 새 인스턴스를 생성합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [JobBindAllDocumentsGutter](#JobBindAllDocumentsGutter) | BindingGutter 점수 속성 값을 DocumentBindingGutter 매개변수에 대한 참조로 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BindingGutter(int value) {#BindingGutter-int-}
+```
+public BindingGutter(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 점수 속성 값. |
+
+### JobBindAllDocumentsGutter {#JobBindAllDocumentsGutter}
+```
+public static final JobBindAllDocuments.BindingGutter JobBindAllDocumentsGutter
+```
+
+
+BindingGutter 점수 속성 값을 DocumentBindingGutter 매개변수에 대한 참조로 지정합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/bindingoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/bindingoption/_index.md
@@ -1,0 +1,298 @@
+---
+title: "JobBindAllDocuments.BindingOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobBindAllDocuments 기능 옵션을 설명합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/jobbindalldocuments.bindingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobBindAllDocuments.BindingOption extends Option
+```
+
+JobBindAllDocuments 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BindingOption(String name, JobBindAllDocuments.IBindingOptionItem[] items)](#BindingOption-java.lang.String-com.aspose.xps.metadata.JobBindAllDocuments.IBindingOptionItem...-) | 새 인스턴스를 생성합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Bale](#Bale) | 베일 제본을 지정합니다. |
+| [BindBottom](#BindBottom) | 하단 가장자리를 따라 제본을 지정합니다. |
+| [BindLeft](#BindLeft) | 왼쪽 가장자리를 따라 제본을 지정합니다. |
+| [BindRight](#BindRight) | 오른쪽 가장자리를 따라 제본을 지정합니다. |
+| [BindTop](#BindTop) | 상단 가장자리를 따라 제본을 지정합니다. |
+| [Booklet](#Booklet) | 소책자 제본을 지정합니다. |
+| [EdgeStitchBottom](#EdgeStitchBottom) | 하단 가장자리를 따라 가장자리 스티칭을 지정합니다. |
+| [EdgeStitchLeft](#EdgeStitchLeft) | 왼쪽 가장자를 따라 가장자리 스티칭을 지정합니다. |
+| [EdgeStitchRight](#EdgeStitchRight) | 오른쪽 가장자를 따라 가장자리 스티칭을 지정합니다. |
+| [EdgeStitchTop](#EdgeStitchTop) | 상단 가장자를 따라 가장자리 스티칭을 지정합니다. |
+| [Fold](#Fold) | 접힌 제본을 지정합니다. |
+| [JogOffset](#JogOffset) | 조깅 오프셋 제본을 지정합니다. |
+| [None](#None) | 제본 없음을 지정합니다. |
+| [Trim](#Trim) | 트리밍 제본을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BindingOption(String name, JobBindAllDocuments.IBindingOptionItem[] items) {#BindingOption-java.lang.String-com.aspose.xps.metadata.JobBindAllDocuments.IBindingOptionItem...-}
+```
+public BindingOption(String name, JobBindAllDocuments.IBindingOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 옵션 이름. |
+| items | [IBindingOptionItem\[\]](../../com.aspose.xps.metadata/ibindingoptionitem) | 법적 하위 항목들의 배열입니다. |
+
+### Bale {#Bale}
+```
+public static final JobBindAllDocuments.BindingOption Bale
+```
+
+
+베일 제본을 지정합니다.
+
+### BindBottom {#BindBottom}
+```
+public static final JobBindAllDocuments.BindingOption BindBottom
+```
+
+
+하단 가장자리를 따라 제본을 지정합니다.
+
+### BindLeft {#BindLeft}
+```
+public static final JobBindAllDocuments.BindingOption BindLeft
+```
+
+
+왼쪽 가장자리를 따라 제본을 지정합니다.
+
+### BindRight {#BindRight}
+```
+public static final JobBindAllDocuments.BindingOption BindRight
+```
+
+
+오른쪽 가장자리를 따라 제본을 지정합니다.
+
+### BindTop {#BindTop}
+```
+public static final JobBindAllDocuments.BindingOption BindTop
+```
+
+
+상단 가장자리를 따라 제본을 지정합니다.
+
+### Booklet {#Booklet}
+```
+public static final JobBindAllDocuments.BindingOption Booklet
+```
+
+
+소책자 제본을 지정합니다.
+
+### EdgeStitchBottom {#EdgeStitchBottom}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchBottom
+```
+
+
+하단 가장자리를 따라 가장자리 스티칭을 지정합니다.
+
+### EdgeStitchLeft {#EdgeStitchLeft}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchLeft
+```
+
+
+왼쪽 가장자를 따라 가장자리 스티칭을 지정합니다.
+
+### EdgeStitchRight {#EdgeStitchRight}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchRight
+```
+
+
+오른쪽 가장자를 따라 가장자리 스티칭을 지정합니다.
+
+### EdgeStitchTop {#EdgeStitchTop}
+```
+public static final JobBindAllDocuments.BindingOption EdgeStitchTop
+```
+
+
+상단 가장자를 따라 가장자리 스티칭을 지정합니다.
+
+### Fold {#Fold}
+```
+public static final JobBindAllDocuments.BindingOption Fold
+```
+
+
+접힌 제본을 지정합니다.
+
+### JogOffset {#JogOffset}
+```
+public static final JobBindAllDocuments.BindingOption JogOffset
+```
+
+
+조깅 오프셋 제본을 지정합니다.
+
+### None {#None}
+```
+public static final JobBindAllDocuments.BindingOption None
+```
+
+
+제본 없음을 지정합니다.
+
+### Trim {#Trim}
+```
+public static final JobBindAllDocuments.BindingOption Trim
+```
+
+
+트리밍 제본을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/bintype/_index.md
+++ b/korean/java/com.aspose.xps.metadata/bintype/_index.md
@@ -1,0 +1,187 @@
+---
+title: "OutputBin.BinType"
+second_title: "Aspose.Page용 Java API 참조"
+description: "BinType 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/outputbin.bintype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem](../../com.aspose.xps.metadata/ioutputbinoptionitem)
+```
+public static final class OutputBin.BinType extends ScoredProperty implements OutputBin.IOutputBinOptionItem
+```
+
+BinType 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Finisher](#Finisher) | Finisher bin입니다. |
+| [MailBox](#MailBox) | MailBox bin입니다. |
+| [None](#None) | 위의 항목 중 어느 것도 아닙니다. |
+| [Sorter](#Sorter) | Sorter bin입니다. |
+| [Stacker](#Stacker) | Stacker bin입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Finisher {#Finisher}
+```
+public static final OutputBin.BinType Finisher
+```
+
+
+Finisher bin입니다.
+
+### MailBox {#MailBox}
+```
+public static final OutputBin.BinType MailBox
+```
+
+
+MailBox bin입니다.
+
+### None {#None}
+```
+public static final OutputBin.BinType None
+```
+
+
+위의 항목 중 어느 것도 아닙니다.
+
+### Sorter {#Sorter}
+```
+public static final OutputBin.BinType Sorter
+```
+
+
+Sorter bin입니다.
+
+### Stacker {#Stacker}
+```
+public static final OutputBin.BinType Stacker
+```
+
+
+Stacker bin입니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/collate/_index.md
+++ b/korean/java/com.aspose.xps.metadata/collate/_index.md
@@ -1,0 +1,149 @@
+---
+title: "정렬"
+second_title: "Aspose.Page용 Java API 참조"
+description: "DocumentCollate 및 JobCollateAllDocuments 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/collate/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class Collate extends Feature
+```
+
+DocumentCollate 및 JobCollateAllDocuments 기능 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/collateoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/collateoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "Collate.CollateOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "DocumentCollate 및 JobCollateAllDocuments 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/collate.collateoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class Collate.CollateOption extends Option
+```
+
+DocumentCollate 및 JobCollateAllDocuments 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Collated](#Collated) | 정렬을 지정합니다. |
+| [Uncollated](#Uncollated) | 정렬하지 않음을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Collated {#Collated}
+```
+public static Collate.CollateOption Collated
+```
+
+
+정렬을 지정합니다.
+
+### Uncollated {#Uncollated}
+```
+public static Collate.CollateOption Uncollated
+```
+
+
+정렬하지 않음을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/compositeprintticketelement/_index.md
+++ b/korean/java/com.aspose.xps.metadata/compositeprintticketelement/_index.md
@@ -1,0 +1,168 @@
+---
+title: "CompositePrintTicketElement"
+second_title: "Aspose.Page용 Java API 참조"
+description: "다른 요소를 포함할 수 있는 복합 Print Schema 요소가 될 수 있는 클래스들의 기본 클래스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/compositeprintticketelement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+```
+public abstract class CompositePrintTicketElement extends PrintTicketElement
+```
+
+다른 요소를 포함할 수 있는 복합 Print Schema 요소가 될 수 있는 클래스들의 기본 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [CompositePrintTicketElement(String name, IPrintTicketElementChild[] items)](#CompositePrintTicketElement-java.lang.String-com.aspose.xps.metadata.IPrintTicketElementChild...-) | 새 인스턴스를 생성합니다. |
+| [CompositePrintTicketElement(CompositePrintTicketElement element)](#CompositePrintTicketElement-com.aspose.xps.metadata.CompositePrintTicketElement-) | 이 요소 인스턴스를 복제합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CompositePrintTicketElement(String name, IPrintTicketElementChild[] items) {#CompositePrintTicketElement-java.lang.String-com.aspose.xps.metadata.IPrintTicketElementChild...-}
+```
+public CompositePrintTicketElement(String name, IPrintTicketElementChild[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 일부 XML 스키마(예: Microsoft Print Schema Framework 또는 기타)에 따른 요소 이름입니다. |
+| items | [IPrintTicketElementChild\[\]](../../com.aspose.xps.metadata/iprintticketelementchild) | 자식 항목의 임의 배열입니다. |
+
+### CompositePrintTicketElement(CompositePrintTicketElement element) {#CompositePrintTicketElement-com.aspose.xps.metadata.CompositePrintTicketElement-}
+```
+public CompositePrintTicketElement(CompositePrintTicketElement element)
+```
+
+
+이 요소 인스턴스를 복제합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| element | [CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement) | 복제할 요소 인스턴스입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/coverbackoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/coverbackoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "JobPrimaryCoverBack.CoverBackOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobPrimaryCoverBack 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobprimarycoverback.coverbackoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPrimaryCoverBack.CoverBackOption extends Option
+```
+
+**JobPrimaryCoverBack** 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BlankCover](#BlankCover) | 빈 표지 시트를 인쇄해야 함을 지정합니다. |
+| [NoCover](#NoCover) | 표지가 출력되지 않음을 지정합니다. |
+| [PrintBack](#PrintBack) | \"CoverBackSource\" 로 지정된 표지를 표지 시트의 뒷면에 인쇄해야 함을 지정합니다. |
+| [PrintBoth](#PrintBoth) | \"CoverBackSource\" 로 지정된 표지를 표지 시트의 양면에 인쇄할 수 있음을 지정합니다. |
+| [PrintFront](#PrintFront) | \"CoverBackSource\" 로 지정된 표지를 표지 시트의 앞면에 인쇄해야 함을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BlankCover {#BlankCover}
+```
+public static final JobPrimaryCoverBack.CoverBackOption BlankCover
+```
+
+
+빈 표지 시트를 인쇄해야 함을 지정합니다.
+
+### NoCover {#NoCover}
+```
+public static final JobPrimaryCoverBack.CoverBackOption NoCover
+```
+
+
+표지가 출력되지 않음을 지정합니다.
+
+### PrintBack {#PrintBack}
+```
+public static final JobPrimaryCoverBack.CoverBackOption PrintBack
+```
+
+
+\"CoverBackSource\" 로 지정된 표지를 표지 시트의 뒷면에 인쇄해야 함을 지정합니다. JobPrimaryCoverBackSource ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### PrintBoth {#PrintBoth}
+```
+public static final JobPrimaryCoverBack.CoverBackOption PrintBoth
+```
+
+
+\"CoverBackSource\" 로 지정된 표지를 표지 시트의 양면에 인쇄할 수 있음을 지정합니다. JobPrimaryCoverBackSource ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### PrintFront {#PrintFront}
+```
+public static final JobPrimaryCoverBack.CoverBackOption PrintFront
+```
+
+
+\"CoverBackSource\" 로 지정된 표지를 표지 시트의 앞면에 인쇄해야 함을 지정합니다. JobPrimaryCoverBackSource ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/coverfrontoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/coverfrontoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "JobPrimaryCoverFront.CoverFrontOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobPrimaryCoverFront 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobprimarycoverfront.coverfrontoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPrimaryCoverFront.CoverFrontOption extends Option
+```
+
+**JobPrimaryCoverFront** 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BlankCover](#BlankCover) | 빈 표지 시트를 인쇄해야 함을 지정합니다. |
+| [NoCover](#NoCover) | 표지가 출력되지 않음을 지정합니다. |
+| [PrintBack](#PrintBack) | \"CoverFrontSource\" 로 지정된 표지를 표지 시트의 뒷면에 인쇄해야 함을 지정합니다. |
+| [PrintBoth](#PrintBoth) | \"CoverFrontSource\" 로 지정된 표지를 표지 시트의 양면에 인쇄할 수 있음을 지정합니다. |
+| [PrintFront](#PrintFront) | \"CoverFrontSource\" 로 지정된 표지를 표지 시트의 앞면에 인쇄해야 함을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BlankCover {#BlankCover}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption BlankCover
+```
+
+
+빈 표지 시트를 인쇄해야 함을 지정합니다.
+
+### NoCover {#NoCover}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption NoCover
+```
+
+
+표지가 출력되지 않음을 지정합니다.
+
+### PrintBack {#PrintBack}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption PrintBack
+```
+
+
+\"CoverFrontSource\" 로 지정된 표지를 표지 시트의 뒷면에 인쇄해야 함을 지정합니다. JobPrimaryCoverFrontSource ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### PrintBoth {#PrintBoth}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption PrintBoth
+```
+
+
+\"CoverFrontSource\" 로 지정된 표지를 표지 시트의 양면에 인쇄할 수 있음을 지정합니다. JobPrimaryCoverFrontSource ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### PrintFront {#PrintFront}
+```
+public static final JobPrimaryCoverFront.CoverFrontOption PrintFront
+```
+
+
+\"CoverFrontSource\" 로 지정된 표지를 표지 시트의 앞면에 인쇄해야 함을 지정합니다. JobPrimaryCoverFrontSource ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/decimalvalue/_index.md
+++ b/korean/java/com.aspose.xps.metadata/decimalvalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "DecimalValue"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 문서에서 Decimal 값을 캡슐화하는 클래스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/decimalvalue/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class DecimalValue extends Value
+```
+
+PrintTicket 문서에서 Decimal 값을 캡슐화하는 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DecimalValue(float value)](#DecimalValue-float-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [getValueString()](#getValueString--) | 값을 문자열로 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DecimalValue(float value) {#DecimalValue-float-}
+```
+public DecimalValue(float value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 소수 값입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+값을 문자열로 가져옵니다.
+
+**Returns:**
+java.lang.String - 값은 문자열입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentbannersheet/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentbannersheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentBannerSheet"
+second_title: "Aspose.Page용 Java API 참조"
+description: "특정 문서에 출력될 배너 시트를 설명합니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/documentbannersheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBannerSheet extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+특정 문서에 출력될 배너 시트를 설명합니다. 배너 시트는 기본 PageMediaSize와 기본 PageMediaType을 사용하여 출력되어야 합니다. 배너 시트는 작업의 나머지 부분과도 분리되어야 합니다. 이는 DocumentDuplex, DocumentStaple, DocumentBinding과 같은 마감 또는 처리 옵션에 배너 시트를 포함하지 않아야 함을 의미합니다. 배너 시트는 작업의 나머지와 분리될 수도, 아닐 수도 있습니다. 이는 작업 마감 또는 처리 옵션에 문서 배너 시트를 포함할 수 있음을 의미합니다. 배너 시트는 문서의 첫 번째 시트로 나타나야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbannersheet
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentBannerSheet(DocumentBannerSheet.BannerSheetOption[] options)](#DocumentBannerSheet-com.aspose.xps.metadata.DocumentBannerSheet.BannerSheetOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBannerSheet(DocumentBannerSheet.BannerSheetOption[] options) {#DocumentBannerSheet-com.aspose.xps.metadata.DocumentBannerSheet.BannerSheetOption...-}
+```
+public DocumentBannerSheet(DocumentBannerSheet.BannerSheetOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [BannerSheetOption\[\]](../../com.aspose.xps.metadata/bannersheetoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentbannersheetsource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentbannersheetsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentBannerSheetSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용자 정의 배너 시트의 소스를 지정합니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.metadata/documentbannersheetsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBannerSheetSource extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+사용자 지정 배너 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbannersheetsource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentBannerSheetSource(String value)](#DocumentBannerSheetSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBannerSheetSource(String value) {#DocumentBannerSheetSource-java.lang.String-}
+```
+public DocumentBannerSheetSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentbinding/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentbinding/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentBinding"
+second_title: "Aspose.Page용 Java API 참조"
+description: "제본 방법을 설명합니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.xps.metadata/documentbinding/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBinding extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+바인딩 방법을 설명합니다. 각 문서는 별도로 바인딩됩니다. DocumentBinding과 JobBindAllDocuments는 서로 배타적입니다. 키워드 간 제약 처리 여부는 드라이버에 달려 있습니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbinding
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentBinding(DocumentBinding.BindingOption[] options)](#DocumentBinding-com.aspose.xps.metadata.DocumentBinding.BindingOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBinding(DocumentBinding.BindingOption[] options) {#DocumentBinding-com.aspose.xps.metadata.DocumentBinding.BindingOption...-}
+```
+public DocumentBinding(DocumentBinding.BindingOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [BindingOption\[\]](../../com.aspose.xps.metadata/bindingoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentbindinggutter/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentbindinggutter/_index.md
@@ -1,0 +1,189 @@
+---
+title: "DocumentBindingGutter"
+second_title: "Aspose.Page용 Java API 참조"
+description: "제본 여백의 너비를 지정합니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.xps.metadata/documentbindinggutter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentBindingGutter extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+바인딩 거터의 너비를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentbindinggutter
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentBindingGutter(int value)](#DocumentBindingGutter-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentBindingGutter(int value) {#DocumentBindingGutter-int-}
+```
+public DocumentBindingGutter(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentcollate/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentcollate/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentCollate"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 정렬 특성을 설명합니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.xps.metadata/documentcollate/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Collate](../../com.aspose.xps.metadata/collate)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCollate extends Collate implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+출력의 정렬 특성을 설명합니다. 각 개별 문서의 모든 페이지가 정렬됩니다. DocumentCollate와 JobCollateAlldocuments는 서로 배타적입니다. 두 키워드 모두 또는 하나만 구현되는지에 대한 동작 및 구현은 드라이버에 맡겨집니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcollate
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentCollate(Collate.CollateOption[] options)](#DocumentCollate-com.aspose.xps.metadata.Collate.CollateOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCollate(Collate.CollateOption[] options) {#DocumentCollate-com.aspose.xps.metadata.Collate.CollateOption...-}
+```
+public DocumentCollate(Collate.CollateOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [CollateOption\[\]](../../com.aspose.xps.metadata/collateoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentcopiesallpages/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentcopiesallpages/_index.md
@@ -1,0 +1,189 @@
+---
+title: "DocumentCopiesAllPages"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서 복사본 수를 지정합니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.xps.metadata/documentcopiesallpages/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCopiesAllPages extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+문서 복사본 수를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcopiesallpages
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentCopiesAllPages(int value)](#DocumentCopiesAllPages-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCopiesAllPages(int value) {#DocumentCopiesAllPages-int-}
+```
+public DocumentCopiesAllPages(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentcoverback/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentcoverback/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentCoverBack"
+second_title: "Aspose.Page용 Java API 참조"
+description: "뒤쪽 마감 표지를 설명합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.xps.metadata/documentcoverback/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverBack extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+뒤쪽(끝) 표지 시트를 설명합니다. 각 문서는 별도의 시트를 가집니다. 표지 시트는 문서의 마지막 페이지에 사용되는 PageMediaSize 및 PageMediaType에 인쇄되어야 합니다. 표지 시트는 지정된 옵션에 따라 (예: DocumentDuplex, DocumentNUp)와 같은 처리 옵션에 통합되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverback
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentCoverBack(DocumentCoverBack.CoverBackOption[] options)](#DocumentCoverBack-com.aspose.xps.metadata.DocumentCoverBack.CoverBackOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverBack(DocumentCoverBack.CoverBackOption[] options) {#DocumentCoverBack-com.aspose.xps.metadata.DocumentCoverBack.CoverBackOption...-}
+```
+public DocumentCoverBack(DocumentCoverBack.CoverBackOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [CoverBackOption\[\]](../../com.aspose.xps.metadata/coverbackoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentcoverbacksource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentcoverbacksource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentCoverBackSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용자 정의 뒷표지 시트의 소스를 지정합니다."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.xps.metadata/documentcoverbacksource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverBackSource extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+사용자 지정 뒷표지 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverbacksource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentCoverBackSource(String value)](#DocumentCoverBackSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverBackSource(String value) {#DocumentCoverBackSource-java.lang.String-}
+```
+public DocumentCoverBackSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentcoverfront/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentcoverfront/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentCoverFront"
+second_title: "Aspose.Page용 Java API 참조"
+description: "앞쪽 시작 표지를 설명합니다."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.xps.metadata/documentcoverfront/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverFront extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+앞표지(시작) 시트를 설명합니다. 각 문서는 별도의 시트를 가집니다. 표지 시트는 문서 첫 페이지에 사용되는  PageMediaSize  및  PageMediaType 에 인쇄되어야 합니다. 표지 시트는 지정된 Option에 따라 처리 옵션(예:  DocumentDuplex ,  DocumentNUp )에 통합되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverfront
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentCoverFront(DocumentCoverFront.CoverFrontOption[] options)](#DocumentCoverFront-com.aspose.xps.metadata.DocumentCoverFront.CoverFrontOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverFront(DocumentCoverFront.CoverFrontOption[] options) {#DocumentCoverFront-com.aspose.xps.metadata.DocumentCoverFront.CoverFrontOption...-}
+```
+public DocumentCoverFront(DocumentCoverFront.CoverFrontOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [CoverFrontOption\[\]](../../com.aspose.xps.metadata/coverfrontoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentcoverfrontsource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentcoverfrontsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentCoverFrontSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용자 정의 앞표지 시트의 소스를 지정합니다."
+type: docs
+weight: 22
+url: /ko/java/com.aspose.xps.metadata/documentcoverfrontsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentCoverFrontSource extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+맞춤형 앞표지 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentcoverfrontsource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentCoverFrontSource(String value)](#DocumentCoverFrontSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentCoverFrontSource(String value) {#DocumentCoverFrontSource-java.lang.String-}
+```
+public DocumentCoverFrontSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentduplex/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentduplex/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentDuplex"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 양면 인쇄 특성을 설명합니다."
+type: docs
+weight: 23
+url: /ko/java/com.aspose.xps.metadata/documentduplex/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Duplex](../../com.aspose.xps.metadata/duplex)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentDuplex extends Duplex implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+출력의 양면 인쇄 특성을 설명합니다. 양면 기능은 매체의 양쪽 면에 인쇄할 수 있게 합니다. 각 문서는 별도로 양면 인쇄됩니다. DocumentDuplex와 JobDuplexAllDocumentsContiguously는 상호 배타적입니다. 이러한 키워드 간의 제약 처리 여부는 드라이버가 결정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentduplex
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentDuplex(Duplex.DuplexOption[] options)](#DocumentDuplex-com.aspose.xps.metadata.Duplex.DuplexOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentDuplex(Duplex.DuplexOption[] options) {#DocumentDuplex-com.aspose.xps.metadata.Duplex.DuplexOption...-}
+```
+public DocumentDuplex(Duplex.DuplexOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [DuplexOption\[\]](../../com.aspose.xps.metadata/duplexoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentholepunch/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentholepunch/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentHolePunch"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 구멍 뚫기 특성을 설명합니다."
+type: docs
+weight: 24
+url: /ko/java/com.aspose.xps.metadata/documentholepunch/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.HolePunch](../../com.aspose.xps.metadata/holepunch)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentHolePunch extends HolePunch implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+출력의 구멍 뚫기 특성을 설명합니다. 각 문서는 별도로 구멍이 뚫립니다. JobHolePunch와 DocumentHolePunch 키워드는 상호 배타적이며 PrintTicket 또는 Print Capabilities 문서에서 동시에 지정해서는 안 됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentholepunch
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentHolePunch(HolePunch.HolePunchOption[] options)](#DocumentHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentHolePunch(HolePunch.HolePunchOption[] options) {#DocumentHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-}
+```
+public DocumentHolePunch(HolePunch.HolePunchOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [HolePunchOption\[\]](../../com.aspose.xps.metadata/holepunchoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentid/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentid/_index.md
@@ -1,0 +1,153 @@
+---
+title: "DocumentID"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서에 대한 고유 ID를 지정합니다."
+type: docs
+weight: 25
+url: /ko/java/com.aspose.xps.metadata/documentid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.IDProperty](../../com.aspose.xps.metadata/idproperty)
+```
+public final class DocumentID extends IDProperty
+```
+
+문서에 대한 고유 ID를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentid
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentID(String documentID)](#DocumentID-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentID(String documentID) {#DocumentID-java.lang.String-}
+```
+public DocumentID(String documentID)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentID | java.lang.String | 문서 ID입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentimpositioncolor/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentimpositioncolor/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentImpositionColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "지정된 명명된 색상으로 라벨링된 애플리케이션 콘텐츠는 모든 색상 분리에서 반드시 표시되어야 합니다."
+type: docs
+weight: 26
+url: /ko/java/com.aspose.xps.metadata/documentimpositioncolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentImpositionColor extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+지정된 명명된 색상으로 라벨링된 애플리케이션 콘텐츠는 모든 색상 분리에서 반드시 표시되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentimpositioncolor
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentImpositionColor(String value)](#DocumentImpositionColor-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentImpositionColor(String value) {#DocumentImpositionColor-java.lang.String-}
+```
+public DocumentImpositionColor(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentinputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentinputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentInputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치에 설치된 입력 빈 또는 장치가 지원하는 전체 빈 목록을 설명합니다."
+type: docs
+weight: 27
+url: /ko/java/com.aspose.xps.metadata/documentinputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.InputBin](../../com.aspose.xps.metadata/inputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentInputBin extends InputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+장치에 설치된 입력 빈 또는 장치가 지원하는 모든 빈 목록을 설명합니다. JobInputBin, DocumentInputBin 및 PageInputBin 키워드는 서로 배타적입니다. PrintTicket 또는 Print Capabilities 문서에서 두 키워드를 동시에 지정해서는 안 됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentinputbin
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentInputBin(InputBin.IInputBinItem[] items)](#DocumentInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentInputBin(InputBin.IInputBinItem[] items) {#DocumentInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-}
+```
+public DocumentInputBin(InputBin.IInputBinItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IInputBinItem\[\]](../../com.aspose.xps.metadata/iinputbinitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentname/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentname/_index.md
@@ -1,0 +1,153 @@
+---
+title: "DocumentName"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서에 대한 설명 이름을 지정합니다."
+type: docs
+weight: 29
+url: /ko/java/com.aspose.xps.metadata/documentname/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.NameProperty](../../com.aspose.xps.metadata/nameproperty)
+```
+public final class DocumentName extends NameProperty
+```
+
+문서에 대한 설명 이름을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentname
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentName(String documentName)](#DocumentName-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentName(String documentName) {#DocumentName-java.lang.String-}
+```
+public DocumentName(String documentName)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentName | java.lang.String | 문서 이름입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentnup/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentnup/_index.md
@@ -1,0 +1,192 @@
+---
+title: "DocumentNUp"
+second_title: "Aspose.Page용 Java API 참조"
+description: "여러 논리 페이지를 하나의 물리 시트에 출력하고 포맷하는 방식을 설명합니다."
+type: docs
+weight: 28
+url: /ko/java/com.aspose.xps.metadata/documentnup/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.NUp](../../com.aspose.xps.metadata/nup)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentNUp extends NUp implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+여러 논리 페이지를 하나의 물리 시트에 출력 및 형식화하는 방법을 설명합니다. 각 문서는 별도로 컴파일됩니다. DocumentNUp와 JobNUpAllDocumentsContiguously는 상호 배타적입니다. 이러한 키워드 간 제약 처리 여부는 드라이버가 결정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentnup
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentNUp(NUp.INUpItem[] items)](#DocumentNUp-com.aspose.xps.metadata.NUp.INUpItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [addPagesPerSheetOption(int value)](#addPagesPerSheetOption-int-) | PagesPerSheet 스코어드 속성 값을 사용하여 옵션을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentNUp(NUp.INUpItem[] items) {#DocumentNUp-com.aspose.xps.metadata.NUp.INUpItem...-}
+```
+public DocumentNUp(NUp.INUpItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [INUpItem\[\]](../../com.aspose.xps.metadata/inupitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### addPagesPerSheetOption(int value) {#addPagesPerSheetOption-int-}
+```
+public DocumentNUp addPagesPerSheetOption(int value)
+```
+
+
+PagesPerSheet 스코어드 속성 값을 사용하여 옵션을 추가합니다. 물리적 시트당 논리 페이지 수를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 값 | int | A |
+
+```
+PagesPerSheet
+```
+
+점수 속성 값. 지원되는 집합은 정수 집합이면 언제든지 가능합니다. 예: \{1,2,4,6,8,9,16\}. |
+
+**Returns:**
+[DocumentNUp](../../com.aspose.xps.metadata/documentnup) - This feature instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentoutputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentoutputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentOutputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치에서 지원되는 모든 빈 목록을 설명합니다."
+type: docs
+weight: 30
+url: /ko/java/com.aspose.xps.metadata/documentoutputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.OutputBin](../../com.aspose.xps.metadata/outputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentOutputBin extends OutputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+장치에서 지원되는 모든 빈 목록을 설명합니다. 문서별로 출력 빈을 지정할 수 있습니다. JobOutputBin ,  DocumentOutputBin  and  PageOutputBin 키워드는 서로 배타적이며 PrintTicket 또는 Print Capabilities 문서에서 하나만 지정해야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentoutputbin
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentOutputBin(OutputBin.IOutputBinItem[] items)](#DocumentOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentOutputBin(OutputBin.IOutputBinItem[] items) {#DocumentOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-}
+```
+public DocumentOutputBin(OutputBin.IOutputBinItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOutputBinItem\[\]](../../com.aspose.xps.metadata/ioutputbinitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentpageranges/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentpageranges/_index.md
@@ -1,0 +1,178 @@
+---
+title: "DocumentPageRanges"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서의 출력 범위를 페이지 단위로 설명합니다."
+type: docs
+weight: 31
+url: /ko/java/com.aspose.xps.metadata/documentpageranges/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentPageRanges extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+문서 페이지의 출력 범위를 설명합니다. 매개변수 값은 다음 구조를 따라야 합니다: - PageRangeText: "PageRange" 또는 "PageRange,PageRange" - PageRange: "PageNumber" 또는 "PageNumber-PageNumber" - PageNumber: 1부터 N까지, 여기서 N은 문서의 페이지 수입니다. PageNumber > N인 경우 PageNumber는 N이 됩니다. 문자열의 공백은 무시되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentpageranges
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentPageRanges(String value)](#DocumentPageRanges-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentPageRanges(String value) {#DocumentPageRanges-java.lang.String-}
+```
+public DocumentPageRanges(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentprintticket/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentprintticket/_index.md
@@ -1,0 +1,181 @@
+---
+title: "DocumentPrintTicket"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서 수준 인쇄 티켓을 캡슐화하는 클래스입니다."
+type: docs
+weight: 32
+url: /ko/java/com.aspose.xps.metadata/documentprintticket/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicket](../../com.aspose.xps.metadata/printticket)
+```
+public final class DocumentPrintTicket extends PrintTicket
+```
+
+문서 수준 인쇄 티켓을 캡슐화하는 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentPrintTicket(IDocumentPrintTicketItem[] items)](#DocumentPrintTicket-com.aspose.xps.metadata.IDocumentPrintTicketItem...-) | 문서 수준 인쇄 티켓 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IDocumentPrintTicketItem[] items)](#add-com.aspose.xps.metadata.IDocumentPrintTicketItem...-) | 이 PrintTicket 항목 목록 끝에 항목 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 인쇄 티켓 항목 이름 반복자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | 이 PrintTicket 항목 목록에서 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentPrintTicket(IDocumentPrintTicketItem[] items) {#DocumentPrintTicket-com.aspose.xps.metadata.IDocumentPrintTicketItem...-}
+```
+public DocumentPrintTicket(IDocumentPrintTicketItem[] items)
+```
+
+
+문서 수준 인쇄 티켓 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IDocumentPrintTicketItem\[\]](../../com.aspose.xps.metadata/idocumentprintticketitem) | 임의의 IDocumentPrintTicketItem 인스턴스 배열입니다. 각 인스턴스는 Feature, ParameterInit 또는 Property 인스턴스여야 합니다. |
+
+### add(IDocumentPrintTicketItem[] items) {#add-com.aspose.xps.metadata.IDocumentPrintTicketItem...-}
+```
+public void add(IDocumentPrintTicketItem[] items)
+```
+
+
+이 PrintTicket 항목 목록 끝에 항목 배열을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스일 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IDocumentPrintTicketItem\[\]](../../com.aspose.xps.metadata/idocumentprintticketitem) | 추가할 항목 배열입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+인쇄 티켓 항목 이름 반복자를 반환합니다.
+
+**Returns:**
+java.util.Iterator<java.lang.String> - 목록에 대한 반복자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+이 PrintTicket 항목 목록에서 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String[] | 항목 이름 배열입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentrollcut/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentrollcut/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentRollCut"
+second_title: "Aspose.Page용 Java API 참조"
+description: "롤 용지에 대한 절단 방법을 설명합니다."
+type: docs
+weight: 33
+url: /ko/java/com.aspose.xps.metadata/documentrollcut/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.RollCut](../../com.aspose.xps.metadata/rollcut)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentRollCut extends RollCut implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+롤 용지의 절단 방법을 설명합니다. 각 문서는 별도로 처리됩니다. 지정된 옵션은 롤 절단에 대한 다양한 방법을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentrollcut
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentRollCut(RollCut.RollCutOption[] options)](#DocumentRollCut-com.aspose.xps.metadata.RollCut.RollCutOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentRollCut(RollCut.RollCutOption[] options) {#DocumentRollCut-com.aspose.xps.metadata.RollCut.RollCutOption...-}
+```
+public DocumentRollCut(RollCut.RollCutOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [RollCutOption\[\]](../../com.aspose.xps.metadata/rollcutoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentseparatorsheet/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentseparatorsheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentSeparatorSheet"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서에 대한 분리 시트 사용을 설명합니다."
+type: docs
+weight: 34
+url: /ko/java/com.aspose.xps.metadata/documentseparatorsheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentSeparatorSheet extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+문서에 대한 구분 시트 사용을 설명합니다. 구분 시트는 아래에 지정된 옵션에 따라 출력에 표시되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentseparatorsheet
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentSeparatorSheet(DocumentSeparatorSheet.DocumentSeparatorSheetOption[] options)](#DocumentSeparatorSheet-com.aspose.xps.metadata.DocumentSeparatorSheet.DocumentSeparatorSheetOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentSeparatorSheet(DocumentSeparatorSheet.DocumentSeparatorSheetOption[] options) {#DocumentSeparatorSheet-com.aspose.xps.metadata.DocumentSeparatorSheet.DocumentSeparatorSheetOption...-}
+```
+public DocumentSeparatorSheet(DocumentSeparatorSheet.DocumentSeparatorSheetOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [DocumentSeparatorSheetOption\[\]](../../com.aspose.xps.metadata/documentseparatorsheetoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentseparatorsheetoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentseparatorsheetoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "DocumentSeparatorSheet.DocumentSeparatorSheetOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "DocumentSeparatorSheet 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/documentseparatorsheet.documentseparatorsheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class DocumentSeparatorSheet.DocumentSeparatorSheetOption extends Option
+```
+
+DocumentSeparatorSheet 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BothSheets](#BothSheets) | 문서 시작과 끝에 구분 시트를 지정합니다. |
+| [EndSheet](#EndSheet) | 문서 끝에 구분 시트를 지정합니다. |
+| [None](#None) | 구분 시트를 지정하지 않습니다. |
+| [StartSheet](#StartSheet) | 문서 시작에 구분 시트를 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BothSheets {#BothSheets}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption BothSheets
+```
+
+
+문서 시작과 끝에 구분 시트를 지정합니다.
+
+### EndSheet {#EndSheet}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption EndSheet
+```
+
+
+문서 끝에 구분 시트를 지정합니다.
+
+### None {#None}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption None
+```
+
+
+구분 시트를 지정하지 않습니다.
+
+### StartSheet {#StartSheet}
+```
+public static DocumentSeparatorSheet.DocumentSeparatorSheetOption StartSheet
+```
+
+
+문서 시작에 구분 시트를 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documentstaple/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documentstaple/_index.md
@@ -1,0 +1,170 @@
+---
+title: "DocumentStaple"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 스테이플링 특성을 설명합니다."
+type: docs
+weight: 35
+url: /ko/java/com.aspose.xps.metadata/documentstaple/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Staple](../../com.aspose.xps.metadata/staple)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem)
+```
+public final class DocumentStaple extends Staple implements IJobPrintTicketItem, IDocumentPrintTicketItem
+```
+
+출력의 스테이플링 특성을 설명합니다. 각 문서는 별도로 스테이플됩니다. JobStapleAllDocuments와 DocumentStaple 키워드는 상호 배타적입니다. 이러한 키워드 간의 제약 처리 여부는 드라이버에 달려 있습니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documentstaple
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentStaple(Staple.StapleOption[] options)](#DocumentStaple-com.aspose.xps.metadata.Staple.StapleOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentStaple(Staple.StapleOption[] options) {#DocumentStaple-com.aspose.xps.metadata.Staple.StapleOption...-}
+```
+public DocumentStaple(Staple.StapleOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [StapleOption\[\]](../../com.aspose.xps.metadata/stapleoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/documenturi/_index.md
+++ b/korean/java/com.aspose.xps.metadata/documenturi/_index.md
@@ -1,0 +1,153 @@
+---
+title: "DocumentURI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서에 대한 통합 자원 식별자(URI)를 지정합니다."
+type: docs
+weight: 36
+url: /ko/java/com.aspose.xps.metadata/documenturi/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.URIProperty](../../com.aspose.xps.metadata/uriproperty)
+```
+public final class DocumentURI extends URIProperty
+```
+
+문서에 대한 통합 리소스 식별자(URI)를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/documenturi
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [DocumentURI(String documentURI)](#DocumentURI-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### DocumentURI(String documentURI) {#DocumentURI-java.lang.String-}
+```
+public DocumentURI(String documentURI)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentURI | java.lang.String | 문서 URI. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/duplex/_index.md
+++ b/korean/java/com.aspose.xps.metadata/duplex/_index.md
@@ -1,0 +1,149 @@
+---
+title: "Duplex"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobDuplexAllDocumentsContiguously 및 DocumentDuplex 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 37
+url: /ko/java/com.aspose.xps.metadata/duplex/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class Duplex extends Feature
+```
+
+JobDuplexAllDocumentsContiguously 및 DocumentDuplex 기능 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/duplexmode/_index.md
+++ b/korean/java/com.aspose.xps.metadata/duplexmode/_index.md
@@ -1,0 +1,157 @@
+---
+title: "Duplex.DuplexMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "DuplexOptions DuplexMode 점수 속성의 가능한 값을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/duplex.duplexmode/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+```
+public static final class Duplex.DuplexMode extends ScoredProperty
+```
+
+DuplexOption의 DuplexMode 점수 속성에 대한 가능한 값을 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Automatic](#Automatic) | 자동 값. |
+| [Manual](#Manual) | 수동 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static final Duplex.DuplexMode Automatic
+```
+
+
+자동 값.
+
+### Manual {#Manual}
+```
+public static final Duplex.DuplexMode Manual
+```
+
+
+수동 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/duplexoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/duplexoption/_index.md
@@ -1,0 +1,200 @@
+---
+title: "Duplex.DuplexOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobDuplexAllDocumentsContiguously 및 DocumentDuplex 기능 옵션을 설명합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/duplex.duplexoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class Duplex.DuplexOption extends Option
+```
+
+JobDuplexAllDocumentsContiguously 및 DocumentDuplex 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [OneSided](#OneSided) | 단면 인쇄를 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [twoSidedLongEdge(Duplex.DuplexMode duplexMode)](#twoSidedLongEdge-com.aspose.xps.metadata.Duplex.DuplexMode-) | 페이지가 MediaSizeHeight 방향에 평행하게 뒤집히도록 양면 인쇄를 지정합니다. |
+| [twoSidedShortEdge(Duplex.DuplexMode duplexMode)](#twoSidedShortEdge-com.aspose.xps.metadata.Duplex.DuplexMode-) | 페이지가 MediaSizeWidth 방향에 평행하게 뒤집히도록 양면 인쇄를 지정합니다. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OneSided {#OneSided}
+```
+public static final Duplex.DuplexOption OneSided
+```
+
+
+단면 인쇄를 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### twoSidedLongEdge(Duplex.DuplexMode duplexMode) {#twoSidedLongEdge-com.aspose.xps.metadata.Duplex.DuplexMode-}
+```
+public static final Duplex.DuplexOption twoSidedLongEdge(Duplex.DuplexMode duplexMode)
+```
+
+
+페이지가 MediaSizeHeight 방향에 평행하게 뒤집히도록 양면 인쇄를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| duplexMode | [DuplexMode](../../com.aspose.xps.metadata/duplexmode) | 다음  DuplexMode |
+
+**Returns:**
+[DuplexOption](../../com.aspose.xps.metadata/duplexoption) - The  Duplex  option.
+### twoSidedShortEdge(Duplex.DuplexMode duplexMode) {#twoSidedShortEdge-com.aspose.xps.metadata.Duplex.DuplexMode-}
+```
+public static final Duplex.DuplexOption twoSidedShortEdge(Duplex.DuplexMode duplexMode)
+```
+
+
+페이지가 MediaSizeWidth 방향에 평행하게 뒤집히도록 양면 인쇄를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| duplexMode | [DuplexMode](../../com.aspose.xps.metadata/duplexmode) | 다음  DuplexMode |
+
+**Returns:**
+[DuplexOption](../../com.aspose.xps.metadata/duplexoption) - The
+
+```
+Duplex
+```
+
+옵션.
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/errorsheetoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/errorsheetoption/_index.md
@@ -1,0 +1,183 @@
+---
+title: "JobErrorSheet.ErrorSheetOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobErrorSheet 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/joberrorsheet.errorsheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem](../../com.aspose.xps.metadata/ijoberrorsheetitem)
+```
+public static final class JobErrorSheet.ErrorSheetOption extends Option implements JobErrorSheet.IJobErrorSheetItem
+```
+
+JobErrorSheet 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Custom](#Custom) | 사용자 정의 오류 시트를 출력하도록 지정합니다. |
+| [None](#None) | 오류 시트가 출력되지 않도록 지정합니다. |
+| [Standard](#Standard) | 표준(장치 정의) 오류 시트가 출력되도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Custom {#Custom}
+```
+public static final JobErrorSheet.ErrorSheetOption Custom
+```
+
+
+사용자 지정 오류 시트가 출력되도록 지정합니다. JobErrorSheetSource   ParameterInit 요소가 지정되지 않은 경우, 이 옵션은 무시되어야 합니다.
+
+### None {#None}
+```
+public static final JobErrorSheet.ErrorSheetOption None
+```
+
+
+오류 시트가 출력되지 않도록 지정합니다.
+
+### Standard {#Standard}
+```
+public static final JobErrorSheet.ErrorSheetOption Standard
+```
+
+
+표준(장치 정의) 오류 시트가 출력되도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/errorsheetwhen/_index.md
+++ b/korean/java/com.aspose.xps.metadata/errorsheetwhen/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobErrorSheet.ErrorSheetWhen"
+second_title: "Aspose.Page용 Java API 참조"
+description: "내부 ErrorSheetWhen 기능을 설명합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/joberrorsheet.errorsheetwhen/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem](../../com.aspose.xps.metadata/ijoberrorsheetitem)
+```
+public static final class JobErrorSheet.ErrorSheetWhen extends Feature implements JobErrorSheet.IJobErrorSheetItem
+```
+
+ErrorSheetWhen 내부 기능을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ErrorSheetWhen(JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption[] options)](#ErrorSheetWhen-com.aspose.xps.metadata.JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ErrorSheetWhen(JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption[] options) {#ErrorSheetWhen-com.aspose.xps.metadata.JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption...-}
+```
+public ErrorSheetWhen(JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ErrorSheetWhenOption\[\]](../../com.aspose.xps.metadata/errorsheetwhenoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/errorsheetwhenoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/errorsheetwhenoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ErrorSheetWhen 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/joberrorsheet.errorsheetwhen.errorsheetwhenoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption extends Option
+```
+
+ErrorSheetWhen 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Always](#Always) | 모든 작업에 대해 오류 시트가 출력되도록 지정합니다. |
+| [OnError](#OnError) | 오류가 발생한 경우에만 오류 시트가 출력되도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Always {#Always}
+```
+public static final JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption Always
+```
+
+
+모든 작업에 대해 오류 시트가 출력되도록 지정합니다.
+
+### OnError {#OnError}
+```
+public static final JobErrorSheet.ErrorSheetWhen.ErrorSheetWhenOption OnError
+```
+
+
+오류가 발생한 경우에만 오류 시트가 출력되도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/feature/_index.md
+++ b/korean/java/com.aspose.xps.metadata/feature/_index.md
@@ -1,0 +1,188 @@
+---
+title: "기능"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 Print Schema 기능을 캡슐화하는 클래스입니다."
+type: docs
+weight: 38
+url: /ko/java/com.aspose.xps.metadata/feature/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem), [com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public class Feature extends CompositePrintTicketElement implements IPrintTicketItem, IFeatureItem
+```
+
+공통 Print Schema 기능을 캡슐화하는 클래스입니다. 모든 스키마 정의 기능의 기본 클래스입니다. A  Feature  요소는 장치 속성, 작업 서식 설정 또는 기타 관련 특성을 완전히 설명하는  Option  및  Property  요소의 전체 목록을 포함합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/feature
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Feature(String name, Option option, IFeatureItem[] items)](#Feature-java.lang.String-com.aspose.xps.metadata.Option-com.aspose.xps.metadata.IFeatureItem...-) | 새 PrintTicket 기능 인스턴스를 생성합니다. |
+| [Feature(String name, Feature feature, IFeatureItem[] items)](#Feature-java.lang.String-com.aspose.xps.metadata.Feature-com.aspose.xps.metadata.IFeatureItem...-) | 새 PrintTicket 기능 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Feature(String name, Option option, IFeatureItem[] items) {#Feature-java.lang.String-com.aspose.xps.metadata.Option-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public Feature(String name, Option option, IFeatureItem[] items)
+```
+
+
+새 PrintTicket 기능 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 기능 이름. |
+| option | [Option](../../com.aspose.xps.metadata/option) | 필수  Option  인스턴스. |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 임의의  IFeatureItem  인스턴스 배열입니다. 각 항목은  Feature ,  Option , 또는  Property  인스턴스여야 합니다. |
+
+### Feature(String name, Feature feature, IFeatureItem[] items) {#Feature-java.lang.String-com.aspose.xps.metadata.Feature-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public Feature(String name, Feature feature, IFeatureItem[] items)
+```
+
+
+새 PrintTicket 기능 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 기능 이름. |
+| feature | [Feature](../../com.aspose.xps.metadata/feature) | 필수 Feature 인스턴스. |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 임의의 Property 인스턴스 배열. 각각은 Feature, Option 또는 Property 인스턴스여야 합니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/feeddirection/_index.md
+++ b/korean/java/com.aspose.xps.metadata/feeddirection/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.FeedDirection"
+second_title: "Aspose.Page용 Java API 참조"
+description: "FeedDirection 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/inputbin.feeddirection/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.FeedDirection extends Property implements InputBin.IInputBinOptionItem
+```
+
+FeedDirection 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [LongEdgeFirst](#LongEdgeFirst) | LongEdgeFirst 값. |
+| [ShortEdgeFirst](#ShortEdgeFirst) | LongEdgeFirst 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### LongEdgeFirst {#LongEdgeFirst}
+```
+public static final InputBin.FeedDirection LongEdgeFirst
+```
+
+
+LongEdgeFirst 값.
+
+### ShortEdgeFirst {#ShortEdgeFirst}
+```
+public static final InputBin.FeedDirection ShortEdgeFirst
+```
+
+
+LongEdgeFirst 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/feedface/_index.md
+++ b/korean/java/com.aspose.xps.metadata/feedface/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.FeedFace"
+second_title: "Aspose.Page용 Java API 참조"
+description: "FeedFace 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/inputbin.feedface/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.FeedFace extends Property implements InputBin.IInputBinOptionItem
+```
+
+FeedFace 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FaceDown](#FaceDown) | FaceDown 값. |
+| [FaceUp](#FaceUp) | FaceUp 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FaceDown {#FaceDown}
+```
+public static final InputBin.FeedFace FaceDown
+```
+
+
+FaceDown 값.
+
+### FaceUp {#FaceUp}
+```
+public static final InputBin.FeedFace FaceUp
+```
+
+
+FaceUp 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/feedtype/_index.md
+++ b/korean/java/com.aspose.xps.metadata/feedtype/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.FeedType"
+second_title: "Aspose.Page용 Java API 참조"
+description: "FeedType 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/inputbin.feedtype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.FeedType extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+FeedType 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Automatic](#Automatic) | 자동 값. |
+| [Manual](#Manual) | 수동 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static final InputBin.FeedType Automatic
+```
+
+
+자동 값.
+
+### Manual {#Manual}
+```
+public static final InputBin.FeedType Manual
+```
+
+
+수동 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/frontcoating/_index.md
+++ b/korean/java/com.aspose.xps.metadata/frontcoating/_index.md
@@ -1,0 +1,196 @@
+---
+title: "PageMediaType.FrontCoating"
+second_title: "Aspose.Page용 Java API 참조"
+description: "FrontCoating 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.frontcoating/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.FrontCoating extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+FrontCoating 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Glossy](#Glossy) | Glossy value. |
+| [HighGloss](#HighGloss) | HighGloss value. |
+| [Matte](#Matte) | Matte value. |
+| [None](#None) | None 값. |
+| [Satin](#Satin) | Satin value. |
+| [SemiGloss](#SemiGloss) | SemiGloss value. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Glossy {#Glossy}
+```
+public static PageMediaType.FrontCoating Glossy
+```
+
+
+Glossy value.
+
+### HighGloss {#HighGloss}
+```
+public static PageMediaType.FrontCoating HighGloss
+```
+
+
+HighGloss value.
+
+### Matte {#Matte}
+```
+public static PageMediaType.FrontCoating Matte
+```
+
+
+Matte value.
+
+### None {#None}
+```
+public static PageMediaType.FrontCoating None
+```
+
+
+None 값.
+
+### Satin {#Satin}
+```
+public static PageMediaType.FrontCoating Satin
+```
+
+
+Satin value.
+
+### SemiGloss {#SemiGloss}
+```
+public static PageMediaType.FrontCoating SemiGloss
+```
+
+
+SemiGloss value.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/holepunch/_index.md
+++ b/korean/java/com.aspose.xps.metadata/holepunch/_index.md
@@ -1,0 +1,149 @@
+---
+title: "HolePunch"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobHolePunch 및 DocumentHolePunch 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 39
+url: /ko/java/com.aspose.xps.metadata/holepunch/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class HolePunch extends Feature
+```
+
+JobHolePunch 및 DocumentHolePunch 기능 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/holepunchoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/holepunchoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "HolePunch.HolePunchOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "HolePunch 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/holepunch.holepunchoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class HolePunch.HolePunchOption extends Option
+```
+
+HolePunch 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BottomEdge](#BottomEdge) | 하단 가장자리를 따라 구멍(들)을 지정합니다. |
+| [LeftEdge](#LeftEdge) | 왼쪽 가장자리를 따라 구멍(들)을 지정합니다. |
+| [None](#None) | 구멍 뚫기를 지정하지 않습니다. |
+| [RightEdge](#RightEdge) | 오른쪽 가장자리를 따라 구멍(들)을 지정합니다. |
+| [TopEdge](#TopEdge) | 상단 가장자리를 따라 구멍(들)을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BottomEdge {#BottomEdge}
+```
+public static HolePunch.HolePunchOption BottomEdge
+```
+
+
+하단 가장자리를 따라 구멍(들)을 지정합니다.
+
+### LeftEdge {#LeftEdge}
+```
+public static HolePunch.HolePunchOption LeftEdge
+```
+
+
+왼쪽 가장자리를 따라 구멍(들)을 지정합니다.
+
+### None {#None}
+```
+public static HolePunch.HolePunchOption None
+```
+
+
+구멍 뚫기를 지정하지 않습니다.
+
+### RightEdge {#RightEdge}
+```
+public static HolePunch.HolePunchOption RightEdge
+```
+
+
+오른쪽 가장자리를 따라 구멍(들)을 지정합니다.
+
+### TopEdge {#TopEdge}
+```
+public static HolePunch.HolePunchOption TopEdge
+```
+
+
+상단 가장자리를 따라 구멍(들)을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/ibindingoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ibindingoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "JobBindAllDocuments.IBindingOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "BindingOption 항목의 인터페이스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/jobbindalldocuments.ibindingoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface JobBindAllDocuments.IBindingOptionItem extends IOptionItem
+```
+
+BindingOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/idocumentprintticketitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/idocumentprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IDocumentPrintTicketItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서 접두사가 붙은 인쇄 티켓 항목의 인터페이스."
+type: docs
+weight: 153
+url: /ko/java/com.aspose.xps.metadata/idocumentprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public interface IDocumentPrintTicketItem extends IPrintTicketItem
+```
+
+문서 접두사가 붙은 인쇄 티켓 항목의 인터페이스.

--- a/korean/java/com.aspose.xps.metadata/idproperty/_index.md
+++ b/korean/java/com.aspose.xps.metadata/idproperty/_index.md
@@ -1,0 +1,135 @@
+---
+title: "IDProperty"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobID 및 DocumentID 속성 클래스의 기본 클래스입니다."
+type: docs
+weight: 40
+url: /ko/java/com.aspose.xps.metadata/idproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public class IDProperty extends Property
+```
+
+JobID 및 DocumentID 속성 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/ifeatureitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ifeatureitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IFeatureItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Print Schema Feature 항목이 될 수 있는 클래스용 기본 인터페이스입니다."
+type: docs
+weight: 154
+url: /ko/java/com.aspose.xps.metadata/ifeatureitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IFeatureItem extends IPrintTicketElementChild
+```
+
+Print Schema Feature 항목이 될 수 있는 클래스들의 기본 인터페이스.

--- a/korean/java/com.aspose.xps.metadata/iinputbinitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/iinputbinitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "InputBin.IInputBinItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 JobInputBin, DocumentInputBin 및 PageInputBin 기능 항목의 인터페이스."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.xps.metadata/inputbin.iinputbinitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface InputBin.IInputBinItem extends IFeatureItem
+```
+
+모든 JobInputBin, DocumentInputBin 및 PageInputBin 기능 항목의 인터페이스.

--- a/korean/java/com.aspose.xps.metadata/iinputbinoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/iinputbinoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "InputBin.IInputBinOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 InputBinOption 항목의 인터페이스입니다."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.xps.metadata/inputbin.iinputbinoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface InputBin.IInputBinOptionItem extends IOptionItem
+```
+
+모든 InputBinOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ijobdevicelanguageoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ijobdevicelanguageoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "JobDeviceLanguage.IJobDeviceLanguageOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobDeviceLanguageOption 항목의 인터페이스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/jobdevicelanguage.ijobdevicelanguageoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface JobDeviceLanguage.IJobDeviceLanguageOptionItem extends IOptionItem
+```
+
+JobDeviceLanguageOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ijoberrorsheetitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ijoberrorsheetitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "JobErrorSheet.IJobErrorSheetItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobErrorSheet 기능 항목의 인터페이스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/joberrorsheet.ijoberrorsheetitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface JobErrorSheet.IJobErrorSheetItem extends IFeatureItem
+```
+
+JobErrorSheet 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ijobprintticketitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ijobprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IJobPrintTicketItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업 접두사가 붙은 인쇄 티켓 항목의 인터페이스입니다."
+type: docs
+weight: 155
+url: /ko/java/com.aspose.xps.metadata/ijobprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public interface IJobPrintTicketItem extends IPrintTicketItem
+```
+
+작업 접두사가 붙은 인쇄 티켓 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/inputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/inputbin/_index.md
@@ -1,0 +1,149 @@
+---
+title: "InputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobInputBin, DocumentInputBin 및 PageInputBin 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 41
+url: /ko/java/com.aspose.xps.metadata/inputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class InputBin extends Feature
+```
+
+JobInputBin, DocumentInputBin 및 PageInputBin 기능 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/inputbinoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/inputbinoption/_index.md
@@ -1,0 +1,247 @@
+---
+title: "InputBin.InputBinOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobInputBin, DocumentInputBin 및 PageInputBin 기능 옵션을 설명합니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.metadata/inputbin.inputbinoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinItem](../../com.aspose.xps.metadata/iinputbinitem)
+```
+public static final class InputBin.InputBinOption extends Option implements InputBin.IInputBinItem
+```
+
+JobInputBin, DocumentInputBin 및 PageInputBin 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [InputBinOption(String optionName, InputBin.IInputBinOptionItem[] items)](#InputBinOption-java.lang.String-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-) | 새 인스턴스를 생성합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AutoSelect](#AutoSelect) | Device will automatically choose best option based on configuration. |
+| [AutoSheetFeeder](#AutoSheetFeeder) | 잉크젯 프린터용 장치 입력 트레이. |
+| [Cassette](#Cassette) | 피드 빈이 카세트임을 지정합니다. |
+| [Manual](#Manual) | 기본 수동 피드 빈을 지정합니다. |
+| [Tractor](#Tractor) | 피드 빈이 트랙터임을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(InputBin.IInputBinOptionItem[] items)](#add-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-) | 옵션에 IInputBinOptionItem 인스턴스 배열을 추가합니다. |
+| [clone()](#clone--) | 이 옵션 인스턴스를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### InputBinOption(String optionName, InputBin.IInputBinOptionItem[] items) {#InputBinOption-java.lang.String-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-}
+```
+public InputBinOption(String optionName, InputBin.IInputBinOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| optionName | java.lang.String | 옵션 이름입니다. |
+| items | [IInputBinOptionItem\[\]](../../com.aspose.xps.metadata/iinputbinoptionitem) | IInputBinOptionItem 인스턴스의 임의 배열입니다. |
+
+### AutoSelect {#AutoSelect}
+```
+public static final InputBin.InputBinOption AutoSelect
+```
+
+
+Device will automatically choose best option based on configuration.
+
+### AutoSheetFeeder {#AutoSheetFeeder}
+```
+public static final InputBin.InputBinOption AutoSheetFeeder
+```
+
+
+잉크젯 프린터용 장치 입력 트레이.
+
+### Cassette {#Cassette}
+```
+public static final InputBin.InputBinOption Cassette
+```
+
+
+피드 빈이 카세트임을 지정합니다.
+
+### Manual {#Manual}
+```
+public static final InputBin.InputBinOption Manual
+```
+
+
+기본 수동 피드 빈을 지정합니다.
+
+### Tractor {#Tractor}
+```
+public static final InputBin.InputBinOption Tractor
+```
+
+
+피드 빈이 트랙터임을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(InputBin.IInputBinOptionItem[] items) {#add-com.aspose.xps.metadata.InputBin.IInputBinOptionItem...-}
+```
+public InputBin.InputBinOption add(InputBin.IInputBinOptionItem[] items)
+```
+
+
+옵션에 IInputBinOptionItem 인스턴스 배열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IInputBinOptionItem\[\]](../../com.aspose.xps.metadata/iinputbinoptionitem) | IInputBinOptionItem 인스턴스의 임의 배열입니다. |
+
+**Returns:**
+[InputBinOption](../../com.aspose.xps.metadata/inputbinoption) - This options instance.
+### clone() {#clone--}
+```
+public InputBin.InputBinOption clone()
+```
+
+
+이 옵션 인스턴스를 복제합니다.
+
+**Returns:**
+[InputBinOption](../../com.aspose.xps.metadata/inputbinoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/integerparameterinit/_index.md
+++ b/korean/java/com.aspose.xps.metadata/integerparameterinit/_index.md
@@ -1,0 +1,187 @@
+---
+title: "IntegerParameterInit"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 정수 매개변수 초기화기의 기본 클래스입니다."
+type: docs
+weight: 42
+url: /ko/java/com.aspose.xps.metadata/integerparameterinit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit)
+```
+public abstract class IntegerParameterInit extends ParameterInit
+```
+
+모든 정수 매개변수 초기화기의 기본 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [IntegerParameterInit(String name, int value)](#IntegerParameterInit-java.lang.String-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntegerParameterInit(String name, int value) {#IntegerParameterInit-java.lang.String-int-}
+```
+public IntegerParameterInit(String name, int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 매개변수 이름. |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/integervalue/_index.md
+++ b/korean/java/com.aspose.xps.metadata/integervalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "IntegerValue"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 문서에서 정수 값을 캡슐화하는 클래스입니다."
+type: docs
+weight: 43
+url: /ko/java/com.aspose.xps.metadata/integervalue/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class IntegerValue extends Value
+```
+
+PrintTicket 문서에서 정수 값을 캡슐화하는 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [IntegerValue(int value)](#IntegerValue-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [getValueString()](#getValueString--) | 값을 문자열로 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### IntegerValue(int value) {#IntegerValue-int-}
+```
+public IntegerValue(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 정수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+값을 문자열로 가져옵니다.
+
+**Returns:**
+java.lang.String - 값은 문자열입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/inupitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/inupitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "NUp.INUpItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobNUpAllDocumentsContiguously 또는 DocumentNUp 기능 항목의 인터페이스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/nup.inupitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface NUp.INUpItem extends IFeatureItem
+```
+
+JobNUpAllDocumentsContiguously 또는 DocumentNUp 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ioptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ioptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Print Schema 옵션 항목이 될 수 있는 클래스의 인터페이스입니다."
+type: docs
+weight: 156
+url: /ko/java/com.aspose.xps.metadata/ioptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IOptionItem extends IPrintTicketElementChild
+```
+
+Print Schema  Option  항목이 될 수 있는 클래스들의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ioutputbinitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ioutputbinitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "OutputBin.IOutputBinItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobOutputBin, DocumentOutputBin 및 PageOutputBin 기능 항목의 인터페이스입니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/outputbin.ioutputbinitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface OutputBin.IOutputBinItem extends IFeatureItem
+```
+
+어떤  JobOutputBin ,  DocumentOutputBin  및  PageOutputBin  기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ioutputbinoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ioutputbinoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "OutputBin.IOutputBinOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 OutputBinOption 항목의 인터페이스입니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.metadata/outputbin.ioutputbinoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface OutputBin.IOutputBinOptionItem extends IOptionItem
+```
+
+모든 OutputBinOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagemediasizeitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagemediasizeitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaSize.IPageMediaSizeItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMediaSize 항목의 인터페이스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/pagemediasize.ipagemediasizeitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageMediaSize.IPageMediaSizeItem extends IFeatureItem
+```
+
+어떤  PageMediaSize  항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagemediasizeoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagemediasizeoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaSize.IPageMediaSizeOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 PageMediaSizeOption 항목의 인터페이스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/pagemediasize.ipagemediasizeoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageMediaSize.IPageMediaSizeOptionItem extends IOptionItem
+```
+
+모든  PageMediaSizeOption  항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagemediatypeitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagemediatypeitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaType.IPageMediaTypeItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMediaType 기능 항목의 인터페이스입니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.ipagemediatypeitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageMediaType.IPageMediaTypeItem extends IFeatureItem
+```
+
+PageMediaType 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagemediatypeoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagemediatypeoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageMediaType.IPageMediaTypeOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMediaType 항목의 인터페이스입니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.ipagemediatypeoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageMediaType.IPageMediaTypeOptionItem extends IOptionItem
+```
+
+PageMediaType 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipageoutputcoloritem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipageoutputcoloritem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageOutputColor.IPageOutputColorItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageOutputColor 기능 항목의 인터페이스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/pageoutputcolor.ipageoutputcoloritem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageOutputColor.IPageOutputColorItem extends IFeatureItem
+```
+
+PageOutputColor 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipageoutputcoloroptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipageoutputcoloroptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageOutputColor.IPageOutputColorOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 PageOutputColorOption 항목의 인터페이스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/pageoutputcolor.ipageoutputcoloroptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageOutputColor.IPageOutputColorOptionItem extends IOptionItem
+```
+
+모든  PageOutputColorOption  항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipageprintticketitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipageprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IPagePrintTicketItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "페이지 접두사가 붙은 인쇄 티켓 항목의 인터페이스입니다."
+type: docs
+weight: 157
+url: /ko/java/com.aspose.xps.metadata/ipageprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public interface IPagePrintTicketItem extends IPrintTicketItem
+```
+
+페이지 접두사가 붙은 인쇄 티켓 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipageresolutionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipageresolutionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageResolution.IPageResolutionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageResolution 기능 항목의 인터페이스입니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/pageresolution.ipageresolutionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageResolution.IPageResolutionItem extends IFeatureItem
+```
+
+PageResolution 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipageresolutionoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipageresolutionoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageResolution.IPageResolutionOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageResolutionOption 항목의 인터페이스입니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/pageresolution.ipageresolutionoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageResolution.IPageResolutionOptionItem extends IOptionItem
+```
+
+PageResolutionOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagescalingitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagescalingitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageScaling.IPageScalingItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageScaling 기능 항목의 인터페이스입니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/pagescaling.ipagescalingitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageScaling.IPageScalingItem extends IFeatureItem
+```
+
+PageScaling 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagewatermarkitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagewatermarkitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageWatermark.IPageWatermarkItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageWatermark 기능 항목의 인터페이스입니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/pagewatermark.ipagewatermarkitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public static interface PageWatermark.IPageWatermarkItem extends IFeatureItem
+```
+
+PageWatermark 기능 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/ipagewatermarkoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipagewatermarkoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "PageWatermark.IPageWatermarkOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageWatermarkOption 항목의 인터페이스입니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.metadata/pagewatermark.ipagewatermarkoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface PageWatermark.IPageWatermarkOptionItem extends IOptionItem
+```
+
+PageWatermarkOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/iprintticketelementchild/_index.md
+++ b/korean/java/com.aspose.xps.metadata/iprintticketelementchild/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IPrintTicketElementChild"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 Print Schema 요소의 자식 요소에 대한 기본 인터페이스입니다."
+type: docs
+weight: 158
+url: /ko/java/com.aspose.xps.metadata/iprintticketelementchild/
+---```
+public interface IPrintTicketElementChild
+```
+
+The base interface of a child element of any Print Schema element.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getName()](#getName--) | Returns the child name. |
+### getName() {#getName--}
+```
+public abstract String getName()
+```
+
+
+Returns the child name.
+
+**Returns:**
+java.lang.String - The child name.

--- a/korean/java/com.aspose.xps.metadata/iprintticketitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/iprintticketitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IPrintTicketItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 루트 요소 항목이 될 수 있는 클래스에 대한 기본 인터페이스입니다."
+type: docs
+weight: 159
+url: /ko/java/com.aspose.xps.metadata/iprintticketitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IPrintTicketItem extends IPrintTicketElementChild
+```
+
+PrintTicket 루트 요소 항목이 될 수 있는 클래스에 대한 기본 인터페이스입니다. 또한 범위 접두사를 정의하는 인터페이스에 대한 기본 인터페이스이기도 합니다.

--- a/korean/java/com.aspose.xps.metadata/ipropertyitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/ipropertyitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IPropertyItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 속성 항목이 될 수 있는 클래스에 대한 기본 인터페이스입니다."
+type: docs
+weight: 160
+url: /ko/java/com.aspose.xps.metadata/ipropertyitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IPropertyItem extends IPrintTicketElementChild
+```
+
+PrintTicket  Property  항목이 될 수 있는 클래스들의 기본 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/iscoredpropertyitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/iscoredpropertyitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "IScoredPropertyItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket ScoredProperty 항목이 될 수 있는 클래스의 기본 인터페이스입니다."
+type: docs
+weight: 161
+url: /ko/java/com.aspose.xps.metadata/iscoredpropertyitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public interface IScoredPropertyItem extends IPrintTicketElementChild
+```
+
+PrintTicket  ScoredProperty  항목이 될 수 있는 클래스들의 기본 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/istapleoptionitem/_index.md
+++ b/korean/java/com.aspose.xps.metadata/istapleoptionitem/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Staple.IStapleOptionItem"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 StapleOption 항목의 인터페이스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/staple.istapleoptionitem/
+---
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem)
+```
+public static interface Staple.IStapleOptionItem extends IOptionItem
+```
+
+모든 StapleOption 항목의 인터페이스입니다.

--- a/korean/java/com.aspose.xps.metadata/jobaccountingsheet/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobaccountingsheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobAccountingSheet"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대해 출력될 회계 시트를 설명합니다."
+type: docs
+weight: 44
+url: /ko/java/com.aspose.xps.metadata/jobaccountingsheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobAccountingSheet extends Feature implements IJobPrintTicketItem
+```
+
+작업에 출력될 회계 시트를 설명합니다. 회계 시트는 기본  PageMediaSize  및 기본  PageMediaType 을 사용하여 출력되어야 합니다. 회계 시트는 작업의 나머지 부분과 분리되어야 합니다. 이는  JobDuplex ,  JobStaple , 또는  JobBinding 과 같은 마감 또는 처리 옵션에 회계 시트가 포함되지 않아야 함을 의미합니다. 회계 시트는 구현자의 재량에 따라 작업의 첫 페이지 또는 마지막 페이지에 나타날 수 있습니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobaccountingsheet
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobAccountingSheet(JobAccountingSheet.JobAccountingSheetOption[] options)](#JobAccountingSheet-com.aspose.xps.metadata.JobAccountingSheet.JobAccountingSheetOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobAccountingSheet(JobAccountingSheet.JobAccountingSheetOption[] options) {#JobAccountingSheet-com.aspose.xps.metadata.JobAccountingSheet.JobAccountingSheetOption...-}
+```
+public JobAccountingSheet(JobAccountingSheet.JobAccountingSheetOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [JobAccountingSheetOption\[\]](../../com.aspose.xps.metadata/jobaccountingsheetoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobaccountingsheetoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobaccountingsheetoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "JobAccountingSheet.JobAccountingSheetOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobAccountingSheet 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobaccountingsheet.jobaccountingsheetoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobAccountingSheet.JobAccountingSheetOption extends Option
+```
+
+JobAccountingSheet 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | 회계 시트가 출력되지 않음을 지정합니다. |
+| [Standard](#Standard) | 표준(장치 정의) 회계 시트를 출력하도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final JobAccountingSheet.JobAccountingSheetOption None
+```
+
+
+회계 시트가 출력되지 않음을 지정합니다.
+
+### Standard {#Standard}
+```
+public static final JobAccountingSheet.JobAccountingSheetOption Standard
+```
+
+
+표준(장치 정의) 회계 시트를 출력하도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobbindalldocuments/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobbindalldocuments/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobBindAllDocuments"
+second_title: "Aspose.Page용 Java API 참조"
+description: "제본 방법을 설명합니다."
+type: docs
+weight: 45
+url: /ko/java/com.aspose.xps.metadata/jobbindalldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobBindAllDocuments extends Feature implements IJobPrintTicketItem
+```
+
+바인딩 방법을 설명합니다. 작업의 모든 문서가 함께 바인딩됩니다. JobBindAllDocuments와 DocumentBinding은 상호 배타적입니다. 이러한 키워드 간의 제약 처리 여부는 드라이버가 결정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobbindalldocuments
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobBindAllDocuments(JobBindAllDocuments.BindingOption[] options)](#JobBindAllDocuments-com.aspose.xps.metadata.JobBindAllDocuments.BindingOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobBindAllDocuments(JobBindAllDocuments.BindingOption[] options) {#JobBindAllDocuments-com.aspose.xps.metadata.JobBindAllDocuments.BindingOption...-}
+```
+public JobBindAllDocuments(JobBindAllDocuments.BindingOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [BindingOption\[\]](../../com.aspose.xps.metadata/bindingoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobbindalldocumentsgutter/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobbindalldocumentsgutter/_index.md
@@ -1,0 +1,189 @@
+---
+title: "JobBindAllDocumentsGutter"
+second_title: "Aspose.Page용 Java API 참조"
+description: "제본 여백의 너비를 지정합니다."
+type: docs
+weight: 46
+url: /ko/java/com.aspose.xps.metadata/jobbindalldocumentsgutter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobBindAllDocumentsGutter extends IntegerParameterInit implements IJobPrintTicketItem
+```
+
+제본 홈(가터)의 너비를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobbindalldocumentsgutter
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobBindAllDocumentsGutter(int value)](#JobBindAllDocumentsGutter-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobBindAllDocumentsGutter(int value) {#JobBindAllDocumentsGutter-int-}
+```
+public JobBindAllDocumentsGutter(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobcollatealldocuments/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobcollatealldocuments/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobCollateAllDocuments"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 정렬 특성을 설명합니다."
+type: docs
+weight: 47
+url: /ko/java/com.aspose.xps.metadata/jobcollatealldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Collate](../../com.aspose.xps.metadata/collate)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobCollateAllDocuments extends Collate implements IJobPrintTicketItem
+```
+
+출력의 정렬 특성을 설명합니다. 각 개별 작업의 모든 문서가 정렬됩니다. DocumentCollate와 JobCollateAllDocuments는 상호 배타적입니다. 두 키워드 중 하나만 구현할지 여부에 대한 동작 및 구현은 드라이버에 맡겨집니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobcollatealldocuments
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobCollateAllDocuments(Collate.CollateOption[] options)](#JobCollateAllDocuments-com.aspose.xps.metadata.Collate.CollateOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobCollateAllDocuments(Collate.CollateOption[] options) {#JobCollateAllDocuments-com.aspose.xps.metadata.Collate.CollateOption...-}
+```
+public JobCollateAllDocuments(Collate.CollateOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [CollateOption\[\]](../../com.aspose.xps.metadata/collateoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobcomment/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobcomment/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobComment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업과 연결된 주석을 지정합니다."
+type: docs
+weight: 48
+url: /ko/java/com.aspose.xps.metadata/jobcomment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobComment extends StringParameterInit implements IJobPrintTicketItem
+```
+
+작업과 연결된 주석을 지정합니다. 예: "Please deliver to room 1234 when completed". https://docs.microsoft.com/en-us/windows/win32/printdocs/jobcomment
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobComment(String value)](#JobComment-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobComment(String value) {#JobComment-java.lang.String-}
+```
+public JobComment(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobcopiesalldocuments/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobcopiesalldocuments/_index.md
@@ -1,0 +1,189 @@
+---
+title: "JobCopiesAllDocuments"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업의 복사본 수를 지정합니다."
+type: docs
+weight: 49
+url: /ko/java/com.aspose.xps.metadata/jobcopiesalldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobCopiesAllDocuments extends IntegerParameterInit implements IJobPrintTicketItem
+```
+
+작업의 복사본 수를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobcopiesalldocuments
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobCopiesAllDocuments(int value)](#JobCopiesAllDocuments-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobCopiesAllDocuments(int value) {#JobCopiesAllDocuments-int-}
+```
+public JobCopiesAllDocuments(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobdevicelanguage/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobdevicelanguage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobDeviceLanguage"
+second_title: "Aspose.Page용 Java API 참조"
+description: "드라이버에서 물리적 장치로 데이터를 전송하기 위해 지원되는 장치 언어를 설명합니다."
+type: docs
+weight: 50
+url: /ko/java/com.aspose.xps.metadata/jobdevicelanguage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobDeviceLanguage extends Feature implements IJobPrintTicketItem
+```
+
+드라이버에서 물리적 장치로 데이터를 전송하는 데 지원되는 장치 언어를 설명합니다. 이는 일반적으로 "Page Description Language"라고 합니다. 이 키워드는 드라이버와 물리적 장치가 지원하는 페이지 설명 언어를 정의합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobdevicelanguage
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobDeviceLanguage(JobDeviceLanguage.JobDeviceLanguageOption[] options)](#JobDeviceLanguage-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDeviceLanguage(JobDeviceLanguage.JobDeviceLanguageOption[] options) {#JobDeviceLanguage-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption...-}
+```
+public JobDeviceLanguage(JobDeviceLanguage.JobDeviceLanguageOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [JobDeviceLanguageOption\[\]](../../com.aspose.xps.metadata/jobdevicelanguageoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobdevicelanguageoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobdevicelanguageoption/_index.md
@@ -1,0 +1,432 @@
+---
+title: "JobDeviceLanguage.JobDeviceLanguageOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobDeviceLanguage 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobdevicelanguage.jobdevicelanguageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobDeviceLanguage.JobDeviceLanguageOption extends Option
+```
+
+JobDeviceLanguage 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobDeviceLanguageOption(String name, JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)](#JobDeviceLanguageOption-java.lang.String-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-) | 새 인스턴스를 생성합니다. |
+| [JobDeviceLanguageOption(JobDeviceLanguage.JobDeviceLanguageOption option)](#JobDeviceLanguageOption-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption-) | 이 옵션 인스턴스를 복제합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ART](#ART) | 지정된 장치 언어는 ART입니다. |
+| [ASCII](#ASCII) | 지정된 장치 언어는 ASCII입니다. |
+| [CaPSL](#CaPSL) | 지정된 장치 언어는 CaPSL입니다. |
+| [ESCP2](#ESCP2) | 지정된 장치 언어는 ESC/P2입니다. |
+| [ESCPage](#ESCPage) | 지정된 장치 언어는 ESC/Page입니다. |
+| [HPGL2](#HPGL2) | 지정된 장치 언어는 HP-GL/2입니다. |
+| [KPDL](#KPDL) | 지정된 장치 언어는 KPDL입니다. |
+| [KS](#KS) | 지정된 장치 언어는 KS입니다. |
+| [KSSM](#KSSM) | 지정된 장치 언어는 KSSM입니다. |
+| [PCL](#PCL) | 지정된 장치 언어는 PCL입니다. |
+| [PCL5c](#PCL5c) | 지정된 장치 언어는 PCL5c입니다. |
+| [PCL5e](#PCL5e) | 지정된 장치 언어는 PCL5e입니다. |
+| [PCLXL](#PCLXL) | 지정된 장치 언어는 PCL-XL입니다. |
+| [PPDS](#PPDS) | 지정된 장치 언어는 PPDS입니다. |
+| [PostScript](#PostScript) | 지정된 장치 언어는 PostScript입니다. |
+| [RPDL](#RPDL) | 지정된 장치 언어는 RPDL입니다. |
+| [RTL](#RTL) | 지정된 장치 언어는 RTL입니다. |
+| [XPS](#XPS) | 장치 언어가 XPS임을 지정합니다. |
+| [_201PL](#-201PL) | 장치 언어가 PC-PR201임을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)](#add-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-) | 옵션에  IJobDeviceLanguageOptionItem  인스턴스 목록을 추가합니다. |
+| [clone()](#clone--) | 이 옵션 인스턴스를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLanguageEncoding(String languageEncoding)](#setLanguageEncoding-java.lang.String-) |   LanguageEncoding  점수 속성 값을 설정합니다. |
+| [setLanguageLevel(String languageLevel)](#setLanguageLevel-java.lang.String-) |   LanguageLevel  점수 속성 값을 설정합니다. |
+| [setLanguageVersion(String languageVersion)](#setLanguageVersion-java.lang.String-) |   LanguageVersion  점수 속성 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDeviceLanguageOption(String name, JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items) {#JobDeviceLanguageOption-java.lang.String-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-}
+```
+public JobDeviceLanguageOption(String name, JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 옵션 이름. |
+| items | [IJobDeviceLanguageOptionItem\[\]](../../com.aspose.xps.metadata/ijobdevicelanguageoptionitem) | 임의의  IJobDeviceLanguageOptionItem  인스턴스 배열. |
+
+### JobDeviceLanguageOption(JobDeviceLanguage.JobDeviceLanguageOption option) {#JobDeviceLanguageOption-com.aspose.xps.metadata.JobDeviceLanguage.JobDeviceLanguageOption-}
+```
+public JobDeviceLanguageOption(JobDeviceLanguage.JobDeviceLanguageOption option)
+```
+
+
+이 옵션 인스턴스를 복제합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| option | [JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) | 복제할 인스턴스. |
+
+### ART {#ART}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ART
+```
+
+
+지정된 장치 언어는 ART입니다.
+
+### ASCII {#ASCII}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ASCII
+```
+
+
+지정된 장치 언어는 ASCII입니다.
+
+### CaPSL {#CaPSL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption CaPSL
+```
+
+
+지정된 장치 언어는 CaPSL입니다.
+
+### ESCP2 {#ESCP2}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ESCP2
+```
+
+
+지정된 장치 언어는 ESC/P2입니다.
+
+### ESCPage {#ESCPage}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption ESCPage
+```
+
+
+지정된 장치 언어는 ESC/Page입니다.
+
+### HPGL2 {#HPGL2}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption HPGL2
+```
+
+
+지정된 장치 언어는 HP-GL/2입니다.
+
+### KPDL {#KPDL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption KPDL
+```
+
+
+지정된 장치 언어는 KPDL입니다.
+
+### KS {#KS}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption KS
+```
+
+
+지정된 장치 언어는 KS입니다.
+
+### KSSM {#KSSM}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption KSSM
+```
+
+
+지정된 장치 언어는 KSSM입니다.
+
+### PCL {#PCL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCL
+```
+
+
+지정된 장치 언어는 PCL입니다.
+
+### PCL5c {#PCL5c}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCL5c
+```
+
+
+지정된 장치 언어는 PCL5c입니다.
+
+### PCL5e {#PCL5e}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCL5e
+```
+
+
+지정된 장치 언어는 PCL5e입니다.
+
+### PCLXL {#PCLXL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PCLXL
+```
+
+
+지정된 장치 언어는 PCL-XL입니다.
+
+### PPDS {#PPDS}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PPDS
+```
+
+
+지정된 장치 언어는 PPDS입니다.
+
+### PostScript {#PostScript}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption PostScript
+```
+
+
+지정된 장치 언어는 PostScript입니다.
+
+### RPDL {#RPDL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption RPDL
+```
+
+
+지정된 장치 언어는 RPDL입니다.
+
+### RTL {#RTL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption RTL
+```
+
+
+지정된 장치 언어는 RTL입니다.
+
+### XPS {#XPS}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption XPS
+```
+
+
+장치 언어가 XPS임을 지정합니다.
+
+### _201PL {#-201PL}
+```
+public static final JobDeviceLanguage.JobDeviceLanguageOption _201PL
+```
+
+
+장치 언어가 PC-PR201임을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items) {#add-com.aspose.xps.metadata.JobDeviceLanguage.IJobDeviceLanguageOptionItem...-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption add(JobDeviceLanguage.IJobDeviceLanguageOptionItem[] items)
+```
+
+
+옵션에  IJobDeviceLanguageOptionItem  인스턴스 목록을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IJobDeviceLanguageOptionItem\[\]](../../com.aspose.xps.metadata/ijobdevicelanguageoptionitem) | 임의의  IJobDeviceLanguageOptionItem  인스턴스 배열. |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### clone() {#clone--}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption clone()
+```
+
+
+이 옵션 인스턴스를 복제합니다. 복제 생성자에 대한 바로 가기.
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLanguageEncoding(String languageEncoding) {#setLanguageEncoding-java.lang.String-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption setLanguageEncoding(String languageEncoding)
+```
+
+
+  LanguageEncoding  점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| languageEncoding | java.lang.String |   LanguageEncoding  점수 속성 값. |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### setLanguageLevel(String languageLevel) {#setLanguageLevel-java.lang.String-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption setLanguageLevel(String languageLevel)
+```
+
+
+  LanguageLevel  점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| languageLevel | java.lang.String |   LanguageLevel  점수 속성 값. |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### setLanguageVersion(String languageVersion) {#setLanguageVersion-java.lang.String-}
+```
+public JobDeviceLanguage.JobDeviceLanguageOption setLanguageVersion(String languageVersion)
+```
+
+
+  LanguageVersion  점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| languageVersion | java.lang.String |   LanguageVersion  점수 속성 값. |
+
+**Returns:**
+[JobDeviceLanguageOption](../../com.aspose.xps.metadata/jobdevicelanguageoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobDigitalSignatureProcessing"
+second_title: "Aspose.Page용 Java API 참조"
+description: "전체 작업에 대한 디지털 서명 처리를 구성하는 방법을 설명합니다."
+type: docs
+weight: 51
+url: /ko/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobDigitalSignatureProcessing extends Feature implements IJobPrintTicketItem
+```
+
+전체 작업에 대한 디지털 서명 처리를 구성하는 방법을 설명합니다. 디지털 서명이 포함된 콘텐츠에만 적용됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobdigitalsignatureprocessing
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobDigitalSignatureProcessing(JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption[] options)](#JobDigitalSignatureProcessing-com.aspose.xps.metadata.JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDigitalSignatureProcessing(JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption[] options) {#JobDigitalSignatureProcessing-com.aspose.xps.metadata.JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption...-}
+```
+public JobDigitalSignatureProcessing(JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [JobDigitalSignatureProcessingOption\[\]](../../com.aspose.xps.metadata/jobdigitalsignatureprocessingoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobdigitalsignatureprocessingoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobdigitalsignatureprocessingoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobDigitalSignatureProcessing 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobdigitalsignatureprocessing.jobdigitalsignatureprocessingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption extends Option
+```
+
+JobDigitalSignatureProcessing 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [PrintInvalidSignatures](#PrintInvalidSignatures) | 디지털 서명의 유효성에 관계없이 작업을 인쇄합니다. |
+| [PrintInvalidSignaturesWithErrorReport](#PrintInvalidSignaturesWithErrorReport) | 디지털 서명의 유효성에 관계없이 작업을 인쇄합니다. |
+| [PrintOnlyValidSignatures](#PrintOnlyValidSignatures) | 모든 디지털 서명이 유효한 경우에만 작업을 인쇄합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintInvalidSignatures {#PrintInvalidSignatures}
+```
+public static final JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption PrintInvalidSignatures
+```
+
+
+디지털 서명의 유효성에 관계없이 작업을 인쇄합니다. 디지털 서명은 무시될 수 있습니다.
+
+### PrintInvalidSignaturesWithErrorReport {#PrintInvalidSignaturesWithErrorReport}
+```
+public static final JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption PrintInvalidSignaturesWithErrorReport
+```
+
+
+디지털 서명의 유효성에 관계없이 작업을 인쇄합니다. 유효하지 않은 서명이 발견될 경우, 작업 끝에 오류 페이지가 인쇄되어야 합니다. 디지털 서인은 무시되어서는 안 됩니다.
+
+### PrintOnlyValidSignatures {#PrintOnlyValidSignatures}
+```
+public static final JobDigitalSignatureProcessing.JobDigitalSignatureProcessingOption PrintOnlyValidSignatures
+```
+
+
+모든 디지털 서명이 유효한 경우에만 작업을 인쇄합니다. 디지털 서인은 무시되어서는 안 됩니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobduplexalldocumentscontiguously/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobduplexalldocumentscontiguously/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobDuplexAllDocumentsContiguously"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 양면 인쇄 특성을 설명합니다."
+type: docs
+weight: 52
+url: /ko/java/com.aspose.xps.metadata/jobduplexalldocumentscontiguously/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Duplex](../../com.aspose.xps.metadata/duplex)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobDuplexAllDocumentsContiguously extends Duplex implements IJobPrintTicketItem
+```
+
+출력의 duplex 특성을 설명합니다. duplex 기능은 매체의 양면에 인쇄할 수 있게 합니다. 작업의 모든 Document가 연속적으로 duplex 처리됩니다. JobDuplexAllDocumentsContiguously와 DocumentDuplex는 상호 배타적입니다. 이러한 키워드 간의 제약 처리 여부는 드라이버가 결정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobduplexalldocumentscontiguously
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobDuplexAllDocumentsContiguously(Duplex.DuplexOption[] options)](#JobDuplexAllDocumentsContiguously-com.aspose.xps.metadata.Duplex.DuplexOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobDuplexAllDocumentsContiguously(Duplex.DuplexOption[] options) {#JobDuplexAllDocumentsContiguously-com.aspose.xps.metadata.Duplex.DuplexOption...-}
+```
+public JobDuplexAllDocumentsContiguously(Duplex.DuplexOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [DuplexOption\[\]](../../com.aspose.xps.metadata/duplexoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joberrorsheet/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joberrorsheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobErrorSheet"
+second_title: "Aspose.Page용 Java API 참조"
+description: "오류 시트 출력에 대해 설명합니다."
+type: docs
+weight: 53
+url: /ko/java/com.aspose.xps.metadata/joberrorsheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobErrorSheet extends Feature implements IJobPrintTicketItem
+```
+
+오류 시트 출력에 대해 설명합니다. 전체 작업은 하나의 오류 시트를 가집니다. 오류 시트는 기본 PageMediaSize와 기본 PageMediaType을 사용하여 출력되어야 합니다. 오류 시트는 작업의 나머지 부분과 분리되어야 합니다. 이는 JobDuplex, JobStaple 또는 JobBinding과 같은 마감 또는 처리 옵션에 오류 시트를 포함해서는 안 된다는 의미입니다. 오류 시트는 작업의 마지막 시트로 배치되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/joberrorsheet
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobErrorSheet(JobErrorSheet.IJobErrorSheetItem[] items)](#JobErrorSheet-com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobErrorSheet(JobErrorSheet.IJobErrorSheetItem[] items) {#JobErrorSheet-com.aspose.xps.metadata.JobErrorSheet.IJobErrorSheetItem...-}
+```
+public JobErrorSheet(JobErrorSheet.IJobErrorSheetItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IJobErrorSheetItem\[\]](../../com.aspose.xps.metadata/ijoberrorsheetitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joberrorsheetsource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joberrorsheetsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobErrorSheetSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "맞춤 오류 시트의 소스를 지정합니다."
+type: docs
+weight: 54
+url: /ko/java/com.aspose.xps.metadata/joberrorsheetsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobErrorSheetSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+사용자 정의 오류 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/joberrorsheetsource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobErrorSheetSource(String value)](#JobErrorSheetSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobErrorSheetSource(String value) {#JobErrorSheetSource-java.lang.String-}
+```
+public JobErrorSheetSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobholepunch/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobholepunch/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobHolePunch"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 구멍 뚫기 특성을 설명합니다."
+type: docs
+weight: 55
+url: /ko/java/com.aspose.xps.metadata/jobholepunch/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.HolePunch](../../com.aspose.xps.metadata/holepunch)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobHolePunch extends HolePunch implements IJobPrintTicketItem
+```
+
+출력의 천공 특성을 설명합니다. 모든 문서는 함께 천공됩니다. JobHolePunch와 DocumentHolePunch 키워드는 서로 배타적입니다. 두 키워드는 PrintTicket 또는 Print Capabilities 문서에서 동시에 지정해서는 안 됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobholepunch
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobHolePunch(HolePunch.HolePunchOption[] options)](#JobHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobHolePunch(HolePunch.HolePunchOption[] options) {#JobHolePunch-com.aspose.xps.metadata.HolePunch.HolePunchOption...-}
+```
+public JobHolePunch(HolePunch.HolePunchOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [HolePunchOption\[\]](../../com.aspose.xps.metadata/holepunchoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobid/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobid/_index.md
@@ -1,0 +1,153 @@
+---
+title: "JobID"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대한 고유 ID를 지정합니다."
+type: docs
+weight: 56
+url: /ko/java/com.aspose.xps.metadata/jobid/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.IDProperty](../../com.aspose.xps.metadata/idproperty)
+```
+public final class JobID extends IDProperty
+```
+
+작업에 대한 고유 ID를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobid
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobID(String jobID)](#JobID-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobID(String jobID) {#JobID-java.lang.String-}
+```
+public JobID(String jobID)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| jobID | java.lang.String | 작업 ID입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobinputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobinputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobInputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치에 설치된 입력 빈 또는 장치가 지원하는 전체 빈 목록을 설명합니다."
+type: docs
+weight: 57
+url: /ko/java/com.aspose.xps.metadata/jobinputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.InputBin](../../com.aspose.xps.metadata/inputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobInputBin extends InputBin implements IJobPrintTicketItem
+```
+
+장치에 설치된 입력 빈 또는 장치가 지원하는 모든 빈 목록을 설명합니다. 작업별로 입력 빈을 지정할 수 있습니다. JobInputBin, DocumentInputBin 및 PageInputBin 키워드는 서로 배타적입니다. PrintTicket 또는 Print Capabilities 문서에서 두 키워드를 동시에 지정해서는 안 됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobinputbin
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobInputBin(InputBin.IInputBinItem[] items)](#JobInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobInputBin(InputBin.IInputBinItem[] items) {#JobInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-}
+```
+public JobInputBin(InputBin.IInputBinItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IInputBinItem\[\]](../../com.aspose.xps.metadata/iinputbinitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobname/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobname/_index.md
@@ -1,0 +1,153 @@
+---
+title: "JobName"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대한 설명 이름을 지정합니다."
+type: docs
+weight: 59
+url: /ko/java/com.aspose.xps.metadata/jobname/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.NameProperty](../../com.aspose.xps.metadata/nameproperty)
+```
+public final class JobName extends NameProperty
+```
+
+작업에 대한 설명 이름을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobname
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobName(String jobName)](#JobName-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobName(String jobName) {#JobName-java.lang.String-}
+```
+public JobName(String jobName)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| jobName | java.lang.String | 작업 이름. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobnupalldocumentscontiguously/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobnupalldocumentscontiguously/_index.md
@@ -1,0 +1,186 @@
+---
+title: "JobNUpAllDocumentsContiguously"
+second_title: "Aspose.Page용 Java API 참조"
+description: "여러 논리 페이지를 하나의 물리적 시트에 출력하는 방법을 설명합니다."
+type: docs
+weight: 58
+url: /ko/java/com.aspose.xps.metadata/jobnupalldocumentscontiguously/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.NUp](../../com.aspose.xps.metadata/nup)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobNUpAllDocumentsContiguously extends NUp implements IJobPrintTicketItem
+```
+
+여러 논리 페이지를 하나의 물리적 시트에 출력하는 방식을 설명합니다. 작업의 모든 문서는 연속적으로 함께 컴파일됩니다. JobNUpAllDocumentsContiguously와 DocumentNUp는 서로 배타적입니다. 이러한 키워드 간의 제약 처리 여부는 드라이버가 결정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobnupalldocumentscontiguously
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobNUpAllDocumentsContiguously(NUp.INUpItem[] items)](#JobNUpAllDocumentsContiguously-com.aspose.xps.metadata.NUp.INUpItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [addPagesPerSheetOption(int value)](#addPagesPerSheetOption-int-) | PagesPerSheet 스코어드 속성 값을 사용하여 옵션을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobNUpAllDocumentsContiguously(NUp.INUpItem[] items) {#JobNUpAllDocumentsContiguously-com.aspose.xps.metadata.NUp.INUpItem...-}
+```
+public JobNUpAllDocumentsContiguously(NUp.INUpItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [INUpItem\[\]](../../com.aspose.xps.metadata/inupitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### addPagesPerSheetOption(int value) {#addPagesPerSheetOption-int-}
+```
+public JobNUpAllDocumentsContiguously addPagesPerSheetOption(int value)
+```
+
+
+PagesPerSheet 스코어드 속성 값을 사용하여 옵션을 추가합니다. 물리적 시트당 논리 페이지 수를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | PagesPerSheet 스코어드 속성 값입니다. 지원되는 집합은 예를 들어 \\{1,2,4,6,8,9,16\\}와 같은 정수 집합이면 됩니다. |
+
+**Returns:**
+[JobNUpAllDocumentsContiguously](../../com.aspose.xps.metadata/jobnupalldocumentscontiguously) - This feature instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile/_index.md
@@ -1,0 +1,158 @@
+---
+title: "JobOptimalDestinationColorProfile"
+second_title: "Aspose.Page용 Java API 참조"
+description: "현재 장치 구성에 따라 최적의 색상 프로파일을 지정합니다."
+type: docs
+weight: 60
+url: /ko/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobOptimalDestinationColorProfile extends Property implements IJobPrintTicketItem
+```
+
+현재 장치 구성에 따라 최적의 색 프로필을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/joboptimaldestinationcolorprofile
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobOptimalDestinationColorProfile(JobOptimalDestinationColorProfile.Profile profile, String profileData, String path)](#JobOptimalDestinationColorProfile-com.aspose.xps.metadata.JobOptimalDestinationColorProfile.Profile-java.lang.String-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobOptimalDestinationColorProfile(JobOptimalDestinationColorProfile.Profile profile, String profileData, String path) {#JobOptimalDestinationColorProfile-com.aspose.xps.metadata.JobOptimalDestinationColorProfile.Profile-java.lang.String-java.lang.String-}
+```
+public JobOptimalDestinationColorProfile(JobOptimalDestinationColorProfile.Profile profile, String profileData, String path)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| profile | [Profile](../../com.aspose.xps.metadata/profile) | 색 프로필. |
+| profileData | java.lang.String | 색 프로필 데이터 내용. |
+| path | java.lang.String | 색 프로필에 대한 경로. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joboutputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joboutputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobOutputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치에 설치된 출력 함 또는 장치가 지원하는 함의 전체 목록을 설명합니다."
+type: docs
+weight: 61
+url: /ko/java/com.aspose.xps.metadata/joboutputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.OutputBin](../../com.aspose.xps.metadata/outputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobOutputBin extends OutputBin implements IJobPrintTicketItem
+```
+
+장치에 설치된 출력 빈 또는 장치가 지원하는 전체 출력 빈 목록을 설명합니다.  JobOutputBin ,  DocumentOutputBin  및  PageOutputBin  키워드는 서로 배타적이며, PrintTicket 또는 Print Capabilities 문서에서 하나만 지정해야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/joboutputbin
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobOutputBin(OutputBin.IOutputBinItem[] items)](#JobOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobOutputBin(OutputBin.IOutputBinItem[] items) {#JobOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-}
+```
+public JobOutputBin(OutputBin.IOutputBinItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOutputBinItem\[\]](../../com.aspose.xps.metadata/ioutputbinitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joboutputoptimization/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joboutputoptimization/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobOutputOptimization"
+second_title: "Aspose.Page용 Java API 참조"
+description: "지정된 옵션에 따라 특정 사용 시나리오에 맞게 출력을 최적화하도록 설계된 작업 처리를 설명합니다."
+type: docs
+weight: 62
+url: /ko/java/com.aspose.xps.metadata/joboutputoptimization/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobOutputOptimization extends Feature implements IJobPrintTicketItem
+```
+
+지정된 옵션에 따라 특정 사용 시나리오에 맞게 출력을 최적화하도록 설계된 작업 처리를 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/joboutputoptimization
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobOutputOptimization(JobOutputOptimization.JobOutputOptimizationOption[] options)](#JobOutputOptimization-com.aspose.xps.metadata.JobOutputOptimization.JobOutputOptimizationOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobOutputOptimization(JobOutputOptimization.JobOutputOptimizationOption[] options) {#JobOutputOptimization-com.aspose.xps.metadata.JobOutputOptimization.JobOutputOptimizationOption...-}
+```
+public JobOutputOptimization(JobOutputOptimization.JobOutputOptimizationOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [JobOutputOptimizationOption\[\]](../../com.aspose.xps.metadata/joboutputoptimizationoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joboutputoptimizationoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joboutputoptimizationoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "JobOutputOptimization.JobOutputOptimizationOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobOutputOptimization 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/joboutputoptimization.joboutputoptimizationoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobOutputOptimization.JobOutputOptimizationOption extends Option
+```
+
+**JobOutputOptimization** 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ArchiveFormat](#ArchiveFormat) | 작업 처리가 아카이브 출력에 최적화되도록 지정합니다. |
+| [None](#None) | 작업 처리가 특정 시나리오에 최적화되지 않도록 지정합니다. |
+| [OptimizeForPortability](#OptimizeForPortability) | 작업 처리가 출력의 이식성(다중 장치)으로 최적화되도록 지정합니다. |
+| [OptimizeForQuality](#OptimizeForQuality) | 작업 처리가 출력 품질에 최적화되도록 지정합니다. |
+| [OptimizeForSpeed](#OptimizeForSpeed) | 작업 처리가 출력 속도에 최적화되도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ArchiveFormat {#ArchiveFormat}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption ArchiveFormat
+```
+
+
+작업 처리가 아카이브 출력에 최적화되도록 지정합니다.
+
+### None {#None}
+```
+public static JobOutputOptimization.JobOutputOptimizationOption None
+```
+
+
+작업 처리가 특정 시나리오에 최적화되지 않도록 지정합니다.
+
+### OptimizeForPortability {#OptimizeForPortability}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption OptimizeForPortability
+```
+
+
+작업 처리가 출력의 이식성(다중 장치)으로 최적화되도록 지정합니다.
+
+### OptimizeForQuality {#OptimizeForQuality}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption OptimizeForQuality
+```
+
+
+작업 처리가 출력 품질에 최적화되도록 지정합니다.
+
+### OptimizeForSpeed {#OptimizeForSpeed}
+```
+public static final JobOutputOptimization.JobOutputOptimizationOption OptimizeForSpeed
+```
+
+
+작업 처리가 출력 속도에 최적화되도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobpageorder/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobpageorder/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobPageOrder"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력에 대한 물리 페이지 순서를 정의합니다."
+type: docs
+weight: 63
+url: /ko/java/com.aspose.xps.metadata/jobpageorder/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPageOrder extends Feature implements IJobPrintTicketItem
+```
+
+출력용 물리 페이지 순서를 정의합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobpageorder
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPageOrder(JobPageOrder.JobPageOrderOption[] options)](#JobPageOrder-com.aspose.xps.metadata.JobPageOrder.JobPageOrderOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPageOrder(JobPageOrder.JobPageOrderOption[] options) {#JobPageOrder-com.aspose.xps.metadata.JobPageOrder.JobPageOrderOption...-}
+```
+public JobPageOrder(JobPageOrder.JobPageOrderOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [JobPageOrderOption\[\]](../../com.aspose.xps.metadata/jobpageorderoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobpageorderoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobpageorderoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "JobPageOrder.JobPageOrderOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobPageOrder 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/jobpageorder.jobpageorderoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class JobPageOrder.JobPageOrderOption extends Option
+```
+
+**JobPageOrder** 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Reverse](#Reverse) | 뒤에서 앞으로 페이지 순서를 지정합니다. |
+| [Standard](#Standard) | 앞에서 뒤로 페이지 순서를 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Reverse {#Reverse}
+```
+public static final JobPageOrder.JobPageOrderOption Reverse
+```
+
+
+뒤에서 앞으로 페이지 순서를 지정합니다.
+
+### Standard {#Standard}
+```
+public static final JobPageOrder.JobPageOrderOption Standard
+```
+
+
+앞에서 뒤로 페이지 순서를 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprimarybannersheet/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprimarybannersheet/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobPrimaryBannerSheet"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대해 출력될 배너 시트를 설명합니다."
+type: docs
+weight: 64
+url: /ko/java/com.aspose.xps.metadata/jobprimarybannersheet/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryBannerSheet extends Feature implements IJobPrintTicketItem
+```
+
+작업에 출력될 배너 시트를 설명합니다. 배너 시트는 기본 PageMediaSize와 기본 PageMediaType을 사용하여 출력되어야 합니다. 배너 시트는 작업의 나머지 부분과 분리되어야 합니다. 이는 모든 마감 또는 처리 옵션(예: JobDuplexAllDocumentsContiguously, JobStapleAllDocuments, 또는 JobBindAllDocuments)이 배너 시트를 포함하지 않아야 함을 의미합니다. 배너 시트는 작업의 첫 번째 시트로 배치되어야 합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPrimaryBannerSheet(JobPrimaryBannerSheet.BannerSheetOption[] options)](#JobPrimaryBannerSheet-com.aspose.xps.metadata.JobPrimaryBannerSheet.BannerSheetOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryBannerSheet(JobPrimaryBannerSheet.BannerSheetOption[] options) {#JobPrimaryBannerSheet-com.aspose.xps.metadata.JobPrimaryBannerSheet.BannerSheetOption...-}
+```
+public JobPrimaryBannerSheet(JobPrimaryBannerSheet.BannerSheetOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [BannerSheetOption\[\]](../../com.aspose.xps.metadata/bannersheetoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprimarybannersheetsource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprimarybannersheetsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobPrimaryBannerSheetSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대한 기본 사용자 정의 배너 시트의 소스를 지정합니다."
+type: docs
+weight: 65
+url: /ko/java/com.aspose.xps.metadata/jobprimarybannersheetsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryBannerSheetSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+작업에 대한 기본 맞춤 배너 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarybannersheetsource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPrimaryBannerSheetSource(String value)](#JobPrimaryBannerSheetSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryBannerSheetSource(String value) {#JobPrimaryBannerSheetSource-java.lang.String-}
+```
+public JobPrimaryBannerSheetSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprimarycoverback/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprimarycoverback/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobPrimaryCoverBack"
+second_title: "Aspose.Page용 Java API 참조"
+description: "뒤쪽 마감 표지를 설명합니다."
+type: docs
+weight: 66
+url: /ko/java/com.aspose.xps.metadata/jobprimarycoverback/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverBack extends Feature implements IJobPrintTicketItem
+```
+
+뒤쪽(마감) 표지를 설명합니다. 각 작업은 별도의 기본 표지를 가집니다. 표지는 작업의 마지막 페이지에 사용되는 PageMediaSize 및 PageMediaType에 인쇄되어야 합니다. 표지는 지정된 옵션에 따라 (예: JobDuplexAllDocumentsContiguously, JobNUpAllDocumentsContiguously) 처리 옵션에 통합되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverback
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPrimaryCoverBack(JobPrimaryCoverBack.CoverBackOption[] options)](#JobPrimaryCoverBack-com.aspose.xps.metadata.JobPrimaryCoverBack.CoverBackOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryCoverBack(JobPrimaryCoverBack.CoverBackOption[] options) {#JobPrimaryCoverBack-com.aspose.xps.metadata.JobPrimaryCoverBack.CoverBackOption...-}
+```
+public JobPrimaryCoverBack(JobPrimaryCoverBack.CoverBackOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [CoverBackOption\[\]](../../com.aspose.xps.metadata/coverbackoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprimarycoverbacksource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprimarycoverbacksource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobPrimaryCoverBackSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대한 사용자 정의 뒷표지 기본 시트의 소스를 지정합니다."
+type: docs
+weight: 67
+url: /ko/java/com.aspose.xps.metadata/jobprimarycoverbacksource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverBackSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+작업에 대한 사용자 정의 뒷표지 기본 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverbacksource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPrimaryCoverBackSource(String value)](#JobPrimaryCoverBackSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryCoverBackSource(String value) {#JobPrimaryCoverBackSource-java.lang.String-}
+```
+public JobPrimaryCoverBackSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprimarycoverfront/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprimarycoverfront/_index.md
@@ -1,0 +1,152 @@
+---
+title: "JobPrimaryCoverFront"
+second_title: "Aspose.Page용 Java API 참조"
+description: "앞쪽 시작 표지를 설명합니다."
+type: docs
+weight: 68
+url: /ko/java/com.aspose.xps.metadata/jobprimarycoverfront/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverFront extends Feature implements IJobPrintTicketItem
+```
+
+앞쪽(시작) 표지를 설명합니다. 전체 작업은 단일 기본 표지를 가집니다. 표지는 작업의 첫 페이지에 사용되는 PageMediaSize 및 PageMediaType에 인쇄되어야 합니다. 표지는 지정된 옵션에 따라 (예: JobDuplexAllDocumentsContiguously, JobNUpAllDocumentsContiguously) 처리 옵션에 통합되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverfront
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprimarycoverfrontsource/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprimarycoverfrontsource/_index.md
@@ -1,0 +1,178 @@
+---
+title: "JobPrimaryCoverFrontSource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업에 대한 사용자 정의 앞표지 기본 시트의 소스를 지정합니다."
+type: docs
+weight: 69
+url: /ko/java/com.aspose.xps.metadata/jobprimarycoverfrontsource/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobPrimaryCoverFrontSource extends StringParameterInit implements IJobPrintTicketItem
+```
+
+작업에 대한 사용자 지정 앞표지 기본 시트의 소스를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobprimarycoverfrontsource
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPrimaryCoverFrontSource(String value)](#JobPrimaryCoverFrontSource-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrimaryCoverFrontSource(String value) {#JobPrimaryCoverFrontSource-java.lang.String-}
+```
+public JobPrimaryCoverFrontSource(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobprintticket/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobprintticket/_index.md
@@ -1,0 +1,181 @@
+---
+title: "JobPrintTicket"
+second_title: "Aspose.Page용 Java API 참조"
+description: "작업 수준 인쇄 티켓을 캡슐화하는 클래스입니다."
+type: docs
+weight: 70
+url: /ko/java/com.aspose.xps.metadata/jobprintticket/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicket](../../com.aspose.xps.metadata/printticket)
+```
+public final class JobPrintTicket extends PrintTicket
+```
+
+작업 수준 인쇄 티켓을 캡슐화하는 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobPrintTicket(IJobPrintTicketItem[] items)](#JobPrintTicket-com.aspose.xps.metadata.IJobPrintTicketItem...-) | 작업 수준의 인쇄 티켓 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IJobPrintTicketItem[] items)](#add-com.aspose.xps.metadata.IJobPrintTicketItem...-) | 이 PrintTicket 항목 목록 끝에 항목 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 인쇄 티켓 항목 이름 반복자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | 이 PrintTicket 항목 목록에서 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobPrintTicket(IJobPrintTicketItem[] items) {#JobPrintTicket-com.aspose.xps.metadata.IJobPrintTicketItem...-}
+```
+public JobPrintTicket(IJobPrintTicketItem[] items)
+```
+
+
+작업 수준의 인쇄 티켓 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IJobPrintTicketItem\[\]](../../com.aspose.xps.metadata/ijobprintticketitem) | 임의의 IJobPrintTicketItem 인스턴스 배열입니다. 각 인스턴스는 Feature, ParameterInit 또는 Property 인스턴스가 될 수 있습니다. |
+
+### add(IJobPrintTicketItem[] items) {#add-com.aspose.xps.metadata.IJobPrintTicketItem...-}
+```
+public void add(IJobPrintTicketItem[] items)
+```
+
+
+이 PrintTicket 항목 목록 끝에 항목 배열을 추가합니다. 각 항목은 Feature, ParameterInit 또는 Property 인스턴스일 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IJobPrintTicketItem\[\]](../../com.aspose.xps.metadata/ijobprintticketitem) | 추가할 항목 배열입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+인쇄 티켓 항목 이름 반복자를 반환합니다.
+
+**Returns:**
+java.util.Iterator<java.lang.String> - 목록에 대한 반복자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+이 PrintTicket 항목 목록에서 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String[] | 항목 이름 배열입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobrollcutatendofjob/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobrollcutatendofjob/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobRollCutAtEndOfJob"
+second_title: "Aspose.Page용 Java API 참조"
+description: "롤 용지에 대한 절단 방법을 설명합니다."
+type: docs
+weight: 71
+url: /ko/java/com.aspose.xps.metadata/jobrollcutatendofjob/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.RollCut](../../com.aspose.xps.metadata/rollcut)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobRollCutAtEndOfJob extends RollCut implements IJobPrintTicketItem
+```
+
+롤 용지의 절단 방법을 설명합니다. 작업이 끝날 때 롤을 절단해야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobrollcutatendofjob
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobRollCutAtEndOfJob(RollCut.RollCutOption[] options)](#JobRollCutAtEndOfJob-com.aspose.xps.metadata.RollCut.RollCutOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobRollCutAtEndOfJob(RollCut.RollCutOption[] options) {#JobRollCutAtEndOfJob-com.aspose.xps.metadata.RollCut.RollCutOption...-}
+```
+public JobRollCutAtEndOfJob(RollCut.RollCutOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [RollCutOption\[\]](../../com.aspose.xps.metadata/rollcutoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/jobstaplealldocuments/_index.md
+++ b/korean/java/com.aspose.xps.metadata/jobstaplealldocuments/_index.md
@@ -1,0 +1,170 @@
+---
+title: "JobStapleAllDocuments"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 스테이플링 특성을 설명합니다."
+type: docs
+weight: 72
+url: /ko/java/com.aspose.xps.metadata/jobstaplealldocuments/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.Staple](../../com.aspose.xps.metadata/staple)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem)
+```
+public final class JobStapleAllDocuments extends Staple implements IJobPrintTicketItem
+```
+
+출력의 스테이플링 특성을 설명합니다. 작업의 모든 문서가 함께 스테이플됩니다. JobStapleAllDocuments와 DocumentStaple 키워드는 상호 배타적입니다. 이러한 키워드 간의 제약 처리 여부는 드라이버가 결정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/jobstaplealldocuments
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobStapleAllDocuments(Staple.StapleOption[] options)](#JobStapleAllDocuments-com.aspose.xps.metadata.Staple.StapleOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobStapleAllDocuments(Staple.StapleOption[] options) {#JobStapleAllDocuments-com.aspose.xps.metadata.Staple.StapleOption...-}
+```
+public JobStapleAllDocuments(Staple.StapleOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [StapleOption\[\]](../../com.aspose.xps.metadata/stapleoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/joburi/_index.md
+++ b/korean/java/com.aspose.xps.metadata/joburi/_index.md
@@ -1,0 +1,153 @@
+---
+title: "JobURI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서에 대한 통합 자원 식별자(URI)를 지정합니다."
+type: docs
+weight: 73
+url: /ko/java/com.aspose.xps.metadata/joburi/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property), [com.aspose.xps.metadata.URIProperty](../../com.aspose.xps.metadata/uriproperty)
+```
+public final class JobURI extends URIProperty
+```
+
+문서에 대한 통합 자원 식별자(URI)를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/joburi
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JobURI(String jobURI)](#JobURI-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JobURI(String jobURI) {#JobURI-java.lang.String-}
+```
+public JobURI(String jobURI)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| jobURI | java.lang.String | 작업 URI입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/layering/_index.md
+++ b/korean/java/com.aspose.xps.metadata/layering/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageWatermark.Layering"
+second_title: "Aspose.Page용 Java API 참조"
+description: "내부 Layering 기능을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagewatermark.layering/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem](../../com.aspose.xps.metadata/ipagewatermarkitem)
+```
+public static final class PageWatermark.Layering extends Feature implements PageWatermark.IPageWatermarkItem
+```
+
+내부 Layering 기능을 설명합니다. 워터마크의 레이어링 동작을 정의합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Layering(PageWatermark.LayeringOption[] options)](#Layering-com.aspose.xps.metadata.PageWatermark.LayeringOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Layering(PageWatermark.LayeringOption[] options) {#Layering-com.aspose.xps.metadata.PageWatermark.LayeringOption...-}
+```
+public Layering(PageWatermark.LayeringOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [LayeringOption\[\]](../../com.aspose.xps.metadata/layeringoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/layeringoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/layeringoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageWatermark.LayeringOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "레이어링 기능 옵션을 설명합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/pagewatermark.layeringoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageWatermark.LayeringOption extends Option
+```
+
+Layering 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Overlay](#Overlay) | 워터마크가 페이지 콘텐츠 위에 표시됩니다. |
+| [Underlay](#Underlay) | 워터마크가 페이지 콘텐츠 아래에 표시됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Overlay {#Overlay}
+```
+public static PageWatermark.LayeringOption Overlay
+```
+
+
+워터마크가 페이지 콘텐츠 위에 표시됩니다.
+
+### Underlay {#Underlay}
+```
+public static PageWatermark.LayeringOption Underlay
+```
+
+
+워터마크가 페이지 콘텐츠 아래에 표시됩니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/material/_index.md
+++ b/korean/java/com.aspose.xps.metadata/material/_index.md
@@ -1,0 +1,205 @@
+---
+title: "PageMediaType.Material"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Material 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.material/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.Material extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+Material 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Aluminum](#Aluminum) | 알루미늄 값. |
+| [Display](#Display) | 디스플레이 값. |
+| [DryFilm](#DryFilm) | DryFilm 값. |
+| [Paper](#Paper) | Paper 값. |
+| [Polyester](#Polyester) | Polyester 값. |
+| [Transparency](#Transparency) | 투명도 값. |
+| [WetFilm](#WetFilm) | WetFilm 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Aluminum {#Aluminum}
+```
+public static PageMediaType.Material Aluminum
+```
+
+
+알루미늄 값.
+
+### Display {#Display}
+```
+public static PageMediaType.Material Display
+```
+
+
+디스플레이 값.
+
+### DryFilm {#DryFilm}
+```
+public static PageMediaType.Material DryFilm
+```
+
+
+DryFilm 값.
+
+### Paper {#Paper}
+```
+public static PageMediaType.Material Paper
+```
+
+
+Paper 값.
+
+### Polyester {#Polyester}
+```
+public static PageMediaType.Material Polyester
+```
+
+
+Polyester 값.
+
+### Transparency {#Transparency}
+```
+public static PageMediaType.Material Transparency
+```
+
+
+투명도 값.
+
+### WetFilm {#WetFilm}
+```
+public static PageMediaType.Material WetFilm
+```
+
+
+WetFilm 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/mediacapacity/_index.md
+++ b/korean/java/com.aspose.xps.metadata/mediacapacity/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaCapacity"
+second_title: "Aspose.Page용 Java API 참조"
+description: "바이너가 고용량 바이너인지 여부를 지정하는 MediaCapacity 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.xps.metadata/inputbin.mediacapacity/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaCapacity extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaCapacity 점수 속성 값에 대한 상수를 정의하며, 해당 빈이 고용량 빈인지 여부를 지정합니다 (정성적).
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [High](#High) | 높은 값. |
+| [Standard](#Standard) | 표준 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### High {#High}
+```
+public static final InputBin.MediaCapacity High
+```
+
+
+높은 값.
+
+### Standard {#Standard}
+```
+public static final InputBin.MediaCapacity Standard
+```
+
+
+표준 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/mediapath/_index.md
+++ b/korean/java/com.aspose.xps.metadata/mediapath/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaPath"
+second_title: "Aspose.Page용 Java API 참조"
+description: "MediaPath 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.xps.metadata/inputbin.mediapath/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaPath extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaPath 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Serpentine](#Serpentine) | 구불구불한 값. |
+| [Straight](#Straight) | 직선 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Serpentine {#Serpentine}
+```
+public static final InputBin.MediaPath Serpentine
+```
+
+
+구불구불한 값.
+
+### Straight {#Straight}
+```
+public static final InputBin.MediaPath Straight
+```
+
+
+직선 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/mediasheetcapacity/_index.md
+++ b/korean/java/com.aspose.xps.metadata/mediasheetcapacity/_index.md
@@ -1,0 +1,156 @@
+---
+title: "OutputBin.MediaSheetCapacity"
+second_title: "Aspose.Page용 Java API 참조"
+description: "MediaSheetCapacity 점수 속성 값을 정의하며, 이는 빈의 전체 용량을 페이지 수로 지정합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/outputbin.mediasheetcapacity/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem](../../com.aspose.xps.metadata/ioutputbinoptionitem)
+```
+public static final class OutputBin.MediaSheetCapacity extends ScoredProperty implements OutputBin.IOutputBinOptionItem
+```
+
+MediaSheetCapacity 점수 속성 값을 정의하며, 빈의 페이지 수(전체 수준)로 미디어 용량을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [MediaSheetCapacity(int mediaSheetCapacity)](#MediaSheetCapacity-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MediaSheetCapacity(int mediaSheetCapacity) {#MediaSheetCapacity-int-}
+```
+public MediaSheetCapacity(int mediaSheetCapacity)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mediaSheetCapacity | int | MediaSheetCapacity 점수 속성 값입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/mediasizeautosense/_index.md
+++ b/korean/java/com.aspose.xps.metadata/mediasizeautosense/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaSizeAutoSense"
+second_title: "Aspose.Page용 Java API 참조"
+description: "MediaSizeAutoSense 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.xps.metadata/inputbin.mediasizeautosense/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaSizeAutoSense extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaSizeAutoSense 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | None 값. |
+| [Supported](#Supported) | 지원되는 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final InputBin.MediaSizeAutoSense None
+```
+
+
+None 값.
+
+### Supported {#Supported}
+```
+public static final InputBin.MediaSizeAutoSense Supported
+```
+
+
+지원되는 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/mediatypeautosense/_index.md
+++ b/korean/java/com.aspose.xps.metadata/mediatypeautosense/_index.md
@@ -1,0 +1,160 @@
+---
+title: "InputBin.MediaTypeAutoSense"
+second_title: "Aspose.Page용 Java API 참조"
+description: "MediaTypeAutoSense 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.xps.metadata/inputbin.mediatypeautosense/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.InputBin.IInputBinOptionItem](../../com.aspose.xps.metadata/iinputbinoptionitem)
+```
+public static final class InputBin.MediaTypeAutoSense extends ScoredProperty implements InputBin.IInputBinOptionItem
+```
+
+MediaTypeAutoSense 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | None 값. |
+| [Supported](#Supported) | 지원되는 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static final InputBin.MediaTypeAutoSense None
+```
+
+
+None 값.
+
+### Supported {#Supported}
+```
+public static final InputBin.MediaTypeAutoSense Supported
+```
+
+
+지원되는 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/nameproperty/_index.md
+++ b/korean/java/com.aspose.xps.metadata/nameproperty/_index.md
@@ -1,0 +1,135 @@
+---
+title: "NameProperty"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobName 및 DocumentName 속성 클래스의 기본 클래스입니다."
+type: docs
+weight: 75
+url: /ko/java/com.aspose.xps.metadata/nameproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public class NameProperty extends Property
+```
+
+JobName 및 DocumentName 속성 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/nup/_index.md
+++ b/korean/java/com.aspose.xps.metadata/nup/_index.md
@@ -1,0 +1,149 @@
+---
+title: "NUp"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobNUpAllDocumentsContiguously 및 DocumentNUp 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 74
+url: /ko/java/com.aspose.xps.metadata/nup/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class NUp extends Feature
+```
+
+JobNUpAllDocumentsContiguously 및 DocumentNUp 기능 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/option/_index.md
+++ b/korean/java/com.aspose.xps.metadata/option/_index.md
@@ -1,0 +1,199 @@
+---
+title: "옵션"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 PrintTicket Option을 구현하는 클래스입니다."
+type: docs
+weight: 76
+url: /ko/java/com.aspose.xps.metadata/option/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem)
+```
+public class Option extends CompositePrintTicketElement implements IFeatureItem
+```
+
+공통 PrintTicket Option을 구현하는 클래스입니다. 모든 스키마 정의 옵션의 기본 클래스입니다. Option 요소는 이 옵션과 연결된 모든 Property 및 ScoredProperty 요소를 포함합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/option
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Option(String name, IOptionItem[] items)](#Option-java.lang.String-com.aspose.xps.metadata.IOptionItem...-) | 새 PrintTicket 옵션 인스턴스를 생성합니다. |
+| [Option(IOptionItem[] items)](#Option-com.aspose.xps.metadata.IOptionItem...-) | 새 PrintTicket 옵션 인스턴스를 생성합니다. |
+| [Option(Option option)](#Option-com.aspose.xps.metadata.Option-) | 복제 옵션 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Option(String name, IOptionItem[] items) {#Option-java.lang.String-com.aspose.xps.metadata.IOptionItem...-}
+```
+public Option(String name, IOptionItem[] items)
+```
+
+
+새 PrintTicket 옵션 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 임의의 옵션 이름입니다. |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 임의의 IOptionItem 인스턴스 배열입니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다. |
+
+### Option(IOptionItem[] items) {#Option-com.aspose.xps.metadata.IOptionItem...-}
+```
+public Option(IOptionItem[] items)
+```
+
+
+새 PrintTicket 옵션 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 임의의 IOptionItem 인스턴스 배열입니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다. |
+
+### Option(Option option) {#Option-com.aspose.xps.metadata.Option-}
+```
+public Option(Option option)
+```
+
+
+복제 옵션 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| option | [Option](../../com.aspose.xps.metadata/option) | 복제할 옵션 인스턴스입니다. |
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/outputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/outputbin/_index.md
@@ -1,0 +1,149 @@
+---
+title: "OutputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobOutputBin, DocumentOutputBin 및 PageOutputBin 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 77
+url: /ko/java/com.aspose.xps.metadata/outputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class OutputBin extends Feature
+```
+
+JobOutputBin, DocumentOutputBin 및 PageOutputBin 기능 클래스의 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/outputbinoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/outputbinoption/_index.md
@@ -1,0 +1,186 @@
+---
+title: "OutputBin.OutputBinOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobOutputBin, DocumentOutputBin 및 PageOutputBin 기능 옵션을 설명합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/outputbin.outputbinoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.OutputBin.IOutputBinItem](../../com.aspose.xps.metadata/ioutputbinitem)
+```
+public static final class OutputBin.OutputBinOption extends Option implements OutputBin.IOutputBinItem
+```
+
+**JobOutputBin**, **DocumentOutputBin** 및 **PageOutputBin** 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [OutputBinOption(OutputBin.IOutputBinOptionItem[] items)](#OutputBinOption-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(OutputBin.IOutputBinOptionItem[] items)](#add-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-) | 기능에 IOutputBinOptionItem 인스턴스 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### OutputBinOption(OutputBin.IOutputBinOptionItem[] items) {#OutputBinOption-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-}
+```
+public OutputBinOption(OutputBin.IOutputBinOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOutputBinOptionItem\[\]](../../com.aspose.xps.metadata/ioutputbinoptionitem) | 임의의 IOutputBinOptionItem 인스턴스 배열입니다. |
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(OutputBin.IOutputBinOptionItem[] items) {#add-com.aspose.xps.metadata.OutputBin.IOutputBinOptionItem...-}
+```
+public OutputBin.OutputBinOption add(OutputBin.IOutputBinOptionItem[] items)
+```
+
+
+기능에 IOutputBinOptionItem 인스턴스 배열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOutputBinOptionItem\[\]](../../com.aspose.xps.metadata/ioutputbinoptionitem) | 임의의 IOutputBinOptionItem 인스턴스 배열입니다. |
+
+**Returns:**
+[OutputBinOption](../../com.aspose.xps.metadata/outputbinoption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessing/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessing/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageBlackGenerationProcessing"
+second_title: "Aspose.Page용 Java API 참조"
+description: "CMYK 분리에서 검정 생성 동작을 지정합니다."
+type: docs
+weight: 78
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessing/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessing extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+CMYK 분리용 검은색 생성 동작을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessing
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessing(PageBlackGenerationProcessing.PageBlackGenerationProcessingOption[] options)](#PageBlackGenerationProcessing-com.aspose.xps.metadata.PageBlackGenerationProcessing.PageBlackGenerationProcessingOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessing(PageBlackGenerationProcessing.PageBlackGenerationProcessingOption[] options) {#PageBlackGenerationProcessing-com.aspose.xps.metadata.PageBlackGenerationProcessing.PageBlackGenerationProcessingOption...-}
+```
+public PageBlackGenerationProcessing(PageBlackGenerationProcessing.PageBlackGenerationProcessingOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageBlackGenerationProcessingOption\[\]](../../com.aspose.xps.metadata/pageblackgenerationprocessingoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingBlackInkLimit"
+second_title: "Aspose.Page용 Java API 참조"
+description: "지정된 명명된 색상으로 라벨링된 애플리케이션 콘텐츠는 모든 색상 분리에서 반드시 표시되어야 합니다."
+type: docs
+weight: 79
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessingblackinklimit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingBlackInkLimit extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+지정된 명명된 색상으로 라벨링된 애플리케이션 콘텐츠는 모든 색상 분리에서 반드시 표시되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingblackinklimit
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingBlackInkLimit(int value)](#PageBlackGenerationProcessingBlackInkLimit-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingBlackInkLimit(int value) {#PageBlackGenerationProcessingBlackInkLimit-int-}
+```
+public PageBlackGenerationProcessingBlackInkLimit(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingGrayComponentReplacementExtent"
+second_title: "Aspose.Page용 Java API 참조"
+description: "GCR이 적용하는 중립 색상에서 색채 색상으로 확장된 범위를 설명합니다. 0은 균일 구성 요소 교체, 100은 회색 구성 요소 교체."
+type: docs
+weight: 80
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementextent/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingGrayComponentReplacementExtent extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+GCR이 적용하는 중립 색상(색채 색상으로)에서 확장된 범위를 설명합니다. 0% = 균일 구성 요소 교체, 100% = 회색 구성 요소 교체. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessinggraycomponentreplacementextent
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingGrayComponentReplacementExtent(int value)](#PageBlackGenerationProcessingGrayComponentReplacementExtent-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingGrayComponentReplacementExtent(int value) {#PageBlackGenerationProcessingGrayComponentReplacementExtent-int-}
+```
+public PageBlackGenerationProcessingGrayComponentReplacementExtent(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingGrayComponentReplacementLevel"
+second_title: "Aspose.Page용 Java API 참조"
+description: "수행할 회색 구성 요소 교체 비율을 지정합니다."
+type: docs
+weight: 81
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementlevel/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingGrayComponentReplacementLevel extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+실행할 회색 성분 교체 비율을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessinggraycomponentreplacementlevel
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingGrayComponentReplacementLevel(int value)](#PageBlackGenerationProcessingGrayComponentReplacementLevel-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingGrayComponentReplacementLevel(int value) {#PageBlackGenerationProcessingGrayComponentReplacementLevel-int-}
+```
+public PageBlackGenerationProcessingGrayComponentReplacementLevel(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingGrayComponentReplacementStart"
+second_title: "Aspose.Page용 Java API 참조"
+description: "GCR이 시작해야 하는 하이라이트에서 그림자 범위의 지점을 설명합니다. 가장 어두운 그림자 100%."
+type: docs
+weight: 82
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessinggraycomponentreplacementstart/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingGrayComponentReplacementStart extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+GCR이 시작해야 하는 "하이라이트에서 그림자" 범위의 지점을 설명합니다 (가장 어두운 그림자 100%). https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessinggraycomponentreplacementstart
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingGrayComponentReplacementStart(int value)](#PageBlackGenerationProcessingGrayComponentReplacementStart-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingGrayComponentReplacementStart(int value) {#PageBlackGenerationProcessingGrayComponentReplacementStart-int-}
+```
+public PageBlackGenerationProcessingGrayComponentReplacementStart(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageBlackGenerationProcessing.PageBlackGenerationProcessingOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageBlackGenerationProcessing 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessing.pageblackgenerationprocessingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageBlackGenerationProcessing.PageBlackGenerationProcessingOption extends Option
+```
+
+**PageBlackGenerationProcessing** 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Automatic](#Automatic) | 자동 옵션. |
+| [Custom](#Custom) | 사용자 지정 옵션. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static PageBlackGenerationProcessing.PageBlackGenerationProcessingOption Automatic
+```
+
+
+자동 옵션.
+
+### Custom {#Custom}
+```
+public static PageBlackGenerationProcessing.PageBlackGenerationProcessingOption Custom
+```
+
+
+사용자 지정 옵션.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingTotalInkCoverageLimit"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이미지 어디에서든 허용되는 네 가지 잉크 커버리지의 최대 합계를 지정합니다."
+type: docs
+weight: 83
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessingtotalinkcoveragelimit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingTotalInkCoverageLimit extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+이미지 어디에서든 네 가지 잉크 커버리지의 허용 가능한 최대 합계를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingtotalinkcoveragelimit
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingTotalInkCoverageLimit(int value)](#PageBlackGenerationProcessingTotalInkCoverageLimit-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingTotalInkCoverageLimit(int value) {#PageBlackGenerationProcessingTotalInkCoverageLimit-int-}
+```
+public PageBlackGenerationProcessingTotalInkCoverageLimit(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingUnderColorAdditionLevel"
+second_title: "Aspose.Page용 Java API 참조"
+description: "GCR/UCR가 BlackInkLimit 또는 UCAStart를 생성한 영역에, 어두운 중성색 및 근중성 영역에 지정된 경우, 회색 성분 비율로 추가할 색채 잉크 양을 설명합니다."
+type: docs
+weight: 84
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionlevel/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingUnderColorAdditionLevel extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+GCR/UCR가 "BlackInkLimit"(또는 지정된 경우 UCAStart)를 생성한 어두운 중성색 및 근중성 영역에 회색 성분 비율로 추가할 색채 잉크 양을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingundercoloradditionlevel
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingUnderColorAdditionLevel(int value)](#PageBlackGenerationProcessingUnderColorAdditionLevel-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingUnderColorAdditionLevel(int value) {#PageBlackGenerationProcessingUnderColorAdditionLevel-int-}
+```
+public PageBlackGenerationProcessingUnderColorAdditionLevel(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageBlackGenerationProcessingUnderColorAdditionStart"
+second_title: "Aspose.Page용 Java API 참조"
+description: "UCA가 적용되는 그림자 수준 이하를 설명합니다."
+type: docs
+weight: 85
+url: /ko/java/com.aspose.xps.metadata/pageblackgenerationprocessingundercoloradditionstart/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlackGenerationProcessingUnderColorAdditionStart extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+UCA가 적용되는 그림자 레벨 이하를 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblackgenerationprocessingundercoloradditionstart
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlackGenerationProcessingUnderColorAdditionStart(int value)](#PageBlackGenerationProcessingUnderColorAdditionStart-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlackGenerationProcessingUnderColorAdditionStart(int value) {#PageBlackGenerationProcessingUnderColorAdditionStart-int-}
+```
+public PageBlackGenerationProcessingUnderColorAdditionStart(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblendcolorspace/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblendcolorspace/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageBlendColorSpace"
+second_title: "Aspose.Page용 Java API 참조"
+description: "블렌딩 작업에 사용되어야 하는 색 공간을 설명합니다."
+type: docs
+weight: 86
+url: /ko/java/com.aspose.xps.metadata/pageblendcolorspace/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlendColorSpace extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+블렌딩 작업에 사용되어야 하는 색 공간을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblendcolorspace
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlendColorSpace(PageBlendColorSpace.PageBlendColorSpaceOption[] options)](#PageBlendColorSpace-com.aspose.xps.metadata.PageBlendColorSpace.PageBlendColorSpaceOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlendColorSpace(PageBlendColorSpace.PageBlendColorSpaceOption[] options) {#PageBlendColorSpace-com.aspose.xps.metadata.PageBlendColorSpace.PageBlendColorSpaceOption...-}
+```
+public PageBlendColorSpace(PageBlendColorSpace.PageBlendColorSpaceOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageBlendColorSpaceOption\[\]](../../com.aspose.xps.metadata/pageblendcolorspaceoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageBlendColorSpaceICCProfileURI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "블렌딩에 사용되어야 하는 색 공간을 정의하는 ICC 프로파일에 대한 상대 URI 참조를 지정합니다."
+type: docs
+weight: 87
+url: /ko/java/com.aspose.xps.metadata/pageblendcolorspaceiccprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBlendColorSpaceICCProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+블렌딩에 사용되어야 하는 색 공간을 정의하는 ICC 프로파일에 대한 상대 URI 참조를 지정합니다. 해당 <Uri>는 패키지 루트에 상대적인 절대 part\_name입니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageblendcolorspaceiccprofileuri
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBlendColorSpaceICCProfileURI(String value)](#PageBlendColorSpaceICCProfileURI-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBlendColorSpaceICCProfileURI(String value) {#PageBlendColorSpaceICCProfileURI-java.lang.String-}
+```
+public PageBlendColorSpaceICCProfileURI(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageblendcolorspaceoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageblendcolorspaceoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "PageBlendColorSpace.PageBlendColorSpaceOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageBlendColorSpace 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageblendcolorspace.pageblendcolorspaceoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageBlendColorSpace.PageBlendColorSpaceOption extends Option
+```
+
+PageBlendColorSpace 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ICCProfile](#ICCProfile) | 혼합에 사용되어야 하는 색 공간을 정의하는 ICC 프로파일을 지정합니다. |
+| [sRGB](#sRGB) | 혼합을 위해 sRGB 색 공간을 사용해야 합니다. |
+| [scRGB](#scRGB) | 혼합을 위해 scRGB 색 공간을 사용해야 합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ICCProfile {#ICCProfile}
+```
+public static PageBlendColorSpace.PageBlendColorSpaceOption ICCProfile
+```
+
+
+혼합에 사용해야 하는 색 공간을 정의하는 ICC 프로파일을 지정합니다. 참고: 이는 XPS 문서에만 적용되며 임의의 PrintTickets에서는 사용해서는 안 됩니다.
+
+### sRGB {#sRGB}
+```
+public static PageBlendColorSpace.PageBlendColorSpaceOption sRGB
+```
+
+
+혼합을 위해 sRGB 색 공간을 사용해야 합니다.
+
+### scRGB {#scRGB}
+```
+public static PageBlendColorSpace.PageBlendColorSpaceOption scRGB
+```
+
+
+혼합을 위해 scRGB 색 공간을 사용해야 합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageborderless/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageborderless/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageBorderless"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이미지 콘텐츠를 매체의 물리적 가장자리에 인쇄해야 하는 시점을 설명합니다."
+type: docs
+weight: 88
+url: /ko/java/com.aspose.xps.metadata/pageborderless/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageBorderless extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+이미지 콘텐츠를 매체의 물리적 가장자리까지 인쇄해야 하는 시점을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageborderless
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageBorderless(PageBorderless.PageBorderlessOption[] options)](#PageBorderless-com.aspose.xps.metadata.PageBorderless.PageBorderlessOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageBorderless(PageBorderless.PageBorderlessOption[] options) {#PageBorderless-com.aspose.xps.metadata.PageBorderless.PageBorderlessOption...-}
+```
+public PageBorderless(PageBorderless.PageBorderlessOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageBorderlessOption\[\]](../../com.aspose.xps.metadata/pageborderlessoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageborderlessoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageborderlessoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageBorderless.PageBorderlessOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageBorderless 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageborderless.pageborderlessoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageBorderless.PageBorderlessOption extends Option
+```
+
+PageBorderless 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Borderless](#Borderless) | 테두리 없는 인쇄를 지정합니다. |
+| [None](#None) | 테두리 없는 인쇄를 지정하지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Borderless {#Borderless}
+```
+public static PageBorderless.PageBorderlessOption Borderless
+```
+
+
+테두리 없는 인쇄를 지정합니다.
+
+### None {#None}
+```
+public static PageBorderless.PageBorderlessOption None
+```
+
+
+테두리 없는 인쇄를 지정하지 않습니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagecolormanagement/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagecolormanagement/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageColorManagement"
+second_title: "Aspose.Page용 Java API 참조"
+description: "현재 페이지에 대한 색 관리 구성을 설정합니다."
+type: docs
+weight: 89
+url: /ko/java/com.aspose.xps.metadata/pagecolormanagement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageColorManagement extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+현재 페이지에 대한 색 관리 구성을 수행합니다. 이는 SHIM - DM\_ICMMethod Add System에서 자동으로 간주됩니다. 색 관리를 수행해야 하는 구성 요소(예: 드라이버)를 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagecolormanagement
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageColorManagement(PageColorManagement.PageColorManagementOption[] options)](#PageColorManagement-com.aspose.xps.metadata.PageColorManagement.PageColorManagementOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageColorManagement(PageColorManagement.PageColorManagementOption[] options) {#PageColorManagement-com.aspose.xps.metadata.PageColorManagement.PageColorManagementOption...-}
+```
+public PageColorManagement(PageColorManagement.PageColorManagementOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageColorManagementOption\[\]](../../com.aspose.xps.metadata/pagecolormanagementoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagecolormanagementoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagecolormanagementoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageColorManagement.PageColorManagementOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageColorManagement 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagecolormanagement.pagecolormanagementoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageColorManagement.PageColorManagementOption extends Option
+```
+
+PageColorManagement 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Device](#Device) | 응용 프로그램이 색 관리를 수행하지 않았으며 장치가 색 관리를 결정합니다. |
+| [Driver](#Driver) | 응용 프로그램이 색 관리를 수행하지 않았으며 드라이버가 색 관리를 결정합니다. |
+| [None](#None) | 응용 프로그램이 대상 프로필에 대한 색 관리를 수행했습니다. |
+| [System](#System) | 색 관리는 시스템에 의해 수행됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Device {#Device}
+```
+public static PageColorManagement.PageColorManagementOption Device
+```
+
+
+응용 프로그램이 색 관리를 수행하지 않았으며 장치가 색 관리를 결정합니다.
+
+### Driver {#Driver}
+```
+public static PageColorManagement.PageColorManagementOption Driver
+```
+
+
+응용 프로그램이 색 관리를 수행하지 않았으며 드라이버가 색 관리를 결정합니다.
+
+### None {#None}
+```
+public static PageColorManagement.PageColorManagementOption None
+```
+
+
+응용 프로그램이 대상 프로필에 대한 색 관리를 수행했습니다.
+
+### System {#System}
+```
+public static PageColorManagement.PageColorManagementOption System
+```
+
+
+색 관리는 시스템에 의해 수행됩니다. XPSDrv 인쇄 드라이버로 인쇄할 때는 사용하지 마십시오.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagecopies/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagecopies/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageCopies"
+second_title: "Aspose.Page용 Java API 참조"
+description: "페이지 복사본 수를 지정합니다."
+type: docs
+weight: 90
+url: /ko/java/com.aspose.xps.metadata/pagecopies/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageCopies extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+페이지 복사본 수를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagecopies
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageCopies(int value)](#PageCopies-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageCopies(int value) {#PageCopies-int-}
+```
+public PageCopies(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofile/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofile/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageDestinationColorProfile"
+second_title: "Aspose.Page용 Java API 참조"
+description: "대상 색 프로파일의 특성을 정의합니다."
+type: docs
+weight: 91
+url: /ko/java/com.aspose.xps.metadata/pagedestinationcolorprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDestinationColorProfile extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+대상 색상 프로필의 특성을 정의합니다. 애플리케이션 또는 드라이버가 사용할 대상 색상 프로필을 선택하는지 여부를 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedestinationcolorprofile
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageDestinationColorProfile(PageDestinationColorProfile.PageDestinationColorProfileOption[] options)](#PageDestinationColorProfile-com.aspose.xps.metadata.PageDestinationColorProfile.PageDestinationColorProfileOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDestinationColorProfile(PageDestinationColorProfile.PageDestinationColorProfileOption[] options) {#PageDestinationColorProfile-com.aspose.xps.metadata.PageDestinationColorProfile.PageDestinationColorProfileOption...-}
+```
+public PageDestinationColorProfile(PageDestinationColorProfile.PageDestinationColorProfileOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageDestinationColorProfileOption\[\]](../../com.aspose.xps.metadata/pagedestinationcolorprofileoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofileembedded/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofileembedded/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageDestinationColorProfileEmbedded"
+second_title: "Aspose.Page용 Java API 참조"
+description: "내장된 대상 색 프로파일을 지정합니다."
+type: docs
+weight: 92
+url: /ko/java/com.aspose.xps.metadata/pagedestinationcolorprofileembedded/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDestinationColorProfileEmbedded extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+내장된 대상 색상 프로파일을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedestinationcolorprofileembedded
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageDestinationColorProfileEmbedded(String value)](#PageDestinationColorProfileEmbedded-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDestinationColorProfileEmbedded(String value) {#PageDestinationColorProfileEmbedded-java.lang.String-}
+```
+public PageDestinationColorProfileEmbedded(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofileoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofileoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageDestinationColorProfile.PageDestinationColorProfileOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageDestinationColorProfile 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagedestinationcolorprofile.pagedestinationcolorprofileoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageDestinationColorProfile.PageDestinationColorProfileOption extends Option
+```
+
+PageDestinationColorProfile 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Application](#Application) | 응용 프로그램은 사용할 대상 프로필을 지정합니다. |
+| [DriverConfiguration](#DriverConfiguration) | 색상 관리를 수행하는 데 사용되는 대상 프로필. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Application {#Application}
+```
+public static PageDestinationColorProfile.PageDestinationColorProfileOption Application
+```
+
+
+응용 프로그램은 사용할 대상 프로필을 지정합니다.
+
+### DriverConfiguration {#DriverConfiguration}
+```
+public static PageDestinationColorProfile.PageDestinationColorProfileOption DriverConfiguration
+```
+
+
+색상 관리를 수행하는 데 사용되는 대상 프로필.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofileuri/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedestinationcolorprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageDestinationColorProfileURI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS 문서에 포함된 ICC 프로파일에 대한 상대 URI 참조를 지정합니다."
+type: docs
+weight: 93
+url: /ko/java/com.aspose.xps.metadata/pagedestinationcolorprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDestinationColorProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+XPS 문서에 포함된 ICC 프로파일에 대한 상대 URI 참조를 지정합니다. 이 옵션의 처리는 PageDeviceColorSpaceUsage 기능 설정에 따라 달라집니다. 해당 프로파일을 사용하는 모든 요소는 이미 적절한 장치 색 공간에 있다고 가정되며, 드라이버나 장치에서 색 관리되지 않습니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedestinationcolorprofileuri
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageDestinationColorProfileURI(String value)](#PageDestinationColorProfileURI-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDestinationColorProfileURI(String value) {#PageDestinationColorProfileURI-java.lang.String-}
+```
+public PageDestinationColorProfileURI(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedevicecolorspaceprofileuri/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedevicecolorspaceprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageDeviceColorSpaceProfileURI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS 문서에 포함된 ICC 프로파일에 대한 패키지 루트의 상대 URI를 지정합니다."
+type: docs
+weight: 94
+url: /ko/java/com.aspose.xps.metadata/pagedevicecolorspaceprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDeviceColorSpaceProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+XPS 문서에 포함된 ICC 프로파일에 대한 패키지 루트의 상대 URI를 지정합니다. 이 옵션의 처리는 PageDeviceColorSpaceUsage 기능 설정에 따라 달라집니다. 해당 프로파일을 사용하는 모든 요소는 이미 적절한 장치 색 공간에 있다고 가정되며, 드라이버나 장치에서 색 관리되지 않습니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedevicecolorspaceprofileuri
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageDeviceColorSpaceProfileURI(String value)](#PageDeviceColorSpaceProfileURI-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDeviceColorSpaceProfileURI(String value) {#PageDeviceColorSpaceProfileURI-java.lang.String-}
+```
+public PageDeviceColorSpaceProfileURI(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedevicecolorspaceusage/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedevicecolorspaceusage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageDeviceColorSpaceUsage"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageDeviceColorSpaceProfileURI 매개변수와 함께 이 매개변수는 디바이스 색 공간에 표시되는 요소들의 렌더링 동작을 정의합니다."
+type: docs
+weight: 95
+url: /ko/java/com.aspose.xps.metadata/pagedevicecolorspaceusage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDeviceColorSpaceUsage extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+PageDeviceColorSpaceProfileURI 매개변수와 함께 이 매개변수는 디바이스 색 공간에 표시되는 요소들의 렌더링 동작을 정의합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedevicecolorspaceusage
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageDeviceColorSpaceUsage(PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption[] options)](#PageDeviceColorSpaceUsage-com.aspose.xps.metadata.PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDeviceColorSpaceUsage(PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption[] options) {#PageDeviceColorSpaceUsage-com.aspose.xps.metadata.PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption...-}
+```
+public PageDeviceColorSpaceUsage(PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageDeviceColorSpaceUsageOption\[\]](../../com.aspose.xps.metadata/pagedevicecolorspaceusageoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedevicecolorspaceusageoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedevicecolorspaceusageoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageDeviceColorSpaceUsage 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagedevicecolorspaceusage.pagedevicecolorspaceusageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption extends Option
+```
+
+PageDeviceColorSpaceUsage 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [MatchToDefault](#MatchToDefault) | 장치가  PageDeviceColorSpaceProfileURI  매개변수에 의해 지정된 프로파일을 장치 색 공간 프로파일로 사용할 수 있다고 판단하면, 동일한 프로파일을 사용하는 모든 요소는 이미 장치 색 공간에 지정된 것으로 처리됩니다. |
+| [OverrideDeviceDefault](#OverrideDeviceDefault) | PageDeviceColorSpaceProfileURI 매개변수에 의해 지정된 프로파일이 장치의 기본 색상 수와 일치하는 채널 수를 가지고 있는 경우, 모든 요소에 대해 장치의 내부 색 관리 대신 해당 프로파일을 사용해야 합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MatchToDefault {#MatchToDefault}
+```
+public static PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption MatchToDefault
+```
+
+
+장치가 PageDeviceColorSpaceProfileURI 매개변수로 지정된 프로파일을 장치 색상 공간 프로파일로 사용할 수 있다고 판단하면, 동일한 프로파일을 사용하는 모든 요소는 이미 장치 색상 공간으로 지정된 것으로 처리됩니다. 다른 모든 요소는 해당 요소에 지정된 프로파일을 사용해야 합니다. 프로파일을 장치 색상 공간 프로파일로 사용할 수 없는 경우, 프로파일을 사용하는 요소는 색상 프로파일을 사용하는 다른 요소와 마찬가지로 색상 관리되어야 합니다.
+
+### OverrideDeviceDefault {#OverrideDeviceDefault}
+```
+public static PageDeviceColorSpaceUsage.PageDeviceColorSpaceUsageOption OverrideDeviceDefault
+```
+
+
+PageDeviceColorSpaceProfileURI 매개변수로 지정된 프로파일이 장치의 기본 색상 수와 일치하는 채널 수를 가지고 있다면, 모든 요소에 대해 장치의 내부 색상 관리 대신 사용되어야 합니다. 이 프로파일을 사용하는 요소는 장치 색상 공간에 있다고 가정되며 더 이상 색상 관리되지 않습니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedevicefontsubstitution/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedevicefontsubstitution/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageDeviceFontSubstitution"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치 글꼴 대체의 활성화/비활성화 상태를 설명합니다."
+type: docs
+weight: 96
+url: /ko/java/com.aspose.xps.metadata/pagedevicefontsubstitution/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageDeviceFontSubstitution extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+장치 글꼴 대체의 활성화/비활성화 상태를 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagedevicefontsubstitution
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageDeviceFontSubstitution(PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption[] options)](#PageDeviceFontSubstitution-com.aspose.xps.metadata.PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageDeviceFontSubstitution(PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption[] options) {#PageDeviceFontSubstitution-com.aspose.xps.metadata.PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption...-}
+```
+public PageDeviceFontSubstitution(PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageDeviceFontSubstitutionOption\[\]](../../com.aspose.xps.metadata/pagedevicefontsubstitutionoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagedevicefontsubstitutionoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagedevicefontsubstitutionoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageDeviceFontSubstitution 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagedevicefontsubstitution.pagedevicefontsubstitutionoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption extends Option
+```
+
+PageDeviceFontSubstitution 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Off](#Off) | 페이지 장치 글꼴 대체가 꺼져 있습니다. |
+| [On](#On) | 페이지 장치 글꼴 대체가 켜져 있습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Off {#Off}
+```
+public static PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption Off
+```
+
+
+페이지 장치 글꼴 대체가 꺼져 있습니다.
+
+### On {#On}
+```
+public static PageDeviceFontSubstitution.PageDeviceFontSubstitutionOption On
+```
+
+
+페이지 장치 글꼴 대체가 켜져 있습니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageforcefrontside/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageforcefrontside/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageForceFrontSide"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력이 매체 시트의 앞면에 나타나도록 강제합니다."
+type: docs
+weight: 97
+url: /ko/java/com.aspose.xps.metadata/pageforcefrontside/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageForceFrontSide extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력을 미디어 시트의 앞면에 표시하도록 강제합니다. 각 면이 다른 표면을 가진 미디어 시트에 적용됩니다. 이 기능이 처리 옵션(예: DocumentDuplex)과 충돌하는 경우, PageForceFrontSide는 해당 기능이 적용되는 특정 페이지에 대해 우선합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageForceFrontSide(PageForceFrontSide.PageForceFrontSideOption[] options)](#PageForceFrontSide-com.aspose.xps.metadata.PageForceFrontSide.PageForceFrontSideOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageForceFrontSide(PageForceFrontSide.PageForceFrontSideOption[] options) {#PageForceFrontSide-com.aspose.xps.metadata.PageForceFrontSide.PageForceFrontSideOption...-}
+```
+public PageForceFrontSide(PageForceFrontSide.PageForceFrontSideOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageForceFrontSideOption\[\]](../../com.aspose.xps.metadata/pageforcefrontsideoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageforcefrontsideoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageforcefrontsideoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageForceFrontSide.PageForceFrontSideOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageForceFrontSide 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageforcefrontside.pageforcefrontsideoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageForceFrontSide.PageForceFrontSideOption extends Option
+```
+
+PageForceFrontSide 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [ForceFrontSide](#ForceFrontSide) | 출력이 시트의 앞면으로 제한되도록 지정합니다. |
+| [None](#None) | 출력 제한이 없도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ForceFrontSide {#ForceFrontSide}
+```
+public static PageForceFrontSide.PageForceFrontSideOption ForceFrontSide
+```
+
+
+출력이 시트의 앞면으로 제한되도록 지정합니다.
+
+### None {#None}
+```
+public static PageForceFrontSide.PageForceFrontSideOption None
+```
+
+
+출력 제한이 없도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageicmrenderingintent/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageicmrenderingintent/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageICMRenderingIntent"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ICC v2 사양에 정의된 렌더링 의도를 설명합니다."
+type: docs
+weight: 98
+url: /ko/java/com.aspose.xps.metadata/pageicmrenderingintent/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageICMRenderingIntent extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+ICC v2 사양에 정의된 렌더링 의도를 설명합니다. 이미지나 그래픽 요소에 렌더링 의도를 지정하는 내장 프로파일이 있는 경우 이 값은 무시되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageicmrenderingintent
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageICMRenderingIntent(PageICMRenderingIntent.PageICMRenderingIntentOption[] options)](#PageICMRenderingIntent-com.aspose.xps.metadata.PageICMRenderingIntent.PageICMRenderingIntentOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageICMRenderingIntent(PageICMRenderingIntent.PageICMRenderingIntentOption[] options) {#PageICMRenderingIntent-com.aspose.xps.metadata.PageICMRenderingIntent.PageICMRenderingIntentOption...-}
+```
+public PageICMRenderingIntent(PageICMRenderingIntent.PageICMRenderingIntentOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageICMRenderingIntentOption\[\]](../../com.aspose.xps.metadata/pageicmrenderingintentoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageicmrenderingintentoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageicmrenderingintentoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageICMRenderingIntent.PageICMRenderingIntentOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageICMRenderingIntent 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageicmrenderingintent.pageicmrenderingintentoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageICMRenderingIntent.PageICMRenderingIntentOption extends Option
+```
+
+PageICMRenderingIntent 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AbsoluteColorimetric](#AbsoluteColorimetric) | 절대 색채계 렌더링 의도. |
+| [BusinessGraphics](#BusinessGraphics) | 비즈니스 그래픽 렌더링 의도. |
+| [Photographs](#Photographs) | 사진 렌더링 의도. |
+| [RelativeColorimetric](#RelativeColorimetric) | 상대 색채계 렌더링 의도. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AbsoluteColorimetric {#AbsoluteColorimetric}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption AbsoluteColorimetric
+```
+
+
+절대 색채계 렌더링 의도.
+
+### BusinessGraphics {#BusinessGraphics}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption BusinessGraphics
+```
+
+
+비즈니스 그래픽 렌더링 의도.
+
+### Photographs {#Photographs}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption Photographs
+```
+
+
+사진 렌더링 의도.
+
+### RelativeColorimetric {#RelativeColorimetric}
+```
+public static PageICMRenderingIntent.PageICMRenderingIntentOption RelativeColorimetric
+```
+
+
+상대 색채계 렌더링 의도.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageimageablesize/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageimageablesize/_index.md
@@ -1,0 +1,248 @@
+---
+title: "PageImageableSize"
+second_title: "Aspose.Page용 Java API 참조"
+description: "레이아웃 및 렌더링을 위한 이미지 캔버스를 설명합니다."
+type: docs
+weight: 99
+url: /ko/java/com.aspose.xps.metadata/pageimageablesize/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageImageableSize extends Property implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+레이아웃 및 렌더링을 위한 이미지 캔버스를 설명합니다. 이는  PageMediaSize  및  PageOrientation  에 따라 보고됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageimageablesize
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageImageableSize(int width, int height)](#PageImageableSize-int-int-) | 새 인스턴스를 생성합니다. |
+| [PageImageableSize(int width, int height, int originWidth, int originHeight, int extentWidth, int extentHeight)](#PageImageableSize-int-int-int-int-int-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageImageableSize(int width, int height) {#PageImageableSize-int-int-}
+```
+public PageImageableSize(int width, int height)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 너비 | int | 하나 |
+
+```
+ImageableSizeWidth
+```
+
+속성 값. |
+|  | 높이 | int | 하나 |
+
+```
+ImageableSizeHeight
+```
+
+속성 값. |
+
+### PageImageableSize(int width, int height, int originWidth, int originHeight, int extentWidth, int extentHeight) {#PageImageableSize-int-int-int-int-int-int-}
+```
+public PageImageableSize(int width, int height, int originWidth, int originHeight, int extentWidth, int extentHeight)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+|  | 너비 | int | 하나 |
+
+```
+ImageableSizeWidth
+```
+
+속성 값. |
+|  | 높이 | int | 하나 |
+
+```
+ImageableSizeHeight
+```
+
+속성 값. |
+|  | originWidth | int | 하나 |
+
+```
+ImageableArea
+```
+
+하위 속성의
+
+```
+OriginWidth
+```
+
+속성 값. |
+|  | originHeight | int | 하나 |
+
+```
+ImageableArea
+```
+
+하위 속성의
+
+```
+OriginHeight
+```
+
+속성 값. |
+|  | extentWidth | int | 하나 |
+
+```
+ImageableArea
+```
+
+하위 속성의
+
+```
+ExtentWidth
+```
+
+속성 값. |
+|  | extentHeight | int | 하나 |
+
+```
+ImageableArea
+```
+
+하위 속성의
+
+```
+ExtentHeight
+```
+
+속성 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageinputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageinputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageInputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치에 설치된 입력 빈 또는 장치가 지원하는 전체 빈 목록을 설명합니다."
+type: docs
+weight: 100
+url: /ko/java/com.aspose.xps.metadata/pageinputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.InputBin](../../com.aspose.xps.metadata/inputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageInputBin extends InputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+장치에 설치된 입력 빈 또는 장치가 지원하는 전체 입력 빈 목록을 설명합니다. 페이지별로 입력 빈을 지정할 수 있습니다.  JobInputBin ,  DocumentInputBin  및  PageInputBin  키워드는 서로 배타적이며, PrintTicket 또는 Print Capabilities 문서에서 동시에 지정해서는 안 됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageinputbin
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageInputBin(InputBin.IInputBinItem[] items)](#PageInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageInputBin(InputBin.IInputBinItem[] items) {#PageInputBin-com.aspose.xps.metadata.InputBin.IInputBinItem...-}
+```
+public PageInputBin(InputBin.IInputBinItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IInputBinItem\[\]](../../com.aspose.xps.metadata/iinputbinitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediacolor/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediacolor/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMediaColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Media Color 옵션 및 각 옵션의 특성을 설명합니다."
+type: docs
+weight: 101
+url: /ko/java/com.aspose.xps.metadata/pagemediacolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaColor extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+Media Color 옵션과 각 옵션의 특성을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediacolor
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaColor(PageMediaColor.PageMediaColorOption[] options)](#PageMediaColor-com.aspose.xps.metadata.PageMediaColor.PageMediaColorOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaColor(PageMediaColor.PageMediaColorOption[] options) {#PageMediaColor-com.aspose.xps.metadata.PageMediaColor.PageMediaColorOption...-}
+```
+public PageMediaColor(PageMediaColor.PageMediaColorOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageMediaColorOption\[\]](../../com.aspose.xps.metadata/pagemediacoloroption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediacoloroption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediacoloroption/_index.md
@@ -1,0 +1,322 @@
+---
+title: "PageMediaColor.PageMediaColorOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMediaColor 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagemediacolor.pagemediacoloroption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageMediaColor.PageMediaColorOption extends Option
+```
+
+PageMediaColor 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Black](#Black) | 검정. |
+| [Blue](#Blue) | 파랑. |
+| [Brown](#Brown) | 갈색. |
+| [Gold](#Gold) | 금색. |
+| [GoldenRod](#GoldenRod) | 골든로드. |
+| [Gray](#Gray) | 회색. |
+| [Green](#Green) | 녹색. |
+| [Ivory](#Ivory) | 아이보리. |
+| [NoColor](#NoColor) | 색 없음. |
+| [Orange](#Orange) | 주황색. |
+| [Pink](#Pink) | 핑크. |
+| [Red](#Red) | 빨간색. |
+| [Silver](#Silver) | 은색. |
+| [Turquoise](#Turquoise) | 청록색. |
+| [Violet](#Violet) | 보라색. |
+| [White](#White) | 흰색. |
+| [Yellow](#Yellow) | 노란색. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getCustom(String mediaColorsRGB)](#getCustom-java.lang.String-) | 사용자 지정 페이지 색상을 지정합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Black {#Black}
+```
+public static PageMediaColor.PageMediaColorOption Black
+```
+
+
+검정.
+
+### Blue {#Blue}
+```
+public static PageMediaColor.PageMediaColorOption Blue
+```
+
+
+파랑.
+
+### Brown {#Brown}
+```
+public static PageMediaColor.PageMediaColorOption Brown
+```
+
+
+갈색.
+
+### Gold {#Gold}
+```
+public static PageMediaColor.PageMediaColorOption Gold
+```
+
+
+금색.
+
+### GoldenRod {#GoldenRod}
+```
+public static PageMediaColor.PageMediaColorOption GoldenRod
+```
+
+
+골든로드.
+
+### Gray {#Gray}
+```
+public static PageMediaColor.PageMediaColorOption Gray
+```
+
+
+회색.
+
+### Green {#Green}
+```
+public static PageMediaColor.PageMediaColorOption Green
+```
+
+
+녹색.
+
+### Ivory {#Ivory}
+```
+public static PageMediaColor.PageMediaColorOption Ivory
+```
+
+
+아이보리.
+
+### NoColor {#NoColor}
+```
+public static PageMediaColor.PageMediaColorOption NoColor
+```
+
+
+색 없음.
+
+### Orange {#Orange}
+```
+public static PageMediaColor.PageMediaColorOption Orange
+```
+
+
+주황색.
+
+### Pink {#Pink}
+```
+public static PageMediaColor.PageMediaColorOption Pink
+```
+
+
+핑크.
+
+### Red {#Red}
+```
+public static PageMediaColor.PageMediaColorOption Red
+```
+
+
+빨간색.
+
+### Silver {#Silver}
+```
+public static PageMediaColor.PageMediaColorOption Silver
+```
+
+
+은색.
+
+### Turquoise {#Turquoise}
+```
+public static PageMediaColor.PageMediaColorOption Turquoise
+```
+
+
+청록색.
+
+### Violet {#Violet}
+```
+public static PageMediaColor.PageMediaColorOption Violet
+```
+
+
+보라색.
+
+### White {#White}
+```
+public static PageMediaColor.PageMediaColorOption White
+```
+
+
+흰색.
+
+### Yellow {#Yellow}
+```
+public static PageMediaColor.PageMediaColorOption Yellow
+```
+
+
+노란색.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getCustom(String mediaColorsRGB) {#getCustom-java.lang.String-}
+```
+public static PageMediaColor.PageMediaColorOption getCustom(String mediaColorsRGB)
+```
+
+
+사용자 지정 페이지 색상을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mediaColorsRGB | java.lang.String | 페이지 색상. |
+
+**Returns:**
+[PageMediaColorOption](../../com.aspose.xps.metadata/pagemediacoloroption) - The option element for a custom color.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasize/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasize/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMediaSize"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력에 사용되는 물리적 매체 차원을 설명합니다."
+type: docs
+weight: 102
+url: /ko/java/com.aspose.xps.metadata/pagemediasize/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSize extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력에 사용되는 물리적 미디어 차원을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasize
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSize(PageMediaSize.IPageMediaSizeItem[] options)](#PageMediaSize-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSize(PageMediaSize.IPageMediaSizeItem[] options) {#PageMediaSize-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeItem...-}
+```
+public PageMediaSize(PageMediaSize.IPageMediaSizeItem[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [IPageMediaSizeItem\[\]](../../com.aspose.xps.metadata/ipagemediasizeitem) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizemediasizeheight/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizemediasizeheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizeMediaSizeHeight"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용자 지정 MediaSize 옵션에 대한 MediaSizeWidth 방향 차원을 지정합니다."
+type: docs
+weight: 103
+url: /ko/java/com.aspose.xps.metadata/pagemediasizemediasizeheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizeMediaSizeHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+사용자 지정 MediaSize 옵션에 대한 MediaSizeWidth 방향 차원을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizemediasizeheight
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizeMediaSizeHeight(int value)](#PageMediaSizeMediaSizeHeight-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizeMediaSizeHeight(int value) {#PageMediaSizeMediaSizeHeight-int-}
+```
+public PageMediaSizeMediaSizeHeight(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizemediasizewidth/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizemediasizewidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizeMediaSizeWidth"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Custom MediaSize 옵션에 대한 MediaSizeHeight 방향의 차원을 지정합니다."
+type: docs
+weight: 104
+url: /ko/java/com.aspose.xps.metadata/pagemediasizemediasizewidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizeMediaSizeWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+Custom MediaSize 옵션에 대한 MediaSizeHeight 방향의 차원을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizemediasizewidth
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizeMediaSizeWidth(int value)](#PageMediaSizeMediaSizeWidth-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizeMediaSizeWidth(int value) {#PageMediaSizeMediaSizeWidth-int-}
+```
+public PageMediaSizeMediaSizeWidth(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizeoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizeoption/_index.md
@@ -1,0 +1,1787 @@
+---
+title: "PageMediaSize.PageMediaSizeOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMediaSize 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagemediasize.pagemediasizeoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeItem](../../com.aspose.xps.metadata/ipagemediasizeitem)
+```
+public static final class PageMediaSize.PageMediaSizeOption extends Option implements PageMediaSize.IPageMediaSizeItem
+```
+
+PageMediaSize 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizeOption(String name, PageMediaSize.IPageMediaSizeOptionItem[] items)](#PageMediaSizeOption-java.lang.String-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-) | 새 인스턴스를 생성합니다. |
+| [PageMediaSizeOption(PageMediaSize.PageMediaSizeOption option)](#PageMediaSizeOption-com.aspose.xps.metadata.PageMediaSize.PageMediaSizeOption-) | 이 옵션 인스턴스를 복제합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BusinessCard](#BusinessCard) | 명함 |
+| [CreditCard](#CreditCard) | 신용카드 |
+| [CustomMediaSize](#CustomMediaSize) | 사용자 정의 미디어 크기를 지정합니다. |
+| [ISOA0](#ISOA0) | ISOA0 |
+| [ISOA1](#ISOA1) | ISOA1 |
+| [ISOA10](#ISOA10) | ISOA10 |
+| [ISOA2](#ISOA2) | ISOA2 |
+| [ISOA3](#ISOA3) | ISOA3 |
+| [ISOA3Extra](#ISOA3Extra) | ISOA3 extra |
+| [ISOA3Rotated](#ISOA3Rotated) | ISOA3 rotated |
+| [ISOA4](#ISOA4) | ISOA4 |
+| [ISOA4Extra](#ISOA4Extra) | ISOA4 extra |
+| [ISOA4Rotated](#ISOA4Rotated) | ISOA4 rotated |
+| [ISOA5](#ISOA5) | ISOA5 |
+| [ISOA5Extra](#ISOA5Extra) | ISOA5 extra |
+| [ISOA5Rotated](#ISOA5Rotated) | ISOA5 rotated |
+| [ISOA6](#ISOA6) | ISOA6 |
+| [ISOA6Rotated](#ISOA6Rotated) | ISOA6 rotated |
+| [ISOA7](#ISOA7) | ISOA7 |
+| [ISOA8](#ISOA8) | ISOA8 |
+| [ISOA9](#ISOA9) | ISOA9 |
+| [ISOB0](#ISOB0) | ISOB0 |
+| [ISOB1](#ISOB1) | ISOB1 |
+| [ISOB10](#ISOB10) | ISOB10 |
+| [ISOB2](#ISOB2) | ISOB2 |
+| [ISOB3](#ISOB3) | ISOB3 |
+| [ISOB4](#ISOB4) | ISOB4 |
+| [ISOB4Envelope](#ISOB4Envelope) | ISOB4 봉투 |
+| [ISOB5Envelope](#ISOB5Envelope) | ISOB5 봉투 |
+| [ISOB5Extra](#ISOB5Extra) | ISOB5 추가 |
+| [ISOB7](#ISOB7) | ISOB7 |
+| [ISOB8](#ISOB8) | ISOB8 |
+| [ISOB9](#ISOB9) | ISOB9 |
+| [ISOC0](#ISOC0) | ISOC0 |
+| [ISOC1](#ISOC1) | ISOC1 |
+| [ISOC10](#ISOC10) | ISOC10 |
+| [ISOC2](#ISOC2) | ISOC2 |
+| [ISOC3](#ISOC3) | ISOC3 |
+| [ISOC3Envelope](#ISOC3Envelope) | ISOC3 봉투 |
+| [ISOC4](#ISOC4) | ISOC4 |
+| [ISOC4Envelope](#ISOC4Envelope) | ISOC4 봉투 |
+| [ISOC5](#ISOC5) | ISOC5 |
+| [ISOC5Envelope](#ISOC5Envelope) | ISOC5 봉투 |
+| [ISOC6](#ISOC6) | ISOC6 |
+| [ISOC6C5Envelope](#ISOC6C5Envelope) | ISOC6C5 봉투 |
+| [ISOC6Envelope](#ISOC6Envelope) | ISOC6 봉투 |
+| [ISOC7](#ISOC7) | ISOC7 |
+| [ISOC8](#ISOC8) | ISOC8 |
+| [ISOC9](#ISOC9) | ISOC9 |
+| [ISODLEnvelope](#ISODLEnvelope) | ISODL 봉투 |
+| [ISODLEnvelopeRotated](#ISODLEnvelopeRotated) | ISODL 봉투 회전 |
+| [ISOSRA3](#ISOSRA3) | ISOSRA3 |
+| [JISB0](#JISB0) | JISB0 |
+| [JISB1](#JISB1) | JISB1 |
+| [JISB10](#JISB10) | JISB10 |
+| [JISB2](#JISB2) | JISB2 |
+| [JISB3](#JISB3) | JISB3 |
+| [JISB4](#JISB4) | JISB4 |
+| [JISB4Rotated](#JISB4Rotated) | JISB4 회전 |
+| [JISB5](#JISB5) | JISB5 |
+| [JISB5Rotated](#JISB5Rotated) | JISB5 회전 |
+| [JISB6](#JISB6) | JISB6 |
+| [JISB6Rotated](#JISB6Rotated) | JISB6 회전 |
+| [JISB7](#JISB7) | JISB7 |
+| [JISB8](#JISB8) | JISB8 |
+| [JISB9](#JISB9) | JISB9 |
+| [Japan2LPhoto](#Japan2LPhoto) | Japan 2L 사진 |
+| [JapanChou3Envelope](#JapanChou3Envelope) | Japan Chou3 봉투 |
+| [JapanChou3EnvelopeRotated](#JapanChou3EnvelopeRotated) | Japan Chou3 봉투 회전 |
+| [JapanChou4Envelope](#JapanChou4Envelope) | Japan Chou4 봉투 |
+| [JapanChou4EnvelopeRotated](#JapanChou4EnvelopeRotated) | Japan Chou4 봉투 회전 |
+| [JapanDoubleHagakiPostcard](#JapanDoubleHagakiPostcard) | 일본 이중 하가키 엽서 |
+| [JapanDoubleHagakiPostcardRotated](#JapanDoubleHagakiPostcardRotated) | 일본 이중 하가키 엽서 회전 |
+| [JapanHagakiPostcard](#JapanHagakiPostcard) | 일본 하가키 엽서 |
+| [JapanHagakiPostcardRotated](#JapanHagakiPostcardRotated) | 일본 하가키 엽서 회전 |
+| [JapanKaku2Envelope](#JapanKaku2Envelope) | 일본 Kaku2 봉투 |
+| [JapanKaku2EnvelopeRotated](#JapanKaku2EnvelopeRotated) | 일본 Kaku2 봉투 회전 |
+| [JapanKaku3Envelope](#JapanKaku3Envelope) | 일본 Kaku3 봉투 |
+| [JapanKaku3EnvelopeRotated](#JapanKaku3EnvelopeRotated) | 일본 Kaku3 봉투 회전 |
+| [JapanLPhoto](#JapanLPhoto) | 일본 L 사진 |
+| [JapanQuadrupleHagakiPostcard](#JapanQuadrupleHagakiPostcard) | 일본 사중 하가키 엽서 |
+| [JapanYou1Envelope](#JapanYou1Envelope) | 일본 You1 봉투 |
+| [JapanYou2Envelope](#JapanYou2Envelope) | 일본 You2 봉투 |
+| [JapanYou3Envelope](#JapanYou3Envelope) | 일본 You3 봉투 |
+| [JapanYou4Envelope](#JapanYou4Envelope) | 일본 You4 봉투 |
+| [JapanYou4EnvelopeRotated](#JapanYou4EnvelopeRotated) | 일본 You4 봉투 회전 |
+| [JapanYou6Envelope](#JapanYou6Envelope) | 일본 You6 봉투 |
+| [JapanYou6EnvelopeRotated](#JapanYou6EnvelopeRotated) | 일본 You6 봉투 회전 |
+| [NorthAmerica10x11](#NorthAmerica10x11) | 북미 10x11 |
+| [NorthAmerica10x12](#NorthAmerica10x12) | 북미 10x12 |
+| [NorthAmerica10x14](#NorthAmerica10x14) | 북미 10x14 |
+| [NorthAmerica11x17](#NorthAmerica11x17) | 북미 11x17 |
+| [NorthAmerica14x17](#NorthAmerica14x17) | 북미 14x17 |
+| [NorthAmerica4x6](#NorthAmerica4x6) | 북미 4x6 |
+| [NorthAmerica4x8](#NorthAmerica4x8) | 북미 4x8 |
+| [NorthAmerica5x7](#NorthAmerica5x7) | 북미 5x7 |
+| [NorthAmerica8x10](#NorthAmerica8x10) | 북미 8x10 |
+| [NorthAmerica9x11](#NorthAmerica9x11) | 북미 9x11 |
+| [NorthAmericaArchitectureASheet](#NorthAmericaArchitectureASheet) | 북미 아키텍처 A 시트 |
+| [NorthAmericaArchitectureBSheet](#NorthAmericaArchitectureBSheet) | 북미 아키텍처 B 시트 |
+| [NorthAmericaArchitectureCSheet](#NorthAmericaArchitectureCSheet) | 북미 아키텍처 C 시트 |
+| [NorthAmericaArchitectureDSheet](#NorthAmericaArchitectureDSheet) | 북미 아키텍처 D 시트 |
+| [NorthAmericaArchitectureESheet](#NorthAmericaArchitectureESheet) | 북미 아키텍처 E 시트 |
+| [NorthAmericaCSheet](#NorthAmericaCSheet) | 북미 C 시트 |
+| [NorthAmericaDSheet](#NorthAmericaDSheet) | 북미 D 시트 |
+| [NorthAmericaESheet](#NorthAmericaESheet) | 북미 E 시트 |
+| [NorthAmericaExecutive](#NorthAmericaExecutive) | 북미 임원 |
+| [NorthAmericaGermanLegalFanfold](#NorthAmericaGermanLegalFanfold) | 북미 독일 법률 팬폴드 |
+| [NorthAmericaGermanStandardFanfold](#NorthAmericaGermanStandardFanfold) | 북미 독일 표준 팬폴드 |
+| [NorthAmericaLegal](#NorthAmericaLegal) | 북미 법률 |
+| [NorthAmericaLegalExtra](#NorthAmericaLegalExtra) | 북미 법률 추가 |
+| [NorthAmericaLetter](#NorthAmericaLetter) | 북미 레터 |
+| [NorthAmericaLetterExtra](#NorthAmericaLetterExtra) | 북미 레터 추가 |
+| [NorthAmericaLetterPlus](#NorthAmericaLetterPlus) | 북미 레터 플러스 |
+| [NorthAmericaLetterRotated](#NorthAmericaLetterRotated) | 북미 레터 회전 |
+| [NorthAmericaMonarchEnvelope](#NorthAmericaMonarchEnvelope) | 북미 모나크 봉투 |
+| [NorthAmericaNote](#NorthAmericaNote) | 북미 노트 |
+| [NorthAmericaNumber10Envelope](#NorthAmericaNumber10Envelope) | 북미 번호 10 봉투 |
+| [NorthAmericaNumber10EnvelopeRotated](#NorthAmericaNumber10EnvelopeRotated) | 북미 번호 10 봉투 회전 |
+| [NorthAmericaNumber11Envelope](#NorthAmericaNumber11Envelope) | 북미 번호 11 봉투 |
+| [NorthAmericaNumber12Envelope](#NorthAmericaNumber12Envelope) | 북미 번호 12 봉투 |
+| [NorthAmericaNumber14Envelope](#NorthAmericaNumber14Envelope) | 북미 번호 14 봉투 |
+| [NorthAmericaNumber9Envelope](#NorthAmericaNumber9Envelope) | 북미 번호 9 봉투 |
+| [NorthAmericaPersonalEnvelope](#NorthAmericaPersonalEnvelope) | 북미 개인 봉투 |
+| [NorthAmericaQuarto](#NorthAmericaQuarto) | 북미 쿼터 |
+| [NorthAmericaStatement](#NorthAmericaStatement) | 북미 명세서 |
+| [NorthAmericaSuperA](#NorthAmericaSuperA) | 북미 슈퍼 A |
+| [NorthAmericaSuperB](#NorthAmericaSuperB) | 북미 슈퍼 B |
+| [NorthAmericaTabloid](#NorthAmericaTabloid) | 북미 타블로이드 |
+| [NorthAmericaTabloidExtra](#NorthAmericaTabloidExtra) | 북미 타블로이드 엑스트라 |
+| [OtherMetricA3Plus](#OtherMetricA3Plus) | 기타 메트릭 A3 플러스 |
+| [OtherMetricA4Plus](#OtherMetricA4Plus) | 기타 메트릭 A4 플러스 |
+| [OtherMetricFolio](#OtherMetricFolio) | 기타 메트릭 폴리오 |
+| [OtherMetricInviteEnvelope](#OtherMetricInviteEnvelope) | 기타 메트릭 초대장 봉투 |
+| [OtherMetricItalianEnvelope](#OtherMetricItalianEnvelope) | 기타 메트릭 이탈리안 봉투 |
+| [PRC10Envelope](#PRC10Envelope) | PRC10 봉투 |
+| [PRC10EnvelopeRotated](#PRC10EnvelopeRotated) | PRC10 봉투 회전 |
+| [PRC16K](#PRC16K) | PRC16K |
+| [PRC16KRotated](#PRC16KRotated) | PRC16K 회전 |
+| [PRC1Envelope](#PRC1Envelope) | PRC1 봉투 |
+| [PRC1EnvelopeRotated](#PRC1EnvelopeRotated) | PRC1 봉투 회전 |
+| [PRC2Envelope](#PRC2Envelope) | PRC2 봉투 |
+| [PRC2EnvelopeRotated](#PRC2EnvelopeRotated) | PRC2 봉투 회전 |
+| [PRC32K](#PRC32K) | PRC32K |
+| [PRC32KBig](#PRC32KBig) | PRC32K 대형 |
+| [PRC32KRotated](#PRC32KRotated) | PRC32K 회전 |
+| [PRC3Envelope](#PRC3Envelope) | PRC3 봉투 |
+| [PRC3EnvelopeRotated](#PRC3EnvelopeRotated) | PRC3 회전된 봉투 |
+| [PRC4Envelope](#PRC4Envelope) | PRC4 봉투 |
+| [PRC4EnvelopeRotated](#PRC4EnvelopeRotated) | PRC4 회전된 봉투 |
+| [PRC5Envelope](#PRC5Envelope) | PRC 봉투 |
+| [PRC5EnvelopeRotated](#PRC5EnvelopeRotated) | PRC5 회전된 봉투 |
+| [PRC6Envelope](#PRC6Envelope) | PRC6 봉투 |
+| [PRC6EnvelopeRotated](#PRC6EnvelopeRotated) | PRC6 회전된 봉투 |
+| [PRC7Envelope](#PRC7Envelope) | PRC7 봉투 |
+| [PRC7EnvelopeRotated](#PRC7EnvelopeRotated) | PRC7 회전된 봉투 |
+| [PRC8Envelope](#PRC8Envelope) | PRC8 봉투 |
+| [PRC8EnvelopeRotated](#PRC8EnvelopeRotated) | PRC8 회전된 봉투 |
+| [PRC9Envelope](#PRC9Envelope) | PRC9 봉투 |
+| [PRC9EnvelopeRotated](#PRC9EnvelopeRotated) | PRC9 회전된 봉투 |
+| [PSCustomMediaSize](#PSCustomMediaSize) | 사용자 정의 미디어 크기를 지정합니다 (PostScript 전용). |
+| [Roll06Inch](#Roll06Inch) | 롤 06인치 |
+| [Roll08Inch](#Roll08Inch) | 롤 08인치 |
+| [Roll12Inch](#Roll12Inch) | 롤 12인치 |
+| [Roll15Inch](#Roll15Inch) | 롤 15인치 |
+| [Roll18Inch](#Roll18Inch) | 롤 18인치 |
+| [Roll22Inch](#Roll22Inch) | 롤 22인치 |
+| [Roll24Inch](#Roll24Inch) | 롤 24인치 |
+| [Roll30Inch](#Roll30Inch) | 롤 30인치 |
+| [Roll36Inch](#Roll36Inch) | 롤 36인치 |
+| [Roll54Inch](#Roll54Inch) | 롤 54인치 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(PageMediaSize.IPageMediaSizeOptionItem[] items)](#add-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-) | 옵션에 항목을 추가합니다. |
+| [clone()](#clone--) | 이 옵션 인스턴스를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setMediaSizeHeight(int mediaSizeHeight)](#setMediaSizeHeight-int-) | MediaSizeWidth 점수 속성 값을 추가합니다. |
+| [setMediaSizeWidth(int mediaSizeWidth)](#setMediaSizeWidth-int-) | MediaSizeWidth 점수 속성 값을 추가합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizeOption(String name, PageMediaSize.IPageMediaSizeOptionItem[] items) {#PageMediaSizeOption-java.lang.String-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-}
+```
+public PageMediaSizeOption(String name, PageMediaSize.IPageMediaSizeOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 옵션 이름입니다. |
+| items | [IPageMediaSizeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediasizeoptionitem) | 옵션 항목입니다. |
+
+### PageMediaSizeOption(PageMediaSize.PageMediaSizeOption option) {#PageMediaSizeOption-com.aspose.xps.metadata.PageMediaSize.PageMediaSizeOption-}
+```
+public PageMediaSizeOption(PageMediaSize.PageMediaSizeOption option)
+```
+
+
+이 옵션 인스턴스를 복제합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| option | [PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) | 복제할 인스턴스. |
+
+### BusinessCard {#BusinessCard}
+```
+public static PageMediaSize.PageMediaSizeOption BusinessCard
+```
+
+
+명함
+
+### CreditCard {#CreditCard}
+```
+public static PageMediaSize.PageMediaSizeOption CreditCard
+```
+
+
+신용카드
+
+### CustomMediaSize {#CustomMediaSize}
+```
+public static PageMediaSize.PageMediaSizeOption CustomMediaSize
+```
+
+
+사용자 지정 미디어 크기를 지정합니다. DeviceMediaSize에 대해 검증되어야 합니다.
+
+### ISOA0 {#ISOA0}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA0
+```
+
+
+ISOA0
+
+### ISOA1 {#ISOA1}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA1
+```
+
+
+ISOA1
+
+### ISOA10 {#ISOA10}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA10
+```
+
+
+ISOA10
+
+### ISOA2 {#ISOA2}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA2
+```
+
+
+ISOA2
+
+### ISOA3 {#ISOA3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA3
+```
+
+
+ISOA3
+
+### ISOA3Extra {#ISOA3Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA3Extra
+```
+
+
+ISOA3 extra
+
+### ISOA3Rotated {#ISOA3Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA3Rotated
+```
+
+
+ISOA3 rotated
+
+### ISOA4 {#ISOA4}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA4
+```
+
+
+ISOA4
+
+### ISOA4Extra {#ISOA4Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA4Extra
+```
+
+
+ISOA4 extra
+
+### ISOA4Rotated {#ISOA4Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA4Rotated
+```
+
+
+ISOA4 rotated
+
+### ISOA5 {#ISOA5}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA5
+```
+
+
+ISOA5
+
+### ISOA5Extra {#ISOA5Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA5Extra
+```
+
+
+ISOA5 extra
+
+### ISOA5Rotated {#ISOA5Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA5Rotated
+```
+
+
+ISOA5 rotated
+
+### ISOA6 {#ISOA6}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA6
+```
+
+
+ISOA6
+
+### ISOA6Rotated {#ISOA6Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA6Rotated
+```
+
+
+ISOA6 rotated
+
+### ISOA7 {#ISOA7}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA7
+```
+
+
+ISOA7
+
+### ISOA8 {#ISOA8}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA8
+```
+
+
+ISOA8
+
+### ISOA9 {#ISOA9}
+```
+public static PageMediaSize.PageMediaSizeOption ISOA9
+```
+
+
+ISOA9
+
+### ISOB0 {#ISOB0}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB0
+```
+
+
+ISOB0
+
+### ISOB1 {#ISOB1}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB1
+```
+
+
+ISOB1
+
+### ISOB10 {#ISOB10}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB10
+```
+
+
+ISOB10
+
+### ISOB2 {#ISOB2}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB2
+```
+
+
+ISOB2
+
+### ISOB3 {#ISOB3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB3
+```
+
+
+ISOB3
+
+### ISOB4 {#ISOB4}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB4
+```
+
+
+ISOB4
+
+### ISOB4Envelope {#ISOB4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB4Envelope
+```
+
+
+ISOB4 봉투
+
+### ISOB5Envelope {#ISOB5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB5Envelope
+```
+
+
+ISOB5 봉투
+
+### ISOB5Extra {#ISOB5Extra}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB5Extra
+```
+
+
+ISOB5 추가
+
+### ISOB7 {#ISOB7}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB7
+```
+
+
+ISOB7
+
+### ISOB8 {#ISOB8}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB8
+```
+
+
+ISOB8
+
+### ISOB9 {#ISOB9}
+```
+public static PageMediaSize.PageMediaSizeOption ISOB9
+```
+
+
+ISOB9
+
+### ISOC0 {#ISOC0}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC0
+```
+
+
+ISOC0
+
+### ISOC1 {#ISOC1}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC1
+```
+
+
+ISOC1
+
+### ISOC10 {#ISOC10}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC10
+```
+
+
+ISOC10
+
+### ISOC2 {#ISOC2}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC2
+```
+
+
+ISOC2
+
+### ISOC3 {#ISOC3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC3
+```
+
+
+ISOC3
+
+### ISOC3Envelope {#ISOC3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC3Envelope
+```
+
+
+ISOC3 봉투
+
+### ISOC4 {#ISOC4}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC4
+```
+
+
+ISOC4
+
+### ISOC4Envelope {#ISOC4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC4Envelope
+```
+
+
+ISOC4 봉투
+
+### ISOC5 {#ISOC5}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC5
+```
+
+
+ISOC5
+
+### ISOC5Envelope {#ISOC5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC5Envelope
+```
+
+
+ISOC5 봉투
+
+### ISOC6 {#ISOC6}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC6
+```
+
+
+ISOC6
+
+### ISOC6C5Envelope {#ISOC6C5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC6C5Envelope
+```
+
+
+ISOC6C5 봉투
+
+### ISOC6Envelope {#ISOC6Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC6Envelope
+```
+
+
+ISOC6 봉투
+
+### ISOC7 {#ISOC7}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC7
+```
+
+
+ISOC7
+
+### ISOC8 {#ISOC8}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC8
+```
+
+
+ISOC8
+
+### ISOC9 {#ISOC9}
+```
+public static PageMediaSize.PageMediaSizeOption ISOC9
+```
+
+
+ISOC9
+
+### ISODLEnvelope {#ISODLEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption ISODLEnvelope
+```
+
+
+ISODL 봉투
+
+### ISODLEnvelopeRotated {#ISODLEnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption ISODLEnvelopeRotated
+```
+
+
+ISODL 봉투 회전
+
+### ISOSRA3 {#ISOSRA3}
+```
+public static PageMediaSize.PageMediaSizeOption ISOSRA3
+```
+
+
+ISOSRA3
+
+### JISB0 {#JISB0}
+```
+public static PageMediaSize.PageMediaSizeOption JISB0
+```
+
+
+JISB0
+
+### JISB1 {#JISB1}
+```
+public static PageMediaSize.PageMediaSizeOption JISB1
+```
+
+
+JISB1
+
+### JISB10 {#JISB10}
+```
+public static PageMediaSize.PageMediaSizeOption JISB10
+```
+
+
+JISB10
+
+### JISB2 {#JISB2}
+```
+public static PageMediaSize.PageMediaSizeOption JISB2
+```
+
+
+JISB2
+
+### JISB3 {#JISB3}
+```
+public static PageMediaSize.PageMediaSizeOption JISB3
+```
+
+
+JISB3
+
+### JISB4 {#JISB4}
+```
+public static PageMediaSize.PageMediaSizeOption JISB4
+```
+
+
+JISB4
+
+### JISB4Rotated {#JISB4Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption JISB4Rotated
+```
+
+
+JISB4 회전
+
+### JISB5 {#JISB5}
+```
+public static PageMediaSize.PageMediaSizeOption JISB5
+```
+
+
+JISB5
+
+### JISB5Rotated {#JISB5Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption JISB5Rotated
+```
+
+
+JISB5 회전
+
+### JISB6 {#JISB6}
+```
+public static PageMediaSize.PageMediaSizeOption JISB6
+```
+
+
+JISB6
+
+### JISB6Rotated {#JISB6Rotated}
+```
+public static PageMediaSize.PageMediaSizeOption JISB6Rotated
+```
+
+
+JISB6 회전
+
+### JISB7 {#JISB7}
+```
+public static PageMediaSize.PageMediaSizeOption JISB7
+```
+
+
+JISB7
+
+### JISB8 {#JISB8}
+```
+public static PageMediaSize.PageMediaSizeOption JISB8
+```
+
+
+JISB8
+
+### JISB9 {#JISB9}
+```
+public static PageMediaSize.PageMediaSizeOption JISB9
+```
+
+
+JISB9
+
+### Japan2LPhoto {#Japan2LPhoto}
+```
+public static PageMediaSize.PageMediaSizeOption Japan2LPhoto
+```
+
+
+Japan 2L 사진
+
+### JapanChou3Envelope {#JapanChou3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou3Envelope
+```
+
+
+Japan Chou3 봉투
+
+### JapanChou3EnvelopeRotated {#JapanChou3EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou3EnvelopeRotated
+```
+
+
+Japan Chou3 봉투 회전
+
+### JapanChou4Envelope {#JapanChou4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou4Envelope
+```
+
+
+Japan Chou4 봉투
+
+### JapanChou4EnvelopeRotated {#JapanChou4EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanChou4EnvelopeRotated
+```
+
+
+Japan Chou4 봉투 회전
+
+### JapanDoubleHagakiPostcard {#JapanDoubleHagakiPostcard}
+```
+public static PageMediaSize.PageMediaSizeOption JapanDoubleHagakiPostcard
+```
+
+
+일본 이중 하가키 엽서
+
+### JapanDoubleHagakiPostcardRotated {#JapanDoubleHagakiPostcardRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanDoubleHagakiPostcardRotated
+```
+
+
+일본 이중 하가키 엽서 회전
+
+### JapanHagakiPostcard {#JapanHagakiPostcard}
+```
+public static PageMediaSize.PageMediaSizeOption JapanHagakiPostcard
+```
+
+
+일본 하가키 엽서
+
+### JapanHagakiPostcardRotated {#JapanHagakiPostcardRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanHagakiPostcardRotated
+```
+
+
+일본 하가키 엽서 회전
+
+### JapanKaku2Envelope {#JapanKaku2Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku2Envelope
+```
+
+
+일본 Kaku2 봉투
+
+### JapanKaku2EnvelopeRotated {#JapanKaku2EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku2EnvelopeRotated
+```
+
+
+일본 Kaku2 봉투 회전
+
+### JapanKaku3Envelope {#JapanKaku3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku3Envelope
+```
+
+
+일본 Kaku3 봉투
+
+### JapanKaku3EnvelopeRotated {#JapanKaku3EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanKaku3EnvelopeRotated
+```
+
+
+일본 Kaku3 봉투 회전
+
+### JapanLPhoto {#JapanLPhoto}
+```
+public static PageMediaSize.PageMediaSizeOption JapanLPhoto
+```
+
+
+일본 L 사진
+
+### JapanQuadrupleHagakiPostcard {#JapanQuadrupleHagakiPostcard}
+```
+public static PageMediaSize.PageMediaSizeOption JapanQuadrupleHagakiPostcard
+```
+
+
+일본 사중 하가키 엽서
+
+### JapanYou1Envelope {#JapanYou1Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou1Envelope
+```
+
+
+일본 You1 봉투
+
+### JapanYou2Envelope {#JapanYou2Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou2Envelope
+```
+
+
+일본 You2 봉투
+
+### JapanYou3Envelope {#JapanYou3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou3Envelope
+```
+
+
+일본 You3 봉투
+
+### JapanYou4Envelope {#JapanYou4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou4Envelope
+```
+
+
+일본 You4 봉투
+
+### JapanYou4EnvelopeRotated {#JapanYou4EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou4EnvelopeRotated
+```
+
+
+일본 You4 봉투 회전
+
+### JapanYou6Envelope {#JapanYou6Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou6Envelope
+```
+
+
+일본 You6 봉투
+
+### JapanYou6EnvelopeRotated {#JapanYou6EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption JapanYou6EnvelopeRotated
+```
+
+
+일본 You6 봉투 회전
+
+### NorthAmerica10x11 {#NorthAmerica10x11}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica10x11
+```
+
+
+북미 10x11
+
+### NorthAmerica10x12 {#NorthAmerica10x12}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica10x12
+```
+
+
+북미 10x12
+
+### NorthAmerica10x14 {#NorthAmerica10x14}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica10x14
+```
+
+
+북미 10x14
+
+### NorthAmerica11x17 {#NorthAmerica11x17}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica11x17
+```
+
+
+북미 11x17
+
+### NorthAmerica14x17 {#NorthAmerica14x17}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica14x17
+```
+
+
+북미 14x17
+
+### NorthAmerica4x6 {#NorthAmerica4x6}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica4x6
+```
+
+
+북미 4x6
+
+### NorthAmerica4x8 {#NorthAmerica4x8}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica4x8
+```
+
+
+북미 4x8
+
+### NorthAmerica5x7 {#NorthAmerica5x7}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica5x7
+```
+
+
+북미 5x7
+
+### NorthAmerica8x10 {#NorthAmerica8x10}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica8x10
+```
+
+
+북미 8x10
+
+### NorthAmerica9x11 {#NorthAmerica9x11}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmerica9x11
+```
+
+
+북미 9x11
+
+### NorthAmericaArchitectureASheet {#NorthAmericaArchitectureASheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureASheet
+```
+
+
+북미 아키텍처 A 시트
+
+### NorthAmericaArchitectureBSheet {#NorthAmericaArchitectureBSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureBSheet
+```
+
+
+북미 아키텍처 B 시트
+
+### NorthAmericaArchitectureCSheet {#NorthAmericaArchitectureCSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureCSheet
+```
+
+
+북미 아키텍처 C 시트
+
+### NorthAmericaArchitectureDSheet {#NorthAmericaArchitectureDSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureDSheet
+```
+
+
+북미 아키텍처 D 시트
+
+### NorthAmericaArchitectureESheet {#NorthAmericaArchitectureESheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaArchitectureESheet
+```
+
+
+북미 아키텍처 E 시트
+
+### NorthAmericaCSheet {#NorthAmericaCSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaCSheet
+```
+
+
+북미 C 시트
+
+### NorthAmericaDSheet {#NorthAmericaDSheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaDSheet
+```
+
+
+북미 D 시트
+
+### NorthAmericaESheet {#NorthAmericaESheet}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaESheet
+```
+
+
+북미 E 시트
+
+### NorthAmericaExecutive {#NorthAmericaExecutive}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaExecutive
+```
+
+
+북미 임원
+
+### NorthAmericaGermanLegalFanfold {#NorthAmericaGermanLegalFanfold}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaGermanLegalFanfold
+```
+
+
+북미 독일 법률 팬폴드
+
+### NorthAmericaGermanStandardFanfold {#NorthAmericaGermanStandardFanfold}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaGermanStandardFanfold
+```
+
+
+북미 독일 표준 팬폴드
+
+### NorthAmericaLegal {#NorthAmericaLegal}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLegal
+```
+
+
+북미 법률
+
+### NorthAmericaLegalExtra {#NorthAmericaLegalExtra}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLegalExtra
+```
+
+
+북미 법률 추가
+
+### NorthAmericaLetter {#NorthAmericaLetter}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetter
+```
+
+
+북미 레터
+
+### NorthAmericaLetterExtra {#NorthAmericaLetterExtra}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetterExtra
+```
+
+
+북미 레터 추가
+
+### NorthAmericaLetterPlus {#NorthAmericaLetterPlus}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetterPlus
+```
+
+
+북미 레터 플러스
+
+### NorthAmericaLetterRotated {#NorthAmericaLetterRotated}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaLetterRotated
+```
+
+
+북미 레터 회전
+
+### NorthAmericaMonarchEnvelope {#NorthAmericaMonarchEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaMonarchEnvelope
+```
+
+
+북미 모나크 봉투
+
+### NorthAmericaNote {#NorthAmericaNote}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNote
+```
+
+
+북미 노트
+
+### NorthAmericaNumber10Envelope {#NorthAmericaNumber10Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber10Envelope
+```
+
+
+북미 번호 10 봉투
+
+### NorthAmericaNumber10EnvelopeRotated {#NorthAmericaNumber10EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber10EnvelopeRotated
+```
+
+
+북미 번호 10 봉투 회전
+
+### NorthAmericaNumber11Envelope {#NorthAmericaNumber11Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber11Envelope
+```
+
+
+북미 번호 11 봉투
+
+### NorthAmericaNumber12Envelope {#NorthAmericaNumber12Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber12Envelope
+```
+
+
+북미 번호 12 봉투
+
+### NorthAmericaNumber14Envelope {#NorthAmericaNumber14Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber14Envelope
+```
+
+
+북미 번호 14 봉투
+
+### NorthAmericaNumber9Envelope {#NorthAmericaNumber9Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaNumber9Envelope
+```
+
+
+북미 번호 9 봉투
+
+### NorthAmericaPersonalEnvelope {#NorthAmericaPersonalEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaPersonalEnvelope
+```
+
+
+북미 개인 봉투
+
+### NorthAmericaQuarto {#NorthAmericaQuarto}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaQuarto
+```
+
+
+북미 쿼터
+
+### NorthAmericaStatement {#NorthAmericaStatement}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaStatement
+```
+
+
+북미 명세서
+
+### NorthAmericaSuperA {#NorthAmericaSuperA}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaSuperA
+```
+
+
+북미 슈퍼 A
+
+### NorthAmericaSuperB {#NorthAmericaSuperB}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaSuperB
+```
+
+
+북미 슈퍼 B
+
+### NorthAmericaTabloid {#NorthAmericaTabloid}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaTabloid
+```
+
+
+북미 타블로이드
+
+### NorthAmericaTabloidExtra {#NorthAmericaTabloidExtra}
+```
+public static PageMediaSize.PageMediaSizeOption NorthAmericaTabloidExtra
+```
+
+
+북미 타블로이드 엑스트라
+
+### OtherMetricA3Plus {#OtherMetricA3Plus}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricA3Plus
+```
+
+
+기타 메트릭 A3 플러스
+
+### OtherMetricA4Plus {#OtherMetricA4Plus}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricA4Plus
+```
+
+
+기타 메트릭 A4 플러스
+
+### OtherMetricFolio {#OtherMetricFolio}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricFolio
+```
+
+
+기타 메트릭 폴리오
+
+### OtherMetricInviteEnvelope {#OtherMetricInviteEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricInviteEnvelope
+```
+
+
+기타 메트릭 초대장 봉투
+
+### OtherMetricItalianEnvelope {#OtherMetricItalianEnvelope}
+```
+public static PageMediaSize.PageMediaSizeOption OtherMetricItalianEnvelope
+```
+
+
+기타 메트릭 이탈리안 봉투
+
+### PRC10Envelope {#PRC10Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC10Envelope
+```
+
+
+PRC10 봉투
+
+### PRC10EnvelopeRotated {#PRC10EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC10EnvelopeRotated
+```
+
+
+PRC10 봉투 회전
+
+### PRC16K {#PRC16K}
+```
+public static PageMediaSize.PageMediaSizeOption PRC16K
+```
+
+
+PRC16K
+
+### PRC16KRotated {#PRC16KRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC16KRotated
+```
+
+
+PRC16K 회전
+
+### PRC1Envelope {#PRC1Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC1Envelope
+```
+
+
+PRC1 봉투
+
+### PRC1EnvelopeRotated {#PRC1EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC1EnvelopeRotated
+```
+
+
+PRC1 봉투 회전
+
+### PRC2Envelope {#PRC2Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC2Envelope
+```
+
+
+PRC2 봉투
+
+### PRC2EnvelopeRotated {#PRC2EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC2EnvelopeRotated
+```
+
+
+PRC2 봉투 회전
+
+### PRC32K {#PRC32K}
+```
+public static PageMediaSize.PageMediaSizeOption PRC32K
+```
+
+
+PRC32K
+
+### PRC32KBig {#PRC32KBig}
+```
+public static PageMediaSize.PageMediaSizeOption PRC32KBig
+```
+
+
+PRC32K 대형
+
+### PRC32KRotated {#PRC32KRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC32KRotated
+```
+
+
+PRC32K 회전
+
+### PRC3Envelope {#PRC3Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC3Envelope
+```
+
+
+PRC3 봉투
+
+### PRC3EnvelopeRotated {#PRC3EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC3EnvelopeRotated
+```
+
+
+PRC3 회전된 봉투
+
+### PRC4Envelope {#PRC4Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC4Envelope
+```
+
+
+PRC4 봉투
+
+### PRC4EnvelopeRotated {#PRC4EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC4EnvelopeRotated
+```
+
+
+PRC4 회전된 봉투
+
+### PRC5Envelope {#PRC5Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC5Envelope
+```
+
+
+PRC 봉투
+
+### PRC5EnvelopeRotated {#PRC5EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC5EnvelopeRotated
+```
+
+
+PRC5 회전된 봉투
+
+### PRC6Envelope {#PRC6Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC6Envelope
+```
+
+
+PRC6 봉투
+
+### PRC6EnvelopeRotated {#PRC6EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC6EnvelopeRotated
+```
+
+
+PRC6 회전된 봉투
+
+### PRC7Envelope {#PRC7Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC7Envelope
+```
+
+
+PRC7 봉투
+
+### PRC7EnvelopeRotated {#PRC7EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC7EnvelopeRotated
+```
+
+
+PRC7 회전된 봉투
+
+### PRC8Envelope {#PRC8Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC8Envelope
+```
+
+
+PRC8 봉투
+
+### PRC8EnvelopeRotated {#PRC8EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC8EnvelopeRotated
+```
+
+
+PRC8 회전된 봉투
+
+### PRC9Envelope {#PRC9Envelope}
+```
+public static PageMediaSize.PageMediaSizeOption PRC9Envelope
+```
+
+
+PRC9 봉투
+
+### PRC9EnvelopeRotated {#PRC9EnvelopeRotated}
+```
+public static PageMediaSize.PageMediaSizeOption PRC9EnvelopeRotated
+```
+
+
+PRC9 회전된 봉투
+
+### PSCustomMediaSize {#PSCustomMediaSize}
+```
+public static PageMediaSize.PageMediaSizeOption PSCustomMediaSize
+```
+
+
+사용자 지정 미디어 크기(PostScript 전용)를 지정합니다. DeviceMediaSize에 대해 검증되어야 합니다.
+
+### Roll06Inch {#Roll06Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll06Inch
+```
+
+
+롤 06인치
+
+### Roll08Inch {#Roll08Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll08Inch
+```
+
+
+롤 08인치
+
+### Roll12Inch {#Roll12Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll12Inch
+```
+
+
+롤 12인치
+
+### Roll15Inch {#Roll15Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll15Inch
+```
+
+
+롤 15인치
+
+### Roll18Inch {#Roll18Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll18Inch
+```
+
+
+롤 18인치
+
+### Roll22Inch {#Roll22Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll22Inch
+```
+
+
+롤 22인치
+
+### Roll24Inch {#Roll24Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll24Inch
+```
+
+
+롤 24인치
+
+### Roll30Inch {#Roll30Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll30Inch
+```
+
+
+롤 30인치
+
+### Roll36Inch {#Roll36Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll36Inch
+```
+
+
+롤 36인치
+
+### Roll54Inch {#Roll54Inch}
+```
+public static PageMediaSize.PageMediaSizeOption Roll54Inch
+```
+
+
+롤 54인치
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(PageMediaSize.IPageMediaSizeOptionItem[] items) {#add-com.aspose.xps.metadata.PageMediaSize.IPageMediaSizeOptionItem...-}
+```
+public PageMediaSize.PageMediaSizeOption add(PageMediaSize.IPageMediaSizeOptionItem[] items)
+```
+
+
+옵션에 항목을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageMediaSizeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediasizeoptionitem) | 추가할 항목입니다. |
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - This options.
+### clone() {#clone--}
+```
+public PageMediaSize.PageMediaSizeOption clone()
+```
+
+
+이 옵션 인스턴스를 복제합니다. 복제 생성자에 대한 바로 가기.
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setMediaSizeHeight(int mediaSizeHeight) {#setMediaSizeHeight-int-}
+```
+public PageMediaSize.PageMediaSizeOption setMediaSizeHeight(int mediaSizeHeight)
+```
+
+
+MediaSizeWidth 점수 속성 값을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mediaSizeHeight | int | MediaSizeHeight 점수 속성 값입니다. |
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - This option.
+### setMediaSizeWidth(int mediaSizeWidth) {#setMediaSizeWidth-int-}
+```
+public PageMediaSize.PageMediaSizeOption setMediaSizeWidth(int mediaSizeWidth)
+```
+
+
+MediaSizeWidth 점수 속성 값을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| mediaSizeWidth | int | MediaSizeWidth 점수 속성 값입니다. |
+
+**Returns:**
+[PageMediaSizeOption](../../com.aspose.xps.metadata/pagemediasizeoption) - This option.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizepsheight/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizepsheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSHeight"
+second_title: "Aspose.Page용 Java API 참조"
+description: "피드 방향과 평행한 페이지 높이를 지정합니다."
+type: docs
+weight: 105
+url: /ko/java/com.aspose.xps.metadata/pagemediasizepsheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+피드 방향과 평행한 페이지 높이를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsheight
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizePSHeight(int value)](#PageMediaSizePSHeight-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSHeight(int value) {#PageMediaSizePSHeight-int-}
+```
+public PageMediaSizePSHeight(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizepsheightoffset/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizepsheightoffset/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSHeightOffset"
+second_title: "Aspose.Page용 Java API 참조"
+description: "피드 방향과 평행한 오프셋을 지정합니다."
+type: docs
+weight: 106
+url: /ko/java/com.aspose.xps.metadata/pagemediasizepsheightoffset/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSHeightOffset extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+피드 방향과 평행한 오프셋을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsheightoffset
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizePSHeightOffset(int value)](#PageMediaSizePSHeightOffset-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSHeightOffset(int value) {#PageMediaSizePSHeightOffset-int-}
+```
+public PageMediaSizePSHeightOffset(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizepsorientation/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizepsorientation/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSOrientation"
+second_title: "Aspose.Page용 Java API 참조"
+description: "피드 방향에 대한 방향을 지정합니다 https//docs.microsoft.com/en-us/windows/win32rintdocsagemediasizepsorientation"
+type: docs
+weight: 107
+url: /ko/java/com.aspose.xps.metadata/pagemediasizepsorientation/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSOrientation extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+피드 방향에 상대적인 방향을 지정합니다 https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepsorientation
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizePSOrientation(int value)](#PageMediaSizePSOrientation-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSOrientation(int value) {#PageMediaSizePSOrientation-int-}
+```
+public PageMediaSizePSOrientation(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizepswidth/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizepswidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSWidth"
+second_title: "Aspose.Page용 Java API 참조"
+description: "피드 방향에 수직인 페이지의 너비를 지정합니다."
+type: docs
+weight: 108
+url: /ko/java/com.aspose.xps.metadata/pagemediasizepswidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+페이지의 피드 방향에 수직인 너비를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepswidth
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizePSWidth(int value)](#PageMediaSizePSWidth-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSWidth(int value) {#PageMediaSizePSWidth-int-}
+```
+public PageMediaSizePSWidth(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediasizepswidthoffset/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediasizepswidthoffset/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageMediaSizePSWidthOffset"
+second_title: "Aspose.Page용 Java API 참조"
+description: "피드 방향에 수직인 오프셋을 지정합니다."
+type: docs
+weight: 109
+url: /ko/java/com.aspose.xps.metadata/pagemediasizepswidthoffset/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaSizePSWidthOffset extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+급지 방향에 수직인 오프셋을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediasizepswidthoffset
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaSizePSWidthOffset(int value)](#PageMediaSizePSWidthOffset-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaSizePSWidthOffset(int value) {#PageMediaSizePSWidthOffset-int-}
+```
+public PageMediaSizePSWidthOffset(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediatype/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediatype/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMediaType"
+second_title: "Aspose.Page용 Java API 참조"
+description: "MediaType 옵션 및 각 옵션의 특성을 설명합니다."
+type: docs
+weight: 110
+url: /ko/java/com.aspose.xps.metadata/pagemediatype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMediaType extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+MediaType 옵션 및 각 옵션의 특성을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemediatype
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaType(PageMediaType.IPageMediaTypeItem[] items)](#PageMediaType-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaType(PageMediaType.IPageMediaTypeItem[] items) {#PageMediaType-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeItem...-}
+```
+public PageMediaType(PageMediaType.IPageMediaTypeItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageMediaTypeItem\[\]](../../com.aspose.xps.metadata/ipagemediatypeitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemediatypeoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemediatypeoption/_index.md
@@ -1,0 +1,493 @@
+---
+title: "PageMediaType.PageMediaTypeOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMediaType 기능 옵션을 설명합니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.pagemediatypeoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeItem](../../com.aspose.xps.metadata/ipagemediatypeitem)
+```
+public static final class PageMediaType.PageMediaTypeOption extends Option implements PageMediaType.IPageMediaTypeItem
+```
+
+PageMediaType 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMediaTypeOption(String optionName, PageMediaType.IPageMediaTypeOptionItem[] items)](#PageMediaTypeOption-java.lang.String-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-) | 새 인스턴스를 생성합니다. |
+| [PageMediaTypeOption(PageMediaType.PageMediaTypeOption option)](#PageMediaTypeOption-com.aspose.xps.metadata.PageMediaType.PageMediaTypeOption-) | 이 옵션 인스턴스를 복제합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Archival](#Archival) | 보관용 고품질 매체를 지정합니다. |
+| [AutoSelect](#AutoSelect) | 미디어가 자동으로 선택됨을 지정합니다. |
+| [BackPrintFilm](#BackPrintFilm) | 특수 백프린팅 필름 미디어를 지정합니다. |
+| [Bond](#Bond) | 표준 본드 미디어를 지정합니다. |
+| [CardStock](#CardStock) | 표준 카드 스톡 미디어를 지정합니다. |
+| [Continous](#Continous) | 연속 공급 미디어를 지정합니다. |
+| [EnvelopePlain](#EnvelopePlain) | 표준 봉투 미디어를 지정합니다. |
+| [EnvelopeWindow](#EnvelopeWindow) | 창이 있는 봉투 미디어를 지정합니다. |
+| [Fabric](#Fabric) | 패브릭 미디어를 지정합니다. |
+| [HighResolution](#HighResolution) | 특수 고해상도 미디어를 지정합니다. |
+| [Label](#Label) | 라벨 미디어를 지정합니다. |
+| [MultiLayerForm](#MultiLayerForm) | 첨부된 다중 파트 양식 미디어를 지정합니다. |
+| [MultiPartForm](#MultiPartForm) | 분리된 다중 파트 양식 미디어를 지정합니다. |
+| [None](#None) | 알 수 없거나 목록에 없는 미디어를 지정합니다. |
+| [Photographic](#Photographic) | 표준 사진 미디어를 지정합니다. |
+| [PhotographicFilm](#PhotographicFilm) | 필름 사진 미디어를 지정합니다. |
+| [PhotographicGlossy](#PhotographicGlossy) | 광택 사진 미디어를 지정합니다. |
+| [PhotographicHighGloss](#PhotographicHighGloss) | 고광택 사진 미디어를 지정합니다. |
+| [PhotographicMatte](#PhotographicMatte) | 무광 사진 미디어를 지정합니다. |
+| [PhotographicSatin](#PhotographicSatin) | 새틴 사진 미디어를 지정합니다. |
+| [PhotographicSemiGloss](#PhotographicSemiGloss) | 반광택 사진 미디어를 지정합니다. |
+| [Plain](#Plain) | 표준 종이 미디어를 지정합니다. |
+| [Screen](#Screen) | 연속 형태로 출력 디스플레이에 출력을 지정합니다. |
+| [ScreenPaged](#ScreenPaged) | 페이지 형태로 출력 디스플레이에 출력을 지정합니다. |
+| [Stationary](#Stationary) | 특수 문구류 미디어를 지정합니다. |
+| [TShirtTransfer](#TShirtTransfer) | 특수 티셔츠 전사 미디어를 지정합니다. |
+| [TabStockFull](#TabStockFull) | 미리 절단되지 않은 탭 재고 미디어(단일 탭)를 지정합니다. |
+| [TabStockPreCut](#TabStockPreCut) | 미리 절단된 탭 재고 미디어(다중 탭)를 지정합니다. |
+| [Transparency](#Transparency) | 투명 미디어를 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(PageMediaType.IPageMediaTypeOptionItem[] items)](#add-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-) | 옵션에  IPageMediaTypeOptionItem  인스턴스 배열을 추가합니다. |
+| [clone()](#clone--) | 이 옵션 인스턴스를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setWeight(int weight)](#setWeight-int-) |   Weight  점수 속성 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMediaTypeOption(String optionName, PageMediaType.IPageMediaTypeOptionItem[] items) {#PageMediaTypeOption-java.lang.String-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-}
+```
+public PageMediaTypeOption(String optionName, PageMediaType.IPageMediaTypeOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| optionName | java.lang.String | 옵션 이름입니다. |
+| items | [IPageMediaTypeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediatypeoptionitem) | 임의의  IPageMediaTypeOptionItem  인스턴스 배열입니다. |
+
+### PageMediaTypeOption(PageMediaType.PageMediaTypeOption option) {#PageMediaTypeOption-com.aspose.xps.metadata.PageMediaType.PageMediaTypeOption-}
+```
+public PageMediaTypeOption(PageMediaType.PageMediaTypeOption option)
+```
+
+
+이 옵션 인스턴스를 복제합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| option | [PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) | 복제할 인스턴스. |
+
+### Archival {#Archival}
+```
+public static PageMediaType.PageMediaTypeOption Archival
+```
+
+
+보관용 고품질 매체를 지정합니다.
+
+### AutoSelect {#AutoSelect}
+```
+public static PageMediaType.PageMediaTypeOption AutoSelect
+```
+
+
+미디어가 자동으로 선택됨을 지정합니다.
+
+### BackPrintFilm {#BackPrintFilm}
+```
+public static PageMediaType.PageMediaTypeOption BackPrintFilm
+```
+
+
+특수 백프린팅 필름 미디어를 지정합니다.
+
+### Bond {#Bond}
+```
+public static PageMediaType.PageMediaTypeOption Bond
+```
+
+
+표준 본드 미디어를 지정합니다.
+
+### CardStock {#CardStock}
+```
+public static PageMediaType.PageMediaTypeOption CardStock
+```
+
+
+표준 카드 스톡 미디어를 지정합니다.
+
+### Continous {#Continous}
+```
+public static PageMediaType.PageMediaTypeOption Continous
+```
+
+
+연속 공급 미디어를 지정합니다.
+
+### EnvelopePlain {#EnvelopePlain}
+```
+public static PageMediaType.PageMediaTypeOption EnvelopePlain
+```
+
+
+표준 봉투 미디어를 지정합니다.
+
+### EnvelopeWindow {#EnvelopeWindow}
+```
+public static PageMediaType.PageMediaTypeOption EnvelopeWindow
+```
+
+
+창이 있는 봉투 미디어를 지정합니다.
+
+### Fabric {#Fabric}
+```
+public static PageMediaType.PageMediaTypeOption Fabric
+```
+
+
+패브릭 미디어를 지정합니다.
+
+### HighResolution {#HighResolution}
+```
+public static PageMediaType.PageMediaTypeOption HighResolution
+```
+
+
+특수 고해상도 미디어를 지정합니다.
+
+### Label {#Label}
+```
+public static PageMediaType.PageMediaTypeOption Label
+```
+
+
+라벨 미디어를 지정합니다.
+
+### MultiLayerForm {#MultiLayerForm}
+```
+public static PageMediaType.PageMediaTypeOption MultiLayerForm
+```
+
+
+첨부된 다중 파트 양식 미디어를 지정합니다.
+
+### MultiPartForm {#MultiPartForm}
+```
+public static PageMediaType.PageMediaTypeOption MultiPartForm
+```
+
+
+분리된 다중 파트 양식 미디어를 지정합니다.
+
+### None {#None}
+```
+public static PageMediaType.PageMediaTypeOption None
+```
+
+
+알 수 없거나 목록에 없는 미디어를 지정합니다.
+
+### Photographic {#Photographic}
+```
+public static PageMediaType.PageMediaTypeOption Photographic
+```
+
+
+표준 사진 미디어를 지정합니다.
+
+### PhotographicFilm {#PhotographicFilm}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicFilm
+```
+
+
+필름 사진 미디어를 지정합니다.
+
+### PhotographicGlossy {#PhotographicGlossy}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicGlossy
+```
+
+
+광택 사진 미디어를 지정합니다.
+
+### PhotographicHighGloss {#PhotographicHighGloss}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicHighGloss
+```
+
+
+고광택 사진 미디어를 지정합니다.
+
+### PhotographicMatte {#PhotographicMatte}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicMatte
+```
+
+
+무광 사진 미디어를 지정합니다.
+
+### PhotographicSatin {#PhotographicSatin}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicSatin
+```
+
+
+새틴 사진 미디어를 지정합니다.
+
+### PhotographicSemiGloss {#PhotographicSemiGloss}
+```
+public static PageMediaType.PageMediaTypeOption PhotographicSemiGloss
+```
+
+
+반광택 사진 미디어를 지정합니다.
+
+### Plain {#Plain}
+```
+public static PageMediaType.PageMediaTypeOption Plain
+```
+
+
+표준 종이 미디어를 지정합니다.
+
+### Screen {#Screen}
+```
+public static PageMediaType.PageMediaTypeOption Screen
+```
+
+
+연속 형태로 출력 디스플레이에 출력을 지정합니다.
+
+### ScreenPaged {#ScreenPaged}
+```
+public static PageMediaType.PageMediaTypeOption ScreenPaged
+```
+
+
+페이지 형태로 출력 디스플레이에 출력을 지정합니다.
+
+### Stationary {#Stationary}
+```
+public static PageMediaType.PageMediaTypeOption Stationary
+```
+
+
+특수 문구류 미디어를 지정합니다.
+
+### TShirtTransfer {#TShirtTransfer}
+```
+public static PageMediaType.PageMediaTypeOption TShirtTransfer
+```
+
+
+특수 티셔츠 전사 미디어를 지정합니다.
+
+### TabStockFull {#TabStockFull}
+```
+public static PageMediaType.PageMediaTypeOption TabStockFull
+```
+
+
+미리 절단되지 않은 탭 재고 미디어(단일 탭)를 지정합니다.
+
+### TabStockPreCut {#TabStockPreCut}
+```
+public static PageMediaType.PageMediaTypeOption TabStockPreCut
+```
+
+
+미리 절단된 탭 재고 미디어(다중 탭)를 지정합니다.
+
+### Transparency {#Transparency}
+```
+public static PageMediaType.PageMediaTypeOption Transparency
+```
+
+
+투명 미디어를 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(PageMediaType.IPageMediaTypeOptionItem[] items) {#add-com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem...-}
+```
+public PageMediaType.PageMediaTypeOption add(PageMediaType.IPageMediaTypeOptionItem[] items)
+```
+
+
+옵션에  IPageMediaTypeOptionItem  인스턴스 배열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageMediaTypeOptionItem\[\]](../../com.aspose.xps.metadata/ipagemediatypeoptionitem) | 임의의  IPageMediaTypeOptionItem  인스턴스 배열입니다. |
+
+**Returns:**
+[PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) - This options instance.
+### clone() {#clone--}
+```
+public PageMediaType.PageMediaTypeOption clone()
+```
+
+
+이 옵션 인스턴스를 복제합니다. 복제 생성자에 대한 바로 가기.
+
+**Returns:**
+[PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setWeight(int weight) {#setWeight-int-}
+```
+public PageMediaType.PageMediaTypeOption setWeight(int weight)
+```
+
+
+  Weight  점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 무게 | int |   Weight  점수 속성 값입니다. |
+
+**Returns:**
+[PageMediaTypeOption](../../com.aspose.xps.metadata/pagemediatypeoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemirrorimage/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemirrorimage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageMirrorImage"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 미러링 설정을 설명합니다."
+type: docs
+weight: 111
+url: /ko/java/com.aspose.xps.metadata/pagemirrorimage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageMirrorImage extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력의 미러링 설정을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagemirrorimage
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageMirrorImage(PageMirrorImage.PageMirrorImageOption[] options)](#PageMirrorImage-com.aspose.xps.metadata.PageMirrorImage.PageMirrorImageOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageMirrorImage(PageMirrorImage.PageMirrorImageOption[] options) {#PageMirrorImage-com.aspose.xps.metadata.PageMirrorImage.PageMirrorImageOption...-}
+```
+public PageMirrorImage(PageMirrorImage.PageMirrorImageOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageMirrorImageOption\[\]](../../com.aspose.xps.metadata/pagemirrorimageoption) | 배열 또는 기능 옵션입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagemirrorimageoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagemirrorimageoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "PageMirrorImage.PageMirrorImageOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageMirrorImage 기능 옵션을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagemirrorimage.pagemirrorimageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageMirrorImage.PageMirrorImageOption extends Option
+```
+
+PageMirrorImage 기능 옵션을 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [MirrorImageHeight](#MirrorImageHeight) | 출력이 MediaSizeHeight 방향에 평행하도록 미러링되어야 함을 지정합니다. |
+| [MirrorImageWidth](#MirrorImageWidth) | 출력이 MediaSizeWidth 방향에 평행하도록 미러링되어야 함을 지정합니다. |
+| [None](#None) | 출력이 미러링되지 않아야 함을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### MirrorImageHeight {#MirrorImageHeight}
+```
+public static PageMirrorImage.PageMirrorImageOption MirrorImageHeight
+```
+
+
+출력이 MediaSizeHeight 방향에 평행하도록 미러링되어야 함을 지정합니다.
+
+### MirrorImageWidth {#MirrorImageWidth}
+```
+public static PageMirrorImage.PageMirrorImageOption MirrorImageWidth
+```
+
+
+출력이 MediaSizeWidth 방향에 평행하도록 미러링되어야 함을 지정합니다.
+
+### None {#None}
+```
+public static PageMirrorImage.PageMirrorImageOption None
+```
+
+
+출력이 미러링되지 않아야 함을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagenegativeimage/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagenegativeimage/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageNegativeImage"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 네거티브 설정을 설명합니다."
+type: docs
+weight: 112
+url: /ko/java/com.aspose.xps.metadata/pagenegativeimage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageNegativeImage extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력의 네거티브 설정을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagenegativeimage
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageNegativeImage(PageNegativeImage.PageNegativeImageOption[] options)](#PageNegativeImage-com.aspose.xps.metadata.PageNegativeImage.PageNegativeImageOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageNegativeImage(PageNegativeImage.PageNegativeImageOption[] options) {#PageNegativeImage-com.aspose.xps.metadata.PageNegativeImage.PageNegativeImageOption...-}
+```
+public PageNegativeImage(PageNegativeImage.PageNegativeImageOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageNegativeImageOption\[\]](../../com.aspose.xps.metadata/pagenegativeimageoption) | 배열 또는 기능 옵션입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagenegativeimageoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagenegativeimageoption/_index.md
@@ -1,0 +1,171 @@
+---
+title: "PageNegativeImage.PageNegativeImageOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageNegativeImage 기능 옵션을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagenegativeimage.pagenegativeimageoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageNegativeImage.PageNegativeImageOption extends Option
+```
+
+PageNegativeImage 기능 옵션을 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Negative](#Negative) | 출력이 음성 이미지가 되도록 지정합니다. |
+| [None](#None) | 출력이 비음성 이미지가 되도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Negative {#Negative}
+```
+public static PageNegativeImage.PageNegativeImageOption Negative
+```
+
+
+출력이 음성 이미지가 되도록 지정합니다.
+
+### None {#None}
+```
+public static PageNegativeImage.PageNegativeImageOption None
+```
+
+
+출력이 비음성 이미지가 되도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageorientation/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageorientation/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOrientation"
+second_title: "Aspose.Page용 Java API 참조"
+description: "물리적 매체 시트의 방향을 설명합니다."
+type: docs
+weight: 113
+url: /ko/java/com.aspose.xps.metadata/pageorientation/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOrientation extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+물리적 매체 시트의 방향을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageorientation
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageOrientation(PageOrientation.PageOrientationOption[] options)](#PageOrientation-com.aspose.xps.metadata.PageOrientation.PageOrientationOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOrientation(PageOrientation.PageOrientationOption[] options) {#PageOrientation-com.aspose.xps.metadata.PageOrientation.PageOrientationOption...-}
+```
+public PageOrientation(PageOrientation.PageOrientationOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageOrientationOption\[\]](../../com.aspose.xps.metadata/pageorientationoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageorientationoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageorientationoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageOrientation.PageOrientationOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageOrientation 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageorientation.pageorientationoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageOrientation.PageOrientationOption extends Option
+```
+
+PageOrientation 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Landscape](#Landscape) | 내용이 표준(세로) 방향에 비해 페이지에서 90도 반시계 방향으로 회전됩니다. |
+| [Portrait](#Portrait) | 표준 방향. |
+| [ReverseLandscape](#ReverseLandscape) | 내용이 페이지에서 표준(세로) 방향에 대해 270도 반시계 방향으로 회전되었습니다. |
+| [ReversePortrait](#ReversePortrait) | 내용이 페이지에서 표준(세로) 방향에 대해 180도 회전되었습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Landscape {#Landscape}
+```
+public static final PageOrientation.PageOrientationOption Landscape
+```
+
+
+내용이 표준(세로) 방향에 비해 페이지에서 90도 반시계 방향으로 회전됩니다.
+
+### Portrait {#Portrait}
+```
+public static final PageOrientation.PageOrientationOption Portrait
+```
+
+
+표준 방향.
+
+### ReverseLandscape {#ReverseLandscape}
+```
+public static final PageOrientation.PageOrientationOption ReverseLandscape
+```
+
+
+내용이 페이지에서 표준(세로) 방향에 대해 270도 반시계 방향으로 회전되었습니다.
+
+### ReversePortrait {#ReversePortrait}
+```
+public static final PageOrientation.PageOrientationOption ReversePortrait
+```
+
+
+내용이 페이지에서 표준(세로) 방향에 대해 180도 회전되었습니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageoutputbin/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageoutputbin/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOutputBin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "장치에서 지원되는 모든 빈 목록을 설명합니다."
+type: docs
+weight: 114
+url: /ko/java/com.aspose.xps.metadata/pageoutputbin/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature), [com.aspose.xps.metadata.OutputBin](../../com.aspose.xps.metadata/outputbin)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOutputBin extends OutputBin implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+디바이스에서 지원되는 모든 bin 목록을 설명합니다. 페이지별로 출력 bin을 지정할 수 있습니다. JobOutputBin, DocumentOutputBin 및 PageOutputBin 키워드는 상호 배타적이며 PrintTicket 또는 Print Capabilities 문서에서 하나만 지정해야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageoutputbin
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageOutputBin(OutputBin.IOutputBinItem[] items)](#PageOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputBin(OutputBin.IOutputBinItem[] items) {#PageOutputBin-com.aspose.xps.metadata.OutputBin.IOutputBinItem...-}
+```
+public PageOutputBin(OutputBin.IOutputBinItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOutputBinItem\[\]](../../com.aspose.xps.metadata/ioutputbinitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageoutputcolor/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageoutputcolor/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOutputColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력에 대한 색상 설정의 특성을 설명합니다."
+type: docs
+weight: 115
+url: /ko/java/com.aspose.xps.metadata/pageoutputcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOutputColor extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력용 색상 설정의 특성을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageoutputcolor
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageOutputColor(PageOutputColor.IPageOutputColorItem[] items)](#PageOutputColor-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputColor(PageOutputColor.IPageOutputColorItem[] items) {#PageOutputColor-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorItem...-}
+```
+public PageOutputColor(PageOutputColor.IPageOutputColorItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageOutputColorItem\[\]](../../com.aspose.xps.metadata/ipageoutputcoloritem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageoutputcoloroption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageoutputcoloroption/_index.md
@@ -1,0 +1,238 @@
+---
+title: "PageOutputColor.PageOutputColorOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageOutputColor 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageoutputcolor.pageoutputcoloroption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageOutputColor.IPageOutputColorItem](../../com.aspose.xps.metadata/ipageoutputcoloritem)
+```
+public static final class PageOutputColor.PageOutputColorOption extends Option implements PageOutputColor.IPageOutputColorItem
+```
+
+PageOutputColor 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageOutputColorOption(String optionName, PageOutputColor.IPageOutputColorOptionItem[] items)](#PageOutputColorOption-java.lang.String-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [Color(int deviceBitsPerPixel, int driverBitsPerPixel)](#Color-int-int-) | 출력이 컬러여야 함을 지정합니다. |
+| [Grayscale(int deviceBitsPerPixel, int driverBitsPerPixel)](#Grayscale-int-int-) | 출력이 그레이스케일이어야 함을 지정합니다. |
+| [Monochrome(int deviceBitsPerPixel, int driverBitsPerPixel)](#Monochrome-int-int-) | 출력이 단색(검정)이어야 함을 지정합니다. |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(PageOutputColor.IPageOutputColorOptionItem[] items)](#add-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-) | 옵션에 IPageOutputColorOptionItem 인스턴스 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputColorOption(String optionName, PageOutputColor.IPageOutputColorOptionItem[] items) {#PageOutputColorOption-java.lang.String-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-}
+```
+public PageOutputColorOption(String optionName, PageOutputColor.IPageOutputColorOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| optionName | java.lang.String | 옵션 이름입니다. |
+| items | [IPageOutputColorOptionItem\[\]](../../com.aspose.xps.metadata/ipageoutputcoloroptionitem) | 임의의 IPageOutputColorOptionItem 인스턴스 배열입니다. |
+
+### Color(int deviceBitsPerPixel, int driverBitsPerPixel) {#Color-int-int-}
+```
+public static final PageOutputColor.PageOutputColorOption Color(int deviceBitsPerPixel, int driverBitsPerPixel)
+```
+
+
+출력이 컬러여야 함을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| deviceBitsPerPixel | int | 프린터가 지원하는 컬러 데이터의 픽셀당 비트 수를 나타내는 DeviceBitsPerPixel 점수 속성 값입니다. |
+| driverBitsPerPixel | int | 코어 드라이버가 비트맵 렌더링 버퍼에 사용할 픽셀당 비트 수를 나타내는 DriverBitsPerPixel 점수 속성 값입니다. |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - The  PageOutputColor  options.
+### Grayscale(int deviceBitsPerPixel, int driverBitsPerPixel) {#Grayscale-int-int-}
+```
+public static final PageOutputColor.PageOutputColorOption Grayscale(int deviceBitsPerPixel, int driverBitsPerPixel)
+```
+
+
+출력이 그레이스케일이어야 함을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| deviceBitsPerPixel | int | 프린터가 지원하는 컬러 데이터의 픽셀당 비트 수를 나타내는 DeviceBitsPerPixel 점수 속성 값입니다. |
+| driverBitsPerPixel | int | 코어 드라이버가 비트맵 렌더링 버퍼에 사용할 픽셀당 비트 수를 나타내는 DriverBitsPerPixel 점수 속성 값입니다. |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - The  PageOutputColor  options.
+### Monochrome(int deviceBitsPerPixel, int driverBitsPerPixel) {#Monochrome-int-int-}
+```
+public static final PageOutputColor.PageOutputColorOption Monochrome(int deviceBitsPerPixel, int driverBitsPerPixel)
+```
+
+
+출력이 단색(검정)이어야 함을 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| deviceBitsPerPixel | int | 프린터가 지원하는 컬러 데이터의 픽셀당 비트 수를 나타내는 DeviceBitsPerPixel 점수 속성 값입니다. |
+| driverBitsPerPixel | int | 코어 드라이버가 비트맵 렌더링 버퍼에 사용할 픽셀당 비트 수를 나타내는 DriverBitsPerPixel 점수 속성 값입니다. |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - The  PageOutputColor  options.
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(PageOutputColor.IPageOutputColorOptionItem[] items) {#add-com.aspose.xps.metadata.PageOutputColor.IPageOutputColorOptionItem...-}
+```
+public PageOutputColor.PageOutputColorOption add(PageOutputColor.IPageOutputColorOptionItem[] items)
+```
+
+
+옵션에 IPageOutputColorOptionItem 인스턴스 배열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageOutputColorOptionItem\[\]](../../com.aspose.xps.metadata/ipageoutputcoloroptionitem) | 임의의 IPageOutputColorOptionItem 인스턴스 배열입니다. |
+
+**Returns:**
+[PageOutputColorOption](../../com.aspose.xps.metadata/pageoutputcoloroption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageoutputquality/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageoutputquality/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageOutputQuality"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 네거티브 설정을 설명합니다."
+type: docs
+weight: 116
+url: /ko/java/com.aspose.xps.metadata/pageoutputquality/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageOutputQuality extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력의 부정 설정을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageoutputquality
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageOutputQuality(PageOutputQuality.PageOutputQualityOption[] options)](#PageOutputQuality-com.aspose.xps.metadata.PageOutputQuality.PageOutputQualityOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageOutputQuality(PageOutputQuality.PageOutputQualityOption[] options) {#PageOutputQuality-com.aspose.xps.metadata.PageOutputQuality.PageOutputQualityOption...-}
+```
+public PageOutputQuality(PageOutputQuality.PageOutputQualityOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageOutputQualityOption\[\]](../../com.aspose.xps.metadata/pageoutputqualityoption) | 배열 또는 기능 옵션입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageoutputqualityoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageoutputqualityoption/_index.md
@@ -1,0 +1,216 @@
+---
+title: "PageOutputQuality.PageOutputQualityOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageOutputQuality 기능 옵션을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageoutputquality.pageoutputqualityoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageOutputQuality.PageOutputQualityOption extends Option
+```
+
+PageOutputQuality 기능 옵션을 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Automatic](#Automatic) | 자동 출력 의도를 지정합니다(클라이언트가 최적 설정을 자동으로 선택하도록 허용). |
+| [Draft](#Draft) | 초안 출력 의도를 지정합니다(초안 품질의 텍스트와 그래픽에 균형). |
+| [Fax](#Fax) | 팩스 출력 의도를 지정합니다(표준 팩스 품질에 균형). |
+| [High](#High) | 고품질 출력 의도를 지정합니다(고품질 텍스트와 그래픽에 균형). |
+| [Normal](#Normal) | 일반 출력에 대한 의도를 지정합니다(텍스트와 그래픽의 품질이 좋도록 균형을 맞춤). |
+| [Photographic](#Photographic) | 사진 출력에 대한 의도를 지정합니다(이미지는 최고 품질이어야 합니다). |
+| [Text](#Text) | 텍스트 전용 출력에 대한 의도를 지정합니다(그래픽은 제대로 출력되지 않거나 전혀 출력되지 않을 수 있습니다). |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static PageOutputQuality.PageOutputQualityOption Automatic
+```
+
+
+자동 출력 의도를 지정합니다(클라이언트가 최적 설정을 자동으로 선택하도록 허용).
+
+### Draft {#Draft}
+```
+public static PageOutputQuality.PageOutputQualityOption Draft
+```
+
+
+초안 출력 의도를 지정합니다(초안 품질의 텍스트와 그래픽에 균형).
+
+### Fax {#Fax}
+```
+public static PageOutputQuality.PageOutputQualityOption Fax
+```
+
+
+팩스 출력 의도를 지정합니다(표준 팩스 품질에 균형).
+
+### High {#High}
+```
+public static PageOutputQuality.PageOutputQualityOption High
+```
+
+
+고품질 출력 의도를 지정합니다(고품질 텍스트와 그래픽에 균형).
+
+### Normal {#Normal}
+```
+public static PageOutputQuality.PageOutputQualityOption Normal
+```
+
+
+일반 출력에 대한 의도를 지정합니다(텍스트와 그래픽의 품질이 좋도록 균형을 맞춤).
+
+### Photographic {#Photographic}
+```
+public static PageOutputQuality.PageOutputQualityOption Photographic
+```
+
+
+사진 출력에 대한 의도를 지정합니다(이미지는 최고 품질이어야 합니다).
+
+### Text {#Text}
+```
+public static PageOutputQuality.PageOutputQualityOption Text
+```
+
+
+텍스트 전용 출력에 대한 의도를 지정합니다(그래픽은 제대로 출력되지 않거나 전혀 출력되지 않을 수 있습니다).
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagephotoprintingintent/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagephotoprintingintent/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PagePhotoPrintingIntent"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사진 인쇄 설정을 채우기 위해 드라이버에 고수준 의도를 표시합니다."
+type: docs
+weight: 117
+url: /ko/java/com.aspose.xps.metadata/pagephotoprintingintent/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PagePhotoPrintingIntent extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+드라이버에 사진 인쇄 설정을 채우기 위한 고수준 의도를 나타냅니다. 이 설정은 사용자가 사진을 인쇄할 때 지정할 수 있는 예상 출력 품질을 다룹니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagephotoprintingintent
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PagePhotoPrintingIntent(PagePhotoPrintingIntent.PagePhotoPrintingIntentOption[] options)](#PagePhotoPrintingIntent-com.aspose.xps.metadata.PagePhotoPrintingIntent.PagePhotoPrintingIntentOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PagePhotoPrintingIntent(PagePhotoPrintingIntent.PagePhotoPrintingIntentOption[] options) {#PagePhotoPrintingIntent-com.aspose.xps.metadata.PagePhotoPrintingIntent.PagePhotoPrintingIntentOption...-}
+```
+public PagePhotoPrintingIntent(PagePhotoPrintingIntent.PagePhotoPrintingIntentOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PagePhotoPrintingIntentOption\[\]](../../com.aspose.xps.metadata/pagephotoprintingintentoption) | 배열 또는 기능 옵션입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagephotoprintingintentoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagephotoprintingintentoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PagePhotoPrintingIntent.PagePhotoPrintingIntentOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PagePhotoPrintingIntent 기능 옵션을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagephotoprintingintent.pagephotoprintingintentoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PagePhotoPrintingIntent.PagePhotoPrintingIntentOption extends Option
+```
+
+PagePhotoPrintingIntent 기능 옵션을 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | Photoprinting Intent 없음 (응용 프로그램이 의도 해석을 지정하지 않도록 허용합니다. |
+| [PhotoBest](#PhotoBest) | 최고 품질 포토프린팅 (주로 마케팅 목적을 위해 제공되며, 장치의 최고 기능을 활용합니다) |
+| [PhotoDraft](#PhotoDraft) | 초안 품질 포토프린팅 (빠르고 잉크 사용량이 적은 인쇄로, 교정 용도에 적합합니다) |
+| [PhotoStandard](#PhotoStandard) | 표준 품질 포토프린팅 (표준 사진 인쇄를 위한 OEM 권장 설정) |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption None
+```
+
+
+Photoprinting Intent 없음 (응용 프로그램이 의도 해석을 지정하지 않도록 허용합니다. PrintTicket 설정은 변경되지 않아야 합니다)
+
+### PhotoBest {#PhotoBest}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption PhotoBest
+```
+
+
+최고 품질 포토프린팅 (주로 마케팅 목적을 위해 제공되며, 장치의 최고 기능을 활용합니다)
+
+### PhotoDraft {#PhotoDraft}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption PhotoDraft
+```
+
+
+초안 품질 포토프린팅 (빠르고 잉크 사용량이 적은 인쇄로, 교정 용도에 적합합니다)
+
+### PhotoStandard {#PhotoStandard}
+```
+public static PagePhotoPrintingIntent.PagePhotoPrintingIntentOption PhotoStandard
+```
+
+
+표준 품질 포토프린팅 (표준 사진 인쇄를 위한 OEM 권장 설정)
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageposter/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageposter/_index.md
@@ -1,0 +1,181 @@
+---
+title: "PagePoster"
+second_title: "Aspose.Page용 Java API 참조"
+description: "단일 페이지의 출력을 여러 물리적 매체 시트에 설명합니다."
+type: docs
+weight: 118
+url: /ko/java/com.aspose.xps.metadata/pageposter/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PagePoster extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+단일 페이지를 여러 물리적 매체 시트에 출력하는 방법을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageposter
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PagePoster()](#PagePoster--) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [addPagesPerSheetOption(int value)](#addPagesPerSheetOption-int-) | PagesPerSheet 스코어드 속성 값을 사용하여 옵션을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PagePoster() {#PagePoster--}
+```
+public PagePoster()
+```
+
+
+새 인스턴스를 생성합니다.
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### addPagesPerSheetOption(int value) {#addPagesPerSheetOption-int-}
+```
+public PagePoster addPagesPerSheetOption(int value)
+```
+
+
+PagesPerSheet 점수 속성 값을 사용하여 옵션을 추가합니다. 논리 페이지당 물리적 시트 수를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | PagesPerSheet 점수 속성 값. |
+
+**Returns:**
+[PagePoster](../../com.aspose.xps.metadata/pageposter) - This feature instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageprintticket/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageprintticket/_index.md
@@ -1,0 +1,181 @@
+---
+title: "PagePrintTicket"
+second_title: "Aspose.Page용 Java API 참조"
+description: "페이지 수준 인쇄 티켓을 캡슐화하는 클래스입니다."
+type: docs
+weight: 119
+url: /ko/java/com.aspose.xps.metadata/pageprintticket/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicket](../../com.aspose.xps.metadata/printticket)
+```
+public final class PagePrintTicket extends PrintTicket
+```
+
+페이지 수준 인쇄 티켓을 캡슐화하는 클래스입니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PagePrintTicket(IPagePrintTicketItem[] items)](#PagePrintTicket-com.aspose.xps.metadata.IPagePrintTicketItem...-) | 페이지 수준 인쇄 티켓 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IPagePrintTicketItem[] items)](#add-com.aspose.xps.metadata.IPagePrintTicketItem...-) | 이 PrintTicket 항목 목록 끝에 항목 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 인쇄 티켓 항목 이름 반복자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | 이 PrintTicket 항목 목록에서 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PagePrintTicket(IPagePrintTicketItem[] items) {#PagePrintTicket-com.aspose.xps.metadata.IPagePrintTicketItem...-}
+```
+public PagePrintTicket(IPagePrintTicketItem[] items)
+```
+
+
+페이지 수준 인쇄 티켓 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPagePrintTicketItem\[\]](../../com.aspose.xps.metadata/ipageprintticketitem) | 임의의 IPagePrintTicketItem 인스턴스 배열입니다. 각 항목은 Feature, ParameterInit 또는 Property 인스턴스여야 합니다. |
+
+### add(IPagePrintTicketItem[] items) {#add-com.aspose.xps.metadata.IPagePrintTicketItem...-}
+```
+public void add(IPagePrintTicketItem[] items)
+```
+
+
+이 PrintTicket 항목 목록 끝에 항목 배열을 추가합니다. 각 항목은 Feature, ParameterInit 또는 Property 인스턴스일 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPagePrintTicketItem\[\]](../../com.aspose.xps.metadata/ipageprintticketitem) | 추가할 항목 배열입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+인쇄 티켓 항목 이름 반복자를 반환합니다.
+
+**Returns:**
+java.util.Iterator<java.lang.String> - 목록에 대한 반복자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+이 PrintTicket 항목 목록에서 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String[] | 항목 이름 배열입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageresolution/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageresolution/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageResolution"
+second_title: "Aspose.Page용 Java API 참조"
+description: "인쇄 출력의 페이지 해상도를 정성적 값, 인치당 도트 수(DPI) 또는 두 가지 모두로 정의합니다."
+type: docs
+weight: 120
+url: /ko/java/com.aspose.xps.metadata/pageresolution/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageResolution extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+인쇄 출력의 페이지 해상도를 정성적 값, 인치당 도트 수(DPI) 또는 두 가지 모두로 정의합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pageresolution
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageResolution(PageResolution.IPageResolutionItem[] items)](#PageResolution-com.aspose.xps.metadata.PageResolution.IPageResolutionItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageResolution(PageResolution.IPageResolutionItem[] items) {#PageResolution-com.aspose.xps.metadata.PageResolution.IPageResolutionItem...-}
+```
+public PageResolution(PageResolution.IPageResolutionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageResolutionItem\[\]](../../com.aspose.xps.metadata/ipageresolutionitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pageresolutionoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pageresolutionoption/_index.md
@@ -1,0 +1,219 @@
+---
+title: "PageResolution.PageResolutionOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageResolution 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pageresolution.pageresolutionoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageResolution.IPageResolutionItem](../../com.aspose.xps.metadata/ipageresolutionitem)
+```
+public static final class PageResolution.PageResolutionOption extends Option implements PageResolution.IPageResolutionItem
+```
+
+PageResolution 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageResolutionOption(String optionName, PageResolution.IPageResolutionOptionItem[] items)](#PageResolutionOption-java.lang.String-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(PageResolution.IPageResolutionOptionItem[] items)](#add-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-) | 옵션에 IPageResolutionOptionItem 인스턴스 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setResolutionX(int resolutionX)](#setResolutionX-int-) | ResolutionX 점수 속성 값을 설정합니다. |
+| [setResolutionY(int resolutionY)](#setResolutionY-int-) | ResolutionY 점수 속성 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageResolutionOption(String optionName, PageResolution.IPageResolutionOptionItem[] items) {#PageResolutionOption-java.lang.String-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-}
+```
+public PageResolutionOption(String optionName, PageResolution.IPageResolutionOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| optionName | java.lang.String | 옵션 이름입니다. |
+| items | [IPageResolutionOptionItem\[\]](../../com.aspose.xps.metadata/ipageresolutionoptionitem) | IPageResolutionOptionItem 인스턴스의 임의 배열입니다. |
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(PageResolution.IPageResolutionOptionItem[] items) {#add-com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem...-}
+```
+public PageResolution.PageResolutionOption add(PageResolution.IPageResolutionOptionItem[] items)
+```
+
+
+옵션에 IPageResolutionOptionItem 인스턴스 배열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageResolutionOptionItem\[\]](../../com.aspose.xps.metadata/ipageresolutionoptionitem) | IPageResolutionOptionItem 인스턴스의 임의 배열입니다. |
+
+**Returns:**
+[PageResolutionOption](../../com.aspose.xps.metadata/pageresolutionoption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setResolutionX(int resolutionX) {#setResolutionX-int-}
+```
+public PageResolution.PageResolutionOption setResolutionX(int resolutionX)
+```
+
+
+ResolutionX 점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| resolutionX | int | ResolutionX 점수 속성 값입니다. |
+
+**Returns:**
+[PageResolutionOption](../../com.aspose.xps.metadata/pageresolutionoption) - This option instance.
+### setResolutionY(int resolutionY) {#setResolutionY-int-}
+```
+public PageResolution.PageResolutionOption setResolutionY(int resolutionY)
+```
+
+
+ResolutionY 점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| resolutionY | int | ResolutionY 점수 속성 값입니다. |
+
+**Returns:**
+[PageResolutionOption](../../com.aspose.xps.metadata/pageresolutionoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescaling/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescaling/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageScaling"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 스케일링 특성을 설명합니다."
+type: docs
+weight: 121
+url: /ko/java/com.aspose.xps.metadata/pagescaling/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScaling extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력의 스케일링 특성을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescaling
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageScaling(PageScaling.IPageScalingItem[] items)](#PageScaling-com.aspose.xps.metadata.PageScaling.IPageScalingItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScaling(PageScaling.IPageScalingItem[] items) {#PageScaling-com.aspose.xps.metadata.PageScaling.IPageScalingItem...-}
+```
+public PageScaling(PageScaling.IPageScalingItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageScalingItem\[\]](../../com.aspose.xps.metadata/ipagescalingitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescalingoffsetheight/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescalingoffsetheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingOffsetHeight"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용자 지정 스케일링을 위해 ImageableSizeWidth 방향의 스케일링 오프셋을 지정합니다."
+type: docs
+weight: 122
+url: /ko/java/com.aspose.xps.metadata/pagescalingoffsetheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingOffsetHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+사용자 지정 스케일링을 위해 ImageableSizeWidth 방향의 스케일링 오프셋을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingoffsetheight
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageScalingOffsetHeight(int value)](#PageScalingOffsetHeight-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingOffsetHeight(int value) {#PageScalingOffsetHeight-int-}
+```
+public PageScalingOffsetHeight(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescalingoffsetwidth/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescalingoffsetwidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingOffsetWidth"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용자 지정 스케일링을 위해 ImageableSizeWidth 방향의 스케일링 오프셋을 지정합니다."
+type: docs
+weight: 123
+url: /ko/java/com.aspose.xps.metadata/pagescalingoffsetwidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingOffsetWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+사용자 지정 스케일링을 위해  ImageableSizeWidth  방향의 스케일링 오프셋을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingoffsetwidth
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageScalingOffsetWidth(int value)](#PageScalingOffsetWidth-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingOffsetWidth(int value) {#PageScalingOffsetWidth-int-}
+```
+public PageScalingOffsetWidth(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescalingoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescalingoption/_index.md
@@ -1,0 +1,219 @@
+---
+title: "PageScaling.PageScalingOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageScaling 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagescaling.pagescalingoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageScaling.IPageScalingItem](../../com.aspose.xps.metadata/ipagescalingitem)
+```
+public static final class PageScaling.PageScalingOption extends Option implements PageScaling.IPageScalingItem
+```
+
+PageScaling 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Custom](#Custom) | Application Media Size에 사용자 정의 스케일링을 적용하도록 지정합니다. |
+| [CustomSquare](#CustomSquare) | Application Media Size에 사용자 정의 정사각형 스케일링을 적용하도록 지정합니다. |
+| [FitApplicationBleedSizeToPageImageableSize](#FitApplicationBleedSizeToPageImageableSize) | 응용 프로그램 블리드 크기를 PageImageableSize에 비율을 유지하면서 스케일링하도록 지정합니다. |
+| [FitApplicationContentSizeToPageImageableSize](#FitApplicationContentSizeToPageImageableSize) | 응용 프로그램 콘텐츠 크기를 PageImageableSize에 비율을 유지하면서 스케일링하도록 지정합니다. |
+| [FitApplicationMediaSizeToPageImageableSize](#FitApplicationMediaSizeToPageImageableSize) | 응용 프로그램 미디어 크기를 PageImageableSize에 비율을 유지하면서 스케일링하도록 지정합니다. |
+| [FitApplicationMediaSizeToPageMediaSize](#FitApplicationMediaSizeToPageMediaSize) | 응용 프로그램 미디어 크기를 PageMediaSize에 비율을 유지하면서 스케일링하도록 지정합니다. |
+| [None](#None) | 스케일링을 적용하지 않도록 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Custom {#Custom}
+```
+public static PageScaling.PageScalingOption Custom
+```
+
+
+Application Media Size에 사용자 정의 스케일링을 적용하도록 지정합니다.
+
+### CustomSquare {#CustomSquare}
+```
+public static PageScaling.PageScalingOption CustomSquare
+```
+
+
+Application Media Size에 사용자 정의 정사각형 스케일링을 적용하도록 지정합니다.
+
+### FitApplicationBleedSizeToPageImageableSize {#FitApplicationBleedSizeToPageImageableSize}
+```
+public static PageScaling.PageScalingOption FitApplicationBleedSizeToPageImageableSize
+```
+
+
+응용 프로그램 블리드 크기를 PageImageableSize에 비율을 유지하면서 스케일링하도록 지정합니다.
+
+### FitApplicationContentSizeToPageImageableSize {#FitApplicationContentSizeToPageImageableSize}
+```
+public static PageScaling.PageScalingOption FitApplicationContentSizeToPageImageableSize
+```
+
+
+응용 프로그램 콘텐츠 크기를 PageImageableSize에 비율을 유지하면서 스케일링하도록 지정합니다.
+
+### FitApplicationMediaSizeToPageImageableSize {#FitApplicationMediaSizeToPageImageableSize}
+```
+public static PageScaling.PageScalingOption FitApplicationMediaSizeToPageImageableSize
+```
+
+
+응용 프로그램 미디어 크기를 PageImageableSize에 비율을 유지하면서 스케일링하도록 지정합니다.
+
+### FitApplicationMediaSizeToPageMediaSize {#FitApplicationMediaSizeToPageMediaSize}
+```
+public static PageScaling.PageScalingOption FitApplicationMediaSizeToPageMediaSize
+```
+
+
+응용 프로그램 미디어 크기를 PageMediaSize에 비율을 유지하면서 스케일링하도록 지정합니다.
+
+### None {#None}
+```
+public static PageScaling.PageScalingOption None
+```
+
+
+스케일링을 적용하지 않도록 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescalingscale/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescalingscale/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingScale"
+second_title: "Aspose.Page용 Java API 참조"
+description: "맞춤 정사각형 스케일링을 위한 스케일링 계수를 지정합니다."
+type: docs
+weight: 124
+url: /ko/java/com.aspose.xps.metadata/pagescalingscale/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingScale extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+맞춤형 정사각형 스케일링을 위한 스케일링 계수를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingscale
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageScalingScale(int value)](#PageScalingScale-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingScale(int value) {#PageScalingScale-int-}
+```
+public PageScalingScale(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescalingscaleheight/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescalingscaleheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingScaleHeight"
+second_title: "Aspose.Page용 Java API 참조"
+description: "맞춤 스케일링을 위해 ImageableSizeHeight 방향의 배율을 지정합니다."
+type: docs
+weight: 125
+url: /ko/java/com.aspose.xps.metadata/pagescalingscaleheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingScaleHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+맞춤 스케일링을 위해 ImageableSizeHeight 방향의 배율을 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingscaleheight
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageScalingScaleHeight(int value)](#PageScalingScaleHeight-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingScaleHeight(int value) {#PageScalingScaleHeight-int-}
+```
+public PageScalingScaleHeight(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagescalingscalewidth/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagescalingscalewidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageScalingScaleWidth"
+second_title: "Aspose.Page용 Java API 참조"
+description: "맞춤 스케일링을 위해 ImageableSizeWidth 방향의 배율 인자를 지정합니다."
+type: docs
+weight: 126
+url: /ko/java/com.aspose.xps.metadata/pagescalingscalewidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageScalingScaleWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+맞춤 스케일링을 위해 ImageableSizeWidth 방향의 배율 인자를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagescalingscalewidth
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageScalingScaleWidth(int value)](#PageScalingScaleWidth-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageScalingScaleWidth(int value) {#PageScalingScaleWidth-int-}
+```
+public PageScalingScaleWidth(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagesourcecolorprofile/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagesourcecolorprofile/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageSourceColorProfile"
+second_title: "Aspose.Page용 Java API 참조"
+description: "소스 색상 프로파일의 특성을 정의합니다."
+type: docs
+weight: 127
+url: /ko/java/com.aspose.xps.metadata/pagesourcecolorprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageSourceColorProfile extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+소스 색 프로파일의 특성을 정의합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagesourcecolorprofile
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageSourceColorProfile(PageSourceColorProfile.PageSourceColorProfileOption[] options)](#PageSourceColorProfile-com.aspose.xps.metadata.PageSourceColorProfile.PageSourceColorProfileOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSourceColorProfile(PageSourceColorProfile.PageSourceColorProfileOption[] options) {#PageSourceColorProfile-com.aspose.xps.metadata.PageSourceColorProfile.PageSourceColorProfileOption...-}
+```
+public PageSourceColorProfile(PageSourceColorProfile.PageSourceColorProfileOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageSourceColorProfileOption\[\]](../../com.aspose.xps.metadata/pagesourcecolorprofileoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagesourcecolorprofileembedded/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagesourcecolorprofileembedded/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageSourceColorProfileEmbedded"
+second_title: "Aspose.Page용 Java API 참조"
+description: "내장된 소스 색상 프로파일을 지정합니다."
+type: docs
+weight: 128
+url: /ko/java/com.aspose.xps.metadata/pagesourcecolorprofileembedded/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageSourceColorProfileEmbedded extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+내장된 소스 색상 프로파일을 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageSourceColorProfileEmbedded(String value)](#PageSourceColorProfileEmbedded-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSourceColorProfileEmbedded(String value) {#PageSourceColorProfileEmbedded-java.lang.String-}
+```
+public PageSourceColorProfileEmbedded(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagesourcecolorprofileoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagesourcecolorprofileoption/_index.md
@@ -1,0 +1,180 @@
+---
+title: "PageSourceColorProfile.PageSourceColorProfileOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageSourceColorProfile 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagesourcecolorprofile.pagesourcecolorprofileoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageSourceColorProfile.PageSourceColorProfileOption extends Option
+```
+
+PageSourceColorProfile 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CMYK](#CMYK) | 태그가 없는 CMYK 데이터에 대한 색상 관리를 수행하는 데 사용되는 소스 프로필입니다. |
+| [None](#None) | 소스 프로필이 없습니다. |
+| [RGB](#RGB) | 태그가 없는 RGB 데이터에 대한 색상 관리를 수행하는 데 사용되는 소스 프로필입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CMYK {#CMYK}
+```
+public static PageSourceColorProfile.PageSourceColorProfileOption CMYK
+```
+
+
+태그가 없는 CMYK 데이터에 대한 색상 관리를 수행하는 데 사용되는 소스 프로필입니다.
+
+### None {#None}
+```
+public static PageSourceColorProfile.PageSourceColorProfileOption None
+```
+
+
+소스 프로필이 없습니다.
+
+### RGB {#RGB}
+```
+public static PageSourceColorProfile.PageSourceColorProfileOption RGB
+```
+
+
+태그가 없는 RGB 데이터에 대한 색상 관리를 수행하는 데 사용되는 소스 프로필입니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagesourcecolorprofileuri/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagesourcecolorprofileuri/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageSourceColorProfileURI"
+second_title: "Aspose.Page용 Java API 참조"
+description: "색상 프로파일의 소스를 지정합니다."
+type: docs
+weight: 129
+url: /ko/java/com.aspose.xps.metadata/pagesourcecolorprofileuri/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageSourceColorProfileURI extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+색상 프로파일의 소스를 지정합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageSourceColorProfileURI(String value)](#PageSourceColorProfileURI-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageSourceColorProfileURI(String value) {#PageSourceColorProfileURI-java.lang.String-}
+```
+public PageSourceColorProfileURI(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagetruetypefontmode/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagetruetypefontmode/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageTrueTypeFontMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용될 TrueType 글꼴 처리 방법을 설명합니다."
+type: docs
+weight: 130
+url: /ko/java/com.aspose.xps.metadata/pagetruetypefontmode/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageTrueTypeFontMode extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+사용할 TrueType 글꼴 처리 방법을 설명합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagetruetypefontmode
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageTrueTypeFontMode(PageTrueTypeFontMode.PageTrueTypeFontModeOption[] options)](#PageTrueTypeFontMode-com.aspose.xps.metadata.PageTrueTypeFontMode.PageTrueTypeFontModeOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageTrueTypeFontMode(PageTrueTypeFontMode.PageTrueTypeFontModeOption[] options) {#PageTrueTypeFontMode-com.aspose.xps.metadata.PageTrueTypeFontMode.PageTrueTypeFontModeOption...-}
+```
+public PageTrueTypeFontMode(PageTrueTypeFontMode.PageTrueTypeFontModeOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PageTrueTypeFontModeOption\[\]](../../com.aspose.xps.metadata/pagetruetypefontmodeoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagetruetypefontmodeoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagetruetypefontmodeoption/_index.md
@@ -1,0 +1,198 @@
+---
+title: "PageTrueTypeFontMode.PageTrueTypeFontModeOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageTrueTypeFontMode 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/pagetruetypefontmode.pagetruetypefontmodeoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageTrueTypeFontMode.PageTrueTypeFontModeOption extends Option
+```
+
+PageTrueTypeFontMode 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Automatic](#Automatic) | TrueType 글꼴을 자동으로 처리합니다. |
+| [DownloadAsNativeTrueTypeFont](#DownloadAsNativeTrueTypeFont) | TrueType 글꼴이 기본 TrueType 글꼴로 다운로드됩니다. |
+| [DownloadAsOutlineFont](#DownloadAsOutlineFont) | TrueType 글꼴이 외곽선 글꼴로 다운로드됩니다. |
+| [DownloadAsRasterFont](#DownloadAsRasterFont) | TrueType 글꼴이 래스터 글꼴로 다운로드됩니다. |
+| [RenderAsBitmap](#RenderAsBitmap) | TrueType 글꼴이 비트맵으로 렌더링됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Automatic {#Automatic}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption Automatic
+```
+
+
+TrueType 글꼴을 자동으로 처리합니다.
+
+### DownloadAsNativeTrueTypeFont {#DownloadAsNativeTrueTypeFont}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption DownloadAsNativeTrueTypeFont
+```
+
+
+TrueType 글꼴이 기본 TrueType 글꼴로 다운로드됩니다.
+
+### DownloadAsOutlineFont {#DownloadAsOutlineFont}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption DownloadAsOutlineFont
+```
+
+
+TrueType 글꼴이 외곽선 글꼴로 다운로드됩니다.
+
+### DownloadAsRasterFont {#DownloadAsRasterFont}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption DownloadAsRasterFont
+```
+
+
+TrueType 글꼴이 래스터 글꼴로 다운로드됩니다.
+
+### RenderAsBitmap {#RenderAsBitmap}
+```
+public static PageTrueTypeFontMode.PageTrueTypeFontModeOption RenderAsBitmap
+```
+
+
+TrueType 글꼴이 비트맵으로 렌더링됩니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermark/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermark/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageWatermark"
+second_title: "Aspose.Page용 Java API 참조"
+description: "출력의 워터마크 설정 및 워터마크 특성을 설명합니다."
+type: docs
+weight: 131
+url: /ko/java/com.aspose.xps.metadata/pagewatermark/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermark extends Feature implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+출력의 워터마크 설정 및 워터마크 특성을 설명합니다. 워터마크는 물리 페이지가 아니라 논리 페이지에 적용됩니다. 예를 들어, DocumentDuplex가 활성화된 경우, 각 시트의 각 NUp 페이지에 워터마크가 표시됩니다. DocumentDuplex가 활성화되고 PagesPerSheet =2인 경우, 각 시트에 워터마크가 2개 표시됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermark
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermark(PageWatermark.IPageWatermarkItem[] items)](#PageWatermark-com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermark(PageWatermark.IPageWatermarkItem[] items) {#PageWatermark-com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem...-}
+```
+public PageWatermark(PageWatermark.IPageWatermarkItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageWatermarkItem\[\]](../../com.aspose.xps.metadata/ipagewatermarkitem) | 해당 기능에 특화된 항목들의 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarkoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarkoption/_index.md
@@ -1,0 +1,225 @@
+---
+title: "PageWatermark.PageWatermarkOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PageWatermark 기능 옵션을 설명합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/pagewatermark.pagewatermarkoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageWatermark.IPageWatermarkItem](../../com.aspose.xps.metadata/ipagewatermarkitem)
+```
+public static final class PageWatermark.PageWatermarkOption extends Option implements PageWatermark.IPageWatermarkItem
+```
+
+PageWatermark 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkOption(String optionName, PageWatermark.IPageWatermarkOptionItem[] items)](#PageWatermarkOption-java.lang.String-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-) | 새 인스턴스를 생성합니다. |
+| [PageWatermarkOption(PageWatermark.PageWatermarkOption option)](#PageWatermarkOption-com.aspose.xps.metadata.PageWatermark.PageWatermarkOption-) | 이 옵션 인스턴스를 복제합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Text](#Text) | 텍스트 전용 워터마크를 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(PageWatermark.IPageWatermarkOptionItem[] items)](#add-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-) | IPageWatermarkOptionItem 인스턴스 배열을 옵션에 추가합니다. |
+| [clone()](#clone--) | 이 옵션 인스턴스를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkOption(String optionName, PageWatermark.IPageWatermarkOptionItem[] items) {#PageWatermarkOption-java.lang.String-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-}
+```
+public PageWatermarkOption(String optionName, PageWatermark.IPageWatermarkOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| optionName | java.lang.String | 옵션 이름입니다. |
+| items | [IPageWatermarkOptionItem\[\]](../../com.aspose.xps.metadata/ipagewatermarkoptionitem) | 임의의 IPageWatermarkOptionItem 인스턴스 배열입니다. |
+
+### PageWatermarkOption(PageWatermark.PageWatermarkOption option) {#PageWatermarkOption-com.aspose.xps.metadata.PageWatermark.PageWatermarkOption-}
+```
+public PageWatermarkOption(PageWatermark.PageWatermarkOption option)
+```
+
+
+이 옵션 인스턴스를 복제합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| option | [PageWatermarkOption](../../com.aspose.xps.metadata/pagewatermarkoption) | 복제할 인스턴스. |
+
+### Text {#Text}
+```
+public static PageWatermark.PageWatermarkOption Text
+```
+
+
+텍스트 전용 워터마크를 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(PageWatermark.IPageWatermarkOptionItem[] items) {#add-com.aspose.xps.metadata.PageWatermark.IPageWatermarkOptionItem...-}
+```
+public PageWatermark.PageWatermarkOption add(PageWatermark.IPageWatermarkOptionItem[] items)
+```
+
+
+IPageWatermarkOptionItem 인스턴스 배열을 옵션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPageWatermarkOptionItem\[\]](../../com.aspose.xps.metadata/ipagewatermarkoptionitem) | 임의의 IPageWatermarkOptionItem 인스턴스 배열입니다. |
+
+**Returns:**
+[PageWatermarkOption](../../com.aspose.xps.metadata/pagewatermarkoption) - This options instance.
+### clone() {#clone--}
+```
+public PageWatermark.PageWatermarkOption clone()
+```
+
+
+이 옵션 인스턴스를 복제합니다. 복제 생성자에 대한 바로 가기.
+
+**Returns:**
+[PageWatermarkOption](../../com.aspose.xps.metadata/pagewatermarkoption) - The clone of this option instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarkoriginheight/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarkoriginheight/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkOriginHeight"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크의 원점을 PageImageableSize의 원점에 상대적으로 지정합니다."
+type: docs
+weight: 132
+url: /ko/java/com.aspose.xps.metadata/pagewatermarkoriginheight/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkOriginHeight extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크의 원점을 PageImageableSize의 원점에 상대적으로 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarkoriginheight
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkOriginHeight(int value)](#PageWatermarkOriginHeight-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkOriginHeight(int value) {#PageWatermarkOriginHeight-int-}
+```
+public PageWatermarkOriginHeight(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarkoriginwidth/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarkoriginwidth/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkOriginWidth"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크의 원점을 PageImageableSize의 원점에 상대적으로 지정합니다."
+type: docs
+weight: 133
+url: /ko/java/com.aspose.xps.metadata/pagewatermarkoriginwidth/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkOriginWidth extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크의 원점을 PageImageableSize의 원점에 상대적으로 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarkoriginwidth
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkOriginWidth(int value)](#PageWatermarkOriginWidth-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkOriginWidth(int value) {#PageWatermarkOriginWidth-int-}
+```
+public PageWatermarkOriginWidth(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarktextangle/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarktextangle/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkTextAngle"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크 텍스트의 각도를 PageImageableSizeWidth 방향에 상대적으로 지정합니다."
+type: docs
+weight: 134
+url: /ko/java/com.aspose.xps.metadata/pagewatermarktextangle/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextAngle extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크 텍스트의 각도를 PageImageableSizeWidth 방향에 상대적으로 지정합니다. 각도는 반시계 방향으로 측정됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktextangle
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkTextAngle(int value)](#PageWatermarkTextAngle-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextAngle(int value) {#PageWatermarkTextAngle-int-}
+```
+public PageWatermarkTextAngle(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarktextcolor/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarktextcolor/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageWatermarkTextColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크 텍스트의 sRGB 색상을 정의합니다."
+type: docs
+weight: 135
+url: /ko/java/com.aspose.xps.metadata/pagewatermarktextcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextColor extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크 텍스트의 sRGB 색상을 정의합니다. 형식은 ARGB: \#AARRGGBB입니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktextcolor
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkTextColor(String value)](#PageWatermarkTextColor-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextColor(String value) {#PageWatermarkTextColor-java.lang.String-}
+```
+public PageWatermarkTextColor(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarktextfontsize/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarktextfontsize/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkTextFontSize"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크 텍스트에 사용할 수 있는 글꼴 크기를 정의합니다."
+type: docs
+weight: 136
+url: /ko/java/com.aspose.xps.metadata/pagewatermarktextfontsize/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextFontSize extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크 텍스트에 사용할 수 있는 글꼴 크기를 정의합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktextfontsize
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkTextFontSize(int value)](#PageWatermarkTextFontSize-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextFontSize(int value) {#PageWatermarkTextFontSize-int-}
+```
+public PageWatermarkTextFontSize(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 큰 값.
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 작은 값.
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarktexttext/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarktexttext/_index.md
@@ -1,0 +1,178 @@
+---
+title: "PageWatermarkTextText"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크의 텍스트를 지정합니다."
+type: docs
+weight: 137
+url: /ko/java/com.aspose.xps.metadata/pagewatermarktexttext/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.StringParameterInit](../../com.aspose.xps.metadata/stringparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTextText extends StringParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크 텍스트를 지정합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktexttext
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkTextText(String value)](#PageWatermarkTextText-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTextText(String value) {#PageWatermarkTextText-java.lang.String-}
+```
+public PageWatermarkTextText(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/pagewatermarktransparency/_index.md
+++ b/korean/java/com.aspose.xps.metadata/pagewatermarktransparency/_index.md
@@ -1,0 +1,189 @@
+---
+title: "PageWatermarkTransparency"
+second_title: "Aspose.Page용 Java API 참조"
+description: "워터마크의 투명도를 지정합니다."
+type: docs
+weight: 138
+url: /ko/java/com.aspose.xps.metadata/pagewatermarktransparency/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit), [com.aspose.xps.metadata.IntegerParameterInit](../../com.aspose.xps.metadata/integerparameterinit)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IJobPrintTicketItem](../../com.aspose.xps.metadata/ijobprintticketitem), [com.aspose.xps.metadata.IDocumentPrintTicketItem](../../com.aspose.xps.metadata/idocumentprintticketitem), [com.aspose.xps.metadata.IPagePrintTicketItem](../../com.aspose.xps.metadata/ipageprintticketitem)
+```
+public final class PageWatermarkTransparency extends IntegerParameterInit implements IJobPrintTicketItem, IDocumentPrintTicketItem, IPagePrintTicketItem
+```
+
+워터마크의 투명성을 지정합니다. 완전히 불투명한 경우 값은 0입니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/pagewatermarktransparency
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PageWatermarkTransparency(int value)](#PageWatermarkTransparency-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxValue()](#getMaxValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다. |
+| [getMinValue()](#getMinValue--) | 정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다. |
+| [getMultiple()](#getMultiple--) | 정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PageWatermarkTransparency(int value) {#PageWatermarkTransparency-int-}
+```
+public PageWatermarkTransparency(int value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxValue() {#getMaxValue--}
+```
+public int getMaxValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 큰 값을 정의합니다.
+
+**Returns:**
+int
+### getMinValue() {#getMinValue--}
+```
+public int getMinValue()
+```
+
+
+정수 또는 소수값 매개변수에 대해 허용되는 가장 작은 값을 정의합니다.
+
+**Returns:**
+int
+### getMultiple() {#getMultiple--}
+```
+public int getMultiple()
+```
+
+
+정수 또는 소수값 매개변수에 대해 매개변수 값은 이 숫자의 배수여야 합니다.
+
+**Returns:**
+int - 매개변수가 배수가 되어야 하는 숫자.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/parameterinit/_index.md
+++ b/korean/java/com.aspose.xps.metadata/parameterinit/_index.md
@@ -1,0 +1,157 @@
+---
+title: "ParameterInit"
+second_title: "Aspose.Page용 Java API 참조"
+description: "인쇄 티켓 매개변수 초기화기를 구현하는 클래스."
+type: docs
+weight: 139
+url: /ko/java/com.aspose.xps.metadata/parameterinit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public class ParameterInit extends PrintTicketElement implements IPrintTicketItem
+```
+
+프린트 티켓 매개변수 초기화자를 구현하는 클래스. 공통 PrintTicket 매개변수 초기화자를 구현하는 클래스. 모든 스키마 정의 매개변수 초기화자의 기본 클래스.  ParameterDef  요소의 인스턴스에 대한 값을 정의합니다.  ParameterInit  요소는  ParameterRef  요소가 만든 참조의 대상입니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/parameterinit
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ParameterInit(String name, Value value)](#ParameterInit-java.lang.String-com.aspose.xps.metadata.Value-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParameterInit(String name, Value value) {#ParameterInit-java.lang.String-com.aspose.xps.metadata.Value-}
+```
+public ParameterInit(String name, Value value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 매개변수 이름입니다. |
+| value | [Value](../../com.aspose.xps.metadata/value) | 매개변수 값입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/parameterref/_index.md
+++ b/korean/java/com.aspose.xps.metadata/parameterref/_index.md
@@ -1,0 +1,156 @@
+---
+title: "ParameterRef"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 PrintTicket 매개변수 참조를 구현하는 클래스."
+type: docs
+weight: 140
+url: /ko/java/com.aspose.xps.metadata/parameterref/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem)
+```
+public class ParameterRef extends PrintTicketElement implements IPrintTicketItem
+```
+
+공통 PrintTicket 매개변수 참조를 구현하는 클래스입니다. ParameterRef 요소는 ParameterInit 요소에 대한 참조를 정의합니다. ParameterRef 요소를 포함하는 ScoredProperty 요소는 명시적으로 설정된 Value 요소를 갖지 않습니다. 대신 ScoredProperty 요소는 ParameterRef 요소가 참조하는 ParameterInit 요소로부터 값을 받습니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/parameterref
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ParameterRef(String name)](#ParameterRef-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ParameterRef(String name) {#ParameterRef-java.lang.String-}
+```
+public ParameterRef(String name)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 매개변수 이름입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/preprinted/_index.md
+++ b/korean/java/com.aspose.xps.metadata/preprinted/_index.md
@@ -1,0 +1,169 @@
+---
+title: "PageMediaType.PrePrinted"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrePrinted 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.preprinted/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.PrePrinted extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+PrePrinted 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Letterhead](#Letterhead) | Letterhead 값입니다. |
+| [None](#None) | None 값. |
+| [PrePrintedValue](#PrePrintedValue) | PrePrinted 값입니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Letterhead {#Letterhead}
+```
+public static PageMediaType.PrePrinted Letterhead
+```
+
+
+Letterhead 값입니다.
+
+### None {#None}
+```
+public static PageMediaType.PrePrinted None
+```
+
+
+None 값.
+
+### PrePrintedValue {#PrePrintedValue}
+```
+public static PageMediaType.PrePrinted PrePrintedValue
+```
+
+
+PrePrinted 값입니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/prepunched/_index.md
+++ b/korean/java/com.aspose.xps.metadata/prepunched/_index.md
@@ -1,0 +1,160 @@
+---
+title: "PageMediaType.PrePunched"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrePunched 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.prepunched/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.PrePunched extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+PrePunched 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | None 값. |
+| [PrePunchedValue](#PrePunchedValue) | PrePunched 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static PageMediaType.PrePunched None
+```
+
+
+None 값.
+
+### PrePunchedValue {#PrePunchedValue}
+```
+public static PageMediaType.PrePunched PrePunchedValue
+```
+
+
+PrePunched 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/presentationdirection/_index.md
+++ b/korean/java/com.aspose.xps.metadata/presentationdirection/_index.md
@@ -1,0 +1,170 @@
+---
+title: "NUp.PresentationDirection"
+second_title: "Aspose.Page용 Java API 참조"
+description: "내부 PresentationDirection 기능을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/nup.presentationdirection/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.NUp.INUpItem](../../com.aspose.xps.metadata/inupitem)
+```
+public static final class NUp.PresentationDirection extends Feature implements NUp.INUpItem
+```
+
+내부 **PresentationDirection** 기능을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PresentationDirection(NUp.PresentationDirection.PresentationDirectionOption[] options)](#PresentationDirection-com.aspose.xps.metadata.NUp.PresentationDirection.PresentationDirectionOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PresentationDirection(NUp.PresentationDirection.PresentationDirectionOption[] options) {#PresentationDirection-com.aspose.xps.metadata.NUp.PresentationDirection.PresentationDirectionOption...-}
+```
+public PresentationDirection(NUp.PresentationDirection.PresentationDirectionOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [PresentationDirectionOption\[\]](../../com.aspose.xps.metadata/presentationdirectionoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/presentationdirectionoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/presentationdirectionoption/_index.md
@@ -1,0 +1,225 @@
+---
+title: "NUp.PresentationDirection.PresentationDirectionOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PresentationDirection 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/nup.presentationdirection.presentationdirectionoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class NUp.PresentationDirection.PresentationDirectionOption extends Option
+```
+
+**PresentationDirection** 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BottomLeft](#BottomLeft) | 위에서 아래로, 오른쪽에서 왼쪽으로 지정합니다. |
+| [BottomRight](#BottomRight) | 위에서 아래로, 왼쪽에서 오른쪽으로 지정합니다. |
+| [LeftBottom](#LeftBottom) | 오른쪽에서 왼쪽으로, 위에서 아래로 지정합니다. |
+| [LeftTop](#LeftTop) | 오른쪽에서 왼쪽으로, 아래에서 위로 지정합니다. |
+| [RightBottom](#RightBottom) | 왼쪽에서 오른쪽으로, 위에서 아래로 지정합니다. |
+| [RightTop](#RightTop) | 왼쪽에서 오른쪽으로, 아래에서 위로 지정합니다. |
+| [TopLeft](#TopLeft) | 아래에서 위로, 오른쪽에서 왼쪽으로 지정합니다. |
+| [TopRight](#TopRight) | 아래에서 위로, 왼쪽에서 오른쪽으로 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BottomLeft {#BottomLeft}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption BottomLeft
+```
+
+
+위에서 아래로, 오른쪽에서 왼쪽으로 지정합니다.
+
+### BottomRight {#BottomRight}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption BottomRight
+```
+
+
+위에서 아래로, 왼쪽에서 오른쪽으로 지정합니다.
+
+### LeftBottom {#LeftBottom}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption LeftBottom
+```
+
+
+오른쪽에서 왼쪽으로, 위에서 아래로 지정합니다.
+
+### LeftTop {#LeftTop}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption LeftTop
+```
+
+
+오른쪽에서 왼쪽으로, 아래에서 위로 지정합니다.
+
+### RightBottom {#RightBottom}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption RightBottom
+```
+
+
+왼쪽에서 오른쪽으로, 위에서 아래로 지정합니다.
+
+### RightTop {#RightTop}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption RightTop
+```
+
+
+왼쪽에서 오른쪽으로, 아래에서 위로 지정합니다.
+
+### TopLeft {#TopLeft}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption TopLeft
+```
+
+
+아래에서 위로, 오른쪽에서 왼쪽으로 지정합니다.
+
+### TopRight {#TopRight}
+```
+public static NUp.PresentationDirection.PresentationDirectionOption TopRight
+```
+
+
+아래에서 위로, 왼쪽에서 오른쪽으로 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/printticket/_index.md
+++ b/korean/java/com.aspose.xps.metadata/printticket/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PrintTicket"
+second_title: "Aspose.Page용 Java API 참조"
+description: "어떤 범위든 공통 PrintTicket을 구현하는 클래스."
+type: docs
+weight: 141
+url: /ko/java/com.aspose.xps.metadata/printticket/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class PrintTicket implements Iterable<String>
+```
+
+어떤 범위에서도 공통 PrintTicket을 구현하는 클래스입니다. 작업, 문서 및 페이지 수준 PrintTicket의 기본 클래스입니다. PrintTicket 요소는 PrintTicket 문서의 루트 요소입니다. PrintTicket 요소는 작업을 출력하는 데 필요한 모든 작업 서식 정보를 포함합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/printticket
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PrintTicket(IPrintTicketItem[] items)](#PrintTicket-com.aspose.xps.metadata.IPrintTicketItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | 인쇄 티켓 항목 이름 반복자를 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(String[] names)](#remove-java.lang.String...-) | 이 PrintTicket 항목 목록에서 항목을 제거합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintTicket(IPrintTicketItem[] items) {#PrintTicket-com.aspose.xps.metadata.IPrintTicketItem...-}
+```
+public PrintTicket(IPrintTicketItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IPrintTicketItem\[\]](../../com.aspose.xps.metadata/iprintticketitem) | IPrintTicketItem 인스턴스의 임의 배열입니다. 각 항목은 Feature, ParameterInit 또는 Property 인스턴스여야 합니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<String> iterator()
+```
+
+
+인쇄 티켓 항목 이름 반복자를 반환합니다.
+
+**Returns:**
+java.util.Iterator<java.lang.String> - 목록에 대한 반복자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(String[] names) {#remove-java.lang.String...-}
+```
+public void remove(String[] names)
+```
+
+
+이 PrintTicket 항목 목록에서 항목을 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String[] | 항목 이름 배열입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/printticketelement/_index.md
+++ b/korean/java/com.aspose.xps.metadata/printticketelement/_index.md
@@ -1,0 +1,156 @@
+---
+title: "PrintTicketElement"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Print Schema 요소가 될 수 있는 클래스들의 기본 클래스."
+type: docs
+weight: 142
+url: /ko/java/com.aspose.xps.metadata/printticketelement/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketElementChild](../../com.aspose.xps.metadata/iprintticketelementchild)
+```
+public abstract class PrintTicketElement implements IPrintTicketElementChild
+```
+
+Print Schema 요소가 될 수 있는 클래스들의 기본 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PrintTicketElement(String name)](#PrintTicketElement-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PrintTicketElement(String name) {#PrintTicketElement-java.lang.String-}
+```
+public PrintTicketElement(String name)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 일부 XML 스키마(예: Microsoft Print Schema Framework 또는 기타)에 따른 요소 이름입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/profile/_index.md
+++ b/korean/java/com.aspose.xps.metadata/profile/_index.md
@@ -1,0 +1,155 @@
+---
+title: "JobOptimalDestinationColorProfile.Profile"
+second_title: "Aspose.Page용 Java API 참조"
+description: "사용 가능한 색상 프로파일을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/joboptimaldestinationcolorprofile.profile/
+---
+**Inheritance:**
+java.lang.Object
+```
+public static final class JobOptimalDestinationColorProfile.Profile
+```
+
+사용 가능한 색상 프로파일을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [CMYK](#CMYK) | CMYK 프로필. |
+| [ICC](#ICC) | ICC 프로필. |
+| [RGB](#RGB) | RGB 프로필. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### CMYK {#CMYK}
+```
+public static final JobOptimalDestinationColorProfile.Profile CMYK
+```
+
+
+CMYK 프로필.
+
+### ICC {#ICC}
+```
+public static final JobOptimalDestinationColorProfile.Profile ICC
+```
+
+
+ICC 프로필.
+
+### RGB {#RGB}
+```
+public static final JobOptimalDestinationColorProfile.Profile RGB
+```
+
+
+RGB 프로필.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/property/_index.md
+++ b/korean/java/com.aspose.xps.metadata/property/_index.md
@@ -1,0 +1,174 @@
+---
+title: "Property"
+second_title: "Aspose.Page용 Java API 참조"
+description: "인쇄 티켓 속성을 구현하는 클래스."
+type: docs
+weight: 143
+url: /ko/java/com.aspose.xps.metadata/property/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IPrintTicketItem](../../com.aspose.xps.metadata/iprintticketitem), [com.aspose.xps.metadata.IFeatureItem](../../com.aspose.xps.metadata/ifeatureitem), [com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem), [com.aspose.xps.metadata.IScoredPropertyItem](../../com.aspose.xps.metadata/iscoredpropertyitem), [com.aspose.xps.metadata.IPropertyItem](../../com.aspose.xps.metadata/ipropertyitem)
+```
+public class Property extends CompositePrintTicketElement implements IPrintTicketItem, IFeatureItem, IOptionItem, IScoredPropertyItem, IPropertyItem
+```
+
+프린트 티켓 속성을 구현하는 클래스입니다. 일반 PrintTicket Property를 구현하는 클래스입니다. 모든 스키마 정의 속성의 기본 클래스입니다. Property 요소는 장치, 작업 포맷팅 또는 기타 관련 속성을 선언하며, 이름은 name 속성으로 지정됩니다. Value 요소는 Property에 값을 할당하는 데 사용됩니다. Property는 복잡할 수 있으며, 여러 하위 속성을 포함할 수 있습니다. 하위 속성도 Property 요소로 표현됩니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/property
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Property(String name, Property property, IPropertyItem[] items)](#Property-java.lang.String-com.aspose.xps.metadata.Property-com.aspose.xps.metadata.IPropertyItem...-) | 새 인스턴스를 생성합니다. |
+| [Property(String name, Value value, IPropertyItem[] items)](#Property-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IPropertyItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Property(String name, Property property, IPropertyItem[] items) {#Property-java.lang.String-com.aspose.xps.metadata.Property-com.aspose.xps.metadata.IPropertyItem...-}
+```
+public Property(String name, Property property, IPropertyItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 속성 이름입니다. |
+| property | [Property](../../com.aspose.xps.metadata/property) | 필수 Property 인스턴스입니다. |
+| items | [IPropertyItem\[\]](../../com.aspose.xps.metadata/ipropertyitem) | 임의의 IPropertyItem 인스턴스 배열입니다. 각 항목은 Property 또는 Value 인스턴스여야 합니다. |
+
+### Property(String name, Value value, IPropertyItem[] items) {#Property-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IPropertyItem...-}
+```
+public Property(String name, Value value, IPropertyItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 속성 이름입니다. |
+| value | [Value](../../com.aspose.xps.metadata/value) | 필수 Value 인스턴스. |
+| items | [IPropertyItem\[\]](../../com.aspose.xps.metadata/ipropertyitem) | 임의의 IPropertyItem 인스턴스 배열입니다. 각 항목은 Property 또는 Value 인스턴스여야 합니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/qnamevalue/_index.md
+++ b/korean/java/com.aspose.xps.metadata/qnamevalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "QNameValue"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 문서에서 QName 값을 캡슐화하는 클래스."
+type: docs
+weight: 144
+url: /ko/java/com.aspose.xps.metadata/qnamevalue/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class QNameValue extends Value
+```
+
+PrintTicket 문서에서 QName 값을 캡슐화하는 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [QNameValue(String value)](#QNameValue-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [getValueString()](#getValueString--) | 값을 문자열로 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### QNameValue(String value) {#QNameValue-java.lang.String-}
+```
+public QNameValue(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | QName 값입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+값을 문자열로 가져옵니다.
+
+**Returns:**
+java.lang.String - 값은 문자열입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/qualitativeresolution/_index.md
+++ b/korean/java/com.aspose.xps.metadata/qualitativeresolution/_index.md
@@ -1,0 +1,187 @@
+---
+title: "PageResolution.QualitativeResolution"
+second_title: "Aspose.Page용 Java API 참조"
+description: "QualitativeResolution 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/pageresolution.qualitativeresolution/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageResolution.IPageResolutionOptionItem](../../com.aspose.xps.metadata/ipageresolutionoptionitem)
+```
+public static final class PageResolution.QualitativeResolution extends ScoredProperty implements PageResolution.IPageResolutionOptionItem
+```
+
+QualitativeResolution 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Default](#Default) | Default value. |
+| [Draft](#Draft) | Draft value. |
+| [High](#High) | 높은 값. |
+| [Normal](#Normal) | Normal value. |
+| [Other](#Other) | Other value. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Default {#Default}
+```
+public static PageResolution.QualitativeResolution Default
+```
+
+
+Default value.
+
+### Draft {#Draft}
+```
+public static PageResolution.QualitativeResolution Draft
+```
+
+
+Draft value.
+
+### High {#High}
+```
+public static PageResolution.QualitativeResolution High
+```
+
+
+높은 값.
+
+### Normal {#Normal}
+```
+public static PageResolution.QualitativeResolution Normal
+```
+
+
+Normal value.
+
+### Other {#Other}
+```
+public static PageResolution.QualitativeResolution Other
+```
+
+
+Other value.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/recycled/_index.md
+++ b/korean/java/com.aspose.xps.metadata/recycled/_index.md
@@ -1,0 +1,160 @@
+---
+title: "PageMediaType.Recycled"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Recycled 점수 속성 값에 대한 상수를 정의합니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.xps.metadata/pagemediatype.recycled/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.ScoredProperty](../../com.aspose.xps.metadata/scoredproperty)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageMediaType.IPageMediaTypeOptionItem](../../com.aspose.xps.metadata/ipagemediatypeoptionitem)
+```
+public static final class PageMediaType.Recycled extends ScoredProperty implements PageMediaType.IPageMediaTypeOptionItem
+```
+
+Recycled 점수 속성 값에 대한 상수를 정의합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | None 값. |
+| [Standard](#Standard) | 표준 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### None {#None}
+```
+public static PageMediaType.Recycled None
+```
+
+
+None 값.
+
+### Standard {#Standard}
+```
+public static PageMediaType.Recycled Standard
+```
+
+
+표준 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/rollcut/_index.md
+++ b/korean/java/com.aspose.xps.metadata/rollcut/_index.md
@@ -1,0 +1,149 @@
+---
+title: "RollCut"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobRollCutAtEndOfJob 및 DocumentRollCut 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 145
+url: /ko/java/com.aspose.xps.metadata/rollcut/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class RollCut extends Feature
+```
+
+JobRollCutAtEndOfJob 및 DocumentRollCut 기능 클래스들의 기본 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/rollcutoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/rollcutoption/_index.md
@@ -1,0 +1,189 @@
+---
+title: "RollCut.RollCutOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobRollCutAtEndOfJob 및 DocumentRollCut 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/rollcut.rollcutoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class RollCut.RollCutOption extends Option
+```
+
+JobRollCutAtEndOfJob 및 DocumentRollCut 기능 옵션을 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Banner](#Banner) | 배너( DocumentRollCut 전용)의 절단 방법을 지정합니다. |
+| [CutSheetAtImageEdge](#CutSheetAtImageEdge) | 이미지 가장자리에서 절단을 지정합니다. |
+| [CutSheetAtStandardMediaSize](#CutSheetAtStandardMediaSize) | 표준 매체 크기에 대한 절단을 지정합니다. |
+| [None](#None) | 작업 롤 컷을 지정하지 않습니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Banner {#Banner}
+```
+public static RollCut.RollCutOption Banner
+```
+
+
+배너( DocumentRollCut 전용)의 절단 방법을 지정합니다.
+
+### CutSheetAtImageEdge {#CutSheetAtImageEdge}
+```
+public static RollCut.RollCutOption CutSheetAtImageEdge
+```
+
+
+이미지 가장자리에서 절단을 지정합니다.
+
+### CutSheetAtStandardMediaSize {#CutSheetAtStandardMediaSize}
+```
+public static RollCut.RollCutOption CutSheetAtStandardMediaSize
+```
+
+
+표준 매체 크기에 대한 절단을 지정합니다.
+
+### None {#None}
+```
+public static RollCut.RollCutOption None
+```
+
+
+작업 롤 컷을 지정하지 않습니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/scaleoffsetalignment/_index.md
+++ b/korean/java/com.aspose.xps.metadata/scaleoffsetalignment/_index.md
@@ -1,0 +1,170 @@
+---
+title: "PageScaling.ScaleOffsetAlignment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "내부 ScaleOffsetAlignment 기능을 설명합니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.metadata/pagescaling.scaleoffsetalignment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.PageScaling.IPageScalingItem](../../com.aspose.xps.metadata/ipagescalingitem)
+```
+public static final class PageScaling.ScaleOffsetAlignment extends Feature implements PageScaling.IPageScalingItem
+```
+
+내부 ScaleOffsetAlignment 기능을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ScaleOffsetAlignment(PageScaling.ScaleOffsetAlignmentOption[] options)](#ScaleOffsetAlignment-com.aspose.xps.metadata.PageScaling.ScaleOffsetAlignmentOption...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ScaleOffsetAlignment(PageScaling.ScaleOffsetAlignmentOption[] options) {#ScaleOffsetAlignment-com.aspose.xps.metadata.PageScaling.ScaleOffsetAlignmentOption...-}
+```
+public ScaleOffsetAlignment(PageScaling.ScaleOffsetAlignmentOption[] options)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ScaleOffsetAlignmentOption\[\]](../../com.aspose.xps.metadata/scaleoffsetalignmentoption) | 해당 기능에 특화된 옵션 배열입니다. |
+
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/scaleoffsetalignmentoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/scaleoffsetalignmentoption/_index.md
@@ -1,0 +1,234 @@
+---
+title: "PageScaling.ScaleOffsetAlignmentOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ScaleOffsetAlignment 기능 옵션을 설명합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.metadata/pagescaling.scaleoffsetalignmentoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class PageScaling.ScaleOffsetAlignmentOption extends Option
+```
+
+ScaleOffsetAlignment 기능 옵션을 설명합니다. 스케일된 콘텐츠의 정렬을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BottomCenter](#BottomCenter) | 스케일링이 매체 하단 가장자리 중앙에 정렬되도록 지정합니다. |
+| [BottomLeft](#BottomLeft) | 스케일링이 미디어의 왼쪽 하단 모서리에 정렬되어야 함을 지정합니다. |
+| [BottomRight](#BottomRight) | 스케일링이 미디어의 오른쪽 하단 모서리에 정렬되어야 함을 지정합니다. |
+| [Center](#Center) | 스케일링이 미디어의 중앙에 배치되어야 함을 지정합니다. |
+| [LeftCenter](#LeftCenter) | 스케일링이 미디어의 왼쪽 가장자리 중앙에 정렬되어야 함을 지정합니다. |
+| [RightCenter](#RightCenter) | 스케일링이 미디어의 오른쪽 가장자리 중앙에 정렬되어야 함을 지정합니다. |
+| [TopCenter](#TopCenter) | 스케일링이 미디어의 위쪽 가장자리 중앙에 정렬되어야 함을 지정합니다. |
+| [TopLeft](#TopLeft) | 스케일링이 미디어의 왼쪽 위 모서리에 정렬되어야 함을 지정합니다. |
+| [TopRight](#TopRight) | 스케일링이 미디어의 오른쪽 위 모서리에 정렬되어야 함을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BottomCenter {#BottomCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption BottomCenter
+```
+
+
+스케일링이 매체 하단 가장자리 중앙에 정렬되도록 지정합니다.
+
+### BottomLeft {#BottomLeft}
+```
+public static PageScaling.ScaleOffsetAlignmentOption BottomLeft
+```
+
+
+스케일링이 미디어의 왼쪽 하단 모서리에 정렬되어야 함을 지정합니다.
+
+### BottomRight {#BottomRight}
+```
+public static PageScaling.ScaleOffsetAlignmentOption BottomRight
+```
+
+
+스케일링이 미디어의 오른쪽 하단 모서리에 정렬되어야 함을 지정합니다.
+
+### Center {#Center}
+```
+public static PageScaling.ScaleOffsetAlignmentOption Center
+```
+
+
+스케일링이 미디어의 중앙에 배치되어야 함을 지정합니다.
+
+### LeftCenter {#LeftCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption LeftCenter
+```
+
+
+스케일링이 미디어의 왼쪽 가장자리 중앙에 정렬되어야 함을 지정합니다.
+
+### RightCenter {#RightCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption RightCenter
+```
+
+
+스케일링이 미디어의 오른쪽 가장자리 중앙에 정렬되어야 함을 지정합니다.
+
+### TopCenter {#TopCenter}
+```
+public static PageScaling.ScaleOffsetAlignmentOption TopCenter
+```
+
+
+스케일링이 미디어의 위쪽 가장자리 중앙에 정렬되어야 함을 지정합니다.
+
+### TopLeft {#TopLeft}
+```
+public static PageScaling.ScaleOffsetAlignmentOption TopLeft
+```
+
+
+스케일링이 미디어의 왼쪽 위 모서리에 정렬되어야 함을 지정합니다.
+
+### TopRight {#TopRight}
+```
+public static PageScaling.ScaleOffsetAlignmentOption TopRight
+```
+
+
+스케일링이 미디어의 오른쪽 위 모서리에 정렬되어야 함을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/scoredproperty/_index.md
+++ b/korean/java/com.aspose.xps.metadata/scoredproperty/_index.md
@@ -1,0 +1,173 @@
+---
+title: "ScoredProperty"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 PrintTicket ScoredProperty를 구현하는 클래스입니다."
+type: docs
+weight: 146
+url: /ko/java/com.aspose.xps.metadata/scoredproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IOptionItem](../../com.aspose.xps.metadata/ioptionitem), [com.aspose.xps.metadata.IScoredPropertyItem](../../com.aspose.xps.metadata/iscoredpropertyitem)
+```
+public class ScoredProperty extends CompositePrintTicketElement implements IOptionItem, IScoredPropertyItem
+```
+
+공통 PrintTicket  ScoredProperty 를 구현하는 클래스입니다. 모든 스키마 정의된 스코어드 속성의 기본 클래스입니다. ScoredProperty 요소는 Option 정의에 내재된 속성을 선언합니다. 이러한 속성은 요청된 Option 이 장치가 지원하는 Option 과 얼마나 일치하는지 평가할 때 비교되어야 합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/scoredproperty
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ScoredProperty(String name, ParameterRef parameterRef)](#ScoredProperty-java.lang.String-com.aspose.xps.metadata.ParameterRef-) | 새 인스턴스를 생성합니다. |
+| [ScoredProperty(String name, Value value, IScoredPropertyItem[] items)](#ScoredProperty-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IScoredPropertyItem...-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ScoredProperty(String name, ParameterRef parameterRef) {#ScoredProperty-java.lang.String-com.aspose.xps.metadata.ParameterRef-}
+```
+public ScoredProperty(String name, ParameterRef parameterRef)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 속성 이름입니다. |
+| parameterRef | [ParameterRef](../../com.aspose.xps.metadata/parameterref) | ParameterRef 인스턴스입니다. |
+
+### ScoredProperty(String name, Value value, IScoredPropertyItem[] items) {#ScoredProperty-java.lang.String-com.aspose.xps.metadata.Value-com.aspose.xps.metadata.IScoredPropertyItem...-}
+```
+public ScoredProperty(String name, Value value, IScoredPropertyItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 속성 이름입니다. |
+| value | [Value](../../com.aspose.xps.metadata/value) | 속성 값입니다. |
+| items | [IScoredPropertyItem\[\]](../../com.aspose.xps.metadata/iscoredpropertyitem) | IScoredPropertyItem 인스턴스의 임의 배열입니다. 각 항목은 ScoredProperty, Property 또는 Value 인스턴스여야 합니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/selectiontype/_index.md
+++ b/korean/java/com.aspose.xps.metadata/selectiontype/_index.md
@@ -1,0 +1,157 @@
+---
+title: "SelectionType"
+second_title: "Aspose.Page용 Java API 참조"
+description: "SelectionType PrintTicket 속성을 위한 편의 클래스."
+type: docs
+weight: 147
+url: /ko/java/com.aspose.xps.metadata/selectiontype/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public final class SelectionType extends Property
+```
+
+SelectionType PrintTicket 속성을 위한 편의 클래스.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [PickMany](#PickMany) | PickMany 값. |
+| [PickOne](#PickOne) | PickOne 값. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PickMany {#PickMany}
+```
+public static final SelectionType PickMany
+```
+
+
+PickMany 값.
+
+### PickOne {#PickOne}
+```
+public static final SelectionType PickOne
+```
+
+
+PickOne 값.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/staple/_index.md
+++ b/korean/java/com.aspose.xps.metadata/staple/_index.md
@@ -1,0 +1,149 @@
+---
+title: "스테이플"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobStapleAllDocuments 및 DocumentStaple 기능 클래스의 기본 클래스입니다."
+type: docs
+weight: 148
+url: /ko/java/com.aspose.xps.metadata/staple/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Feature](../../com.aspose.xps.metadata/feature)
+```
+public abstract class Staple extends Feature
+```
+
+JobStapleAllDocuments 및 DocumentStaple 기능 클래스들의 기본 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IFeatureItem[] items)](#add-com.aspose.xps.metadata.IFeatureItem...-) | 이 기능의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(IFeatureItem[] items) {#add-com.aspose.xps.metadata.IFeatureItem...-}
+```
+public void add(IFeatureItem[] items)
+```
+
+
+이 기능의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 Feature, Option 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IFeatureItem\[\]](../../com.aspose.xps.metadata/ifeatureitem) | 추가할 항목 목록. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/stapleoption/_index.md
+++ b/korean/java/com.aspose.xps.metadata/stapleoption/_index.md
@@ -1,0 +1,310 @@
+---
+title: "Staple.StapleOption"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobStapleAllDocuments 및 DocumentStaple 기능 옵션을 설명합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.metadata/staple.stapleoption/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Option](../../com.aspose.xps.metadata/option)
+```
+public static final class Staple.StapleOption extends Option
+```
+
+JobStapleAllDocuments 및 DocumentStaple 기능 옵션을 설명합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StapleOption(String optionName, Staple.IStapleOptionItem[] items)](#StapleOption-java.lang.String-com.aspose.xps.metadata.Staple.IStapleOptionItem...-) | 새 인스턴스를 생성합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [None](#None) | 스테이플링을 하지 않음을 지정합니다. |
+| [SaddleStitch](#SaddleStitch) | 새들 스티치 스테이플링을 지정합니다. |
+| [StapleBottomLeft](#StapleBottomLeft) | 하단 왼쪽 모서리에 단일 스테이플을 지정합니다. |
+| [StapleBottomRight](#StapleBottomRight) | 하단 오른쪽 모서리에 단일 스테이플을 지정합니다. |
+| [StapleDualBottom](#StapleDualBottom) | 하단 가장자리를 따라 두 개의 스테이플을 지정합니다. |
+| [StapleDualLeft](#StapleDualLeft) | 왼쪽 가장자리를 따라 두 개의 스테이플을 지정합니다. |
+| [StapleDualRight](#StapleDualRight) | 오른쪽 가장자리를 따라 두 개의 스테이플을 지정합니다. |
+| [StapleDualTop](#StapleDualTop) | 상단 가장자리를 따라 두 개의 스테이플을 지정합니다 |
+| [StapleTopLeft](#StapleTopLeft) | 상단 왼쪽 모서리에 단일 스테이플을 지정합니다. |
+| [StapleTopRight](#StapleTopRight) | 상단 오른쪽 모서리에 단일 스테이플을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(IOptionItem[] items)](#add-com.aspose.xps.metadata.IOptionItem...-) | 이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. |
+| [add(Staple.IStapleOptionItem[] items)](#add-com.aspose.xps.metadata.Staple.IStapleOptionItem...-) | 특징에 IStapleOptionItem 인스턴스 배열을 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAngle(int angle)](#setAngle-int-) | Angle 점수 속성 값을 설정합니다. |
+| [setSheetCapacity(int sheetCapacity)](#setSheetCapacity-int-) | SheetCapacity 점수 속성 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StapleOption(String optionName, Staple.IStapleOptionItem[] items) {#StapleOption-java.lang.String-com.aspose.xps.metadata.Staple.IStapleOptionItem...-}
+```
+public StapleOption(String optionName, Staple.IStapleOptionItem[] items)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| optionName | java.lang.String | 옵션 이름입니다. |
+| items | [IStapleOptionItem\[\]](../../com.aspose.xps.metadata/istapleoptionitem) | 임의의 IStapleOptionItem 인스턴스 배열입니다. |
+
+### None {#None}
+```
+public static final Staple.StapleOption None
+```
+
+
+스테이플링을 하지 않음을 지정합니다.
+
+### SaddleStitch {#SaddleStitch}
+```
+public static final Staple.StapleOption SaddleStitch
+```
+
+
+새들 스티치 스테이플링을 지정합니다.
+
+### StapleBottomLeft {#StapleBottomLeft}
+```
+public static final Staple.StapleOption StapleBottomLeft
+```
+
+
+하단 왼쪽 모서리에 단일 스테이플을 지정합니다.
+
+### StapleBottomRight {#StapleBottomRight}
+```
+public static final Staple.StapleOption StapleBottomRight
+```
+
+
+하단 오른쪽 모서리에 단일 스테이플을 지정합니다.
+
+### StapleDualBottom {#StapleDualBottom}
+```
+public static final Staple.StapleOption StapleDualBottom
+```
+
+
+하단 가장자리를 따라 두 개의 스테이플을 지정합니다.
+
+### StapleDualLeft {#StapleDualLeft}
+```
+public static final Staple.StapleOption StapleDualLeft
+```
+
+
+왼쪽 가장자리를 따라 두 개의 스테이플을 지정합니다.
+
+### StapleDualRight {#StapleDualRight}
+```
+public static final Staple.StapleOption StapleDualRight
+```
+
+
+오른쪽 가장자리를 따라 두 개의 스테이플을 지정합니다.
+
+### StapleDualTop {#StapleDualTop}
+```
+public static final Staple.StapleOption StapleDualTop
+```
+
+
+상단 가장자리를 따라 두 개의 스테이플을 지정합니다
+
+### StapleTopLeft {#StapleTopLeft}
+```
+public static final Staple.StapleOption StapleTopLeft
+```
+
+
+상단 왼쪽 모서리에 단일 스테이플을 지정합니다.
+
+### StapleTopRight {#StapleTopRight}
+```
+public static final Staple.StapleOption StapleTopRight
+```
+
+
+상단 오른쪽 모서리에 단일 스테이플을 지정합니다.
+
+### add(IOptionItem[] items) {#add-com.aspose.xps.metadata.IOptionItem...-}
+```
+public void add(IOptionItem[] items)
+```
+
+
+이 옵션의 항목 목록 끝에 항목 목록을 추가합니다. 각 항목은 ScoredProperty 또는 Property 인스턴스여야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IOptionItem\[\]](../../com.aspose.xps.metadata/ioptionitem) | 추가할 항목 목록. |
+
+### add(Staple.IStapleOptionItem[] items) {#add-com.aspose.xps.metadata.Staple.IStapleOptionItem...-}
+```
+public Staple.StapleOption add(Staple.IStapleOptionItem[] items)
+```
+
+
+특징에 IStapleOptionItem 인스턴스 배열을 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| items | [IStapleOptionItem\[\]](../../com.aspose.xps.metadata/istapleoptionitem) | 임의의 IStapleOptionItem 인스턴스 배열입니다. |
+
+**Returns:**
+[StapleOption](../../com.aspose.xps.metadata/stapleoption) - This options instance.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAngle(int angle) {#setAngle-int-}
+```
+public final Staple.StapleOption setAngle(int angle)
+```
+
+
+Angle 점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | int | Angle 점수 속성 값입니다. |
+
+**Returns:**
+[StapleOption](../../com.aspose.xps.metadata/stapleoption) - This option instance.
+### setSheetCapacity(int sheetCapacity) {#setSheetCapacity-int-}
+```
+public final Staple.StapleOption setSheetCapacity(int sheetCapacity)
+```
+
+
+SheetCapacity 점수 속성 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| sheetCapacity | int | SheetCapacity 점수 속성 값입니다. |
+
+**Returns:**
+[StapleOption](../../com.aspose.xps.metadata/stapleoption) - This option instance.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/stringparameterinit/_index.md
+++ b/korean/java/com.aspose.xps.metadata/stringparameterinit/_index.md
@@ -1,0 +1,176 @@
+---
+title: "StringParameterInit"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 문자열 매개변수 초기화기의 기본 클래스."
+type: docs
+weight: 149
+url: /ko/java/com.aspose.xps.metadata/stringparameterinit/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.ParameterInit](../../com.aspose.xps.metadata/parameterinit)
+```
+public abstract class StringParameterInit extends ParameterInit
+```
+
+모든 문자열 매개변수 초기화기의 기본 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StringParameterInit(String name, String value)](#StringParameterInit-java.lang.String-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getMaxLength()](#getMaxLength--) | 문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다. |
+| [getMinLength()](#getMinLength--) | 문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다. |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringParameterInit(String name, String value) {#StringParameterInit-java.lang.String-java.lang.String-}
+```
+public StringParameterInit(String name, String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String | 매개변수 이름. |
+| 값 | java.lang.String | 매개변수 값. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getMaxLength() {#getMaxLength--}
+```
+public int getMaxLength()
+```
+
+
+문자열 값에 대해, 가장 짧은 최장 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 긴 문자열.
+### getMinLength() {#getMinLength--}
+```
+public int getMinLength()
+```
+
+
+문자열 값에 대해, 허용되는 가장 짧은 문자열을 정의합니다.
+
+**Returns:**
+int - 허용되는 가장 짧은 문자열.
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/stringvalue/_index.md
+++ b/korean/java/com.aspose.xps.metadata/stringvalue/_index.md
@@ -1,0 +1,164 @@
+---
+title: "StringValue"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 문서에서 문자열 값을 캡슐화하는 클래스."
+type: docs
+weight: 150
+url: /ko/java/com.aspose.xps.metadata/stringvalue/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.Value](../../com.aspose.xps.metadata/value)
+```
+public final class StringValue extends Value
+```
+
+PrintTicket 문서에서 문자열 값을 캡슐화하는 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [StringValue(String value)](#StringValue-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [getValueString()](#getValueString--) | 값을 문자열로 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### StringValue(String value) {#StringValue-java.lang.String-}
+```
+public StringValue(String value)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 문자열 값입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+값을 문자열로 가져옵니다.
+
+**Returns:**
+java.lang.String - 값은 문자열입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/uriproperty/_index.md
+++ b/korean/java/com.aspose.xps.metadata/uriproperty/_index.md
@@ -1,0 +1,135 @@
+---
+title: "URIProperty"
+second_title: "Aspose.Page용 Java API 참조"
+description: "JobURI 및 DocumentURI 속성 클래스의 기본 클래스입니다."
+type: docs
+weight: 151
+url: /ko/java/com.aspose.xps.metadata/uriproperty/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement), [com.aspose.xps.metadata.CompositePrintTicketElement](../../com.aspose.xps.metadata/compositeprintticketelement), [com.aspose.xps.metadata.Property](../../com.aspose.xps.metadata/property)
+```
+public class URIProperty extends Property
+```
+
+JobURI 및 DocumentURI 속성 클래스들의 기본 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.metadata/value/_index.md
+++ b/korean/java/com.aspose.xps.metadata/value/_index.md
@@ -1,0 +1,149 @@
+---
+title: "값"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PrintTicket 문서에서 Property 또는 ScoredProperty 값을 캡슐화하는 기본 클래스입니다."
+type: docs
+weight: 152
+url: /ko/java/com.aspose.xps.metadata/value/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.metadata.PrintTicketElement](../../com.aspose.xps.metadata/printticketelement)
+
+**All Implemented Interfaces:**
+[com.aspose.xps.metadata.IScoredPropertyItem](../../com.aspose.xps.metadata/iscoredpropertyitem), [com.aspose.xps.metadata.IPropertyItem](../../com.aspose.xps.metadata/ipropertyitem)
+```
+public class Value extends PrintTicketElement implements IScoredPropertyItem, IPropertyItem
+```
+
+PrintTicket 문서에서 Property 또는 ScoredProperty 값을 캡슐화하는 기본 클래스입니다. Value 요소는 리터럴을 유형과 연결합니다. https://docs.microsoft.com/en-us/windows/win32/printdocs/value
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getName()](#getName--) | 요소 이름을 가져옵니다. |
+| [getValueString()](#getValueString--) | 값을 문자열로 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getName() {#getName--}
+```
+public String getName()
+```
+
+
+요소 이름을 가져옵니다.
+
+**Returns:**
+java.lang.String
+### getValueString() {#getValueString--}
+```
+public String getValueString()
+```
+
+
+값을 문자열로 가져옵니다.
+
+**Returns:**
+java.lang.String - 값은 문자열입니다.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.plugins/_index.md
+++ b/korean/java/com.aspose.xps.plugins/_index.md
@@ -1,0 +1,20 @@
+---
+title: "com.aspose.xps.plugins"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.xps.plugins는 XPS 플러그인 클래스를 포함합니다."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.xps.plugins/
+---
+
+  **com.aspose.xps.plugins** 는 XPS 플러그인 클래스를 포함합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [XpsConverter](../com.aspose.xps.plugins/xpsconverter) | XpsConverter 플러그인을 나타냅니다. |
+| [XpsConverterOptions](../com.aspose.xps.plugins/xpsconverteroptions) | [XpsConverter](../com.aspose.xps.plugins/xpsconverter) 플러그인의 옵션 기본 클래스를 나타냅니다. |
+| [XpsConverterToImageOptions](../com.aspose.xps.plugins/xpsconvertertoimageoptions) | [XpsConverter](../com.aspose.xps.plugins/xpsconverter) 플러그인의 XPS에서 이미지 변환 옵션을 나타냅니다. |
+| [XpsConverterToPdfOptions](../com.aspose.xps.plugins/xpsconvertertopdfoptions) | [XpsConverter](../com.aspose.xps.plugins/xpsconverter) 플러그인의 XPS에서 PDF 변환 옵션을 나타냅니다. |

--- a/korean/java/com.aspose.xps.plugins/xpsconverter/_index.md
+++ b/korean/java/com.aspose.xps.plugins/xpsconverter/_index.md
@@ -1,0 +1,175 @@
+---
+title: "XpsConverter"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XpsConverter 플러그인을 나타냅니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.plugins/xpsconverter/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPlugin](../../com.aspose.page.plugins/iplugin)
+```
+public class XpsConverter implements IPlugin
+```
+
+XpsConverter 플러그인을 나타냅니다.
+
+이 예제는 XPS 문서를 PDF 문서로 변환하는 방법을 보여줍니다.
+
+// XpsConverter 생성 XpsConverter converter = new XpsConverter(); // XpsConverterToPdfOptions 객체를 생성하여 출력 데이터 유형을 파일로 설정 XpsConverterToPdfOptions opt = new XpsConverterToPdfOptions(); // 입력 파일 경로 추가 opt.addDataSource(new FileDataSource(inputPath)); // 출력 파일 경로 설정 opt.addSaveDataSource(new FileDataSource(outputPath)); // 변환 프로세스 시작 ResultContainer results = converter.process(opt);
+
+이 예제는 XPS 문서를 파일 출력 이미지로 변환하는 방법을 보여줍니다.
+
+// XpsConverter 생성 XpsConverter converter = new XpsConverter(); // JPEG 대상 이미지 형식으로 XpsConverterToImageOptions 객체를 생성합니다. 결과 이미지의 기본 형식은 PNG입니다. // 또한 결과 이미지의 크기, 해상도, 스무딩 모드 및 JPEG 결과 이미지 형식의 JPEG 품질 수준을 설정할 수 있습니다. XpsConverterToImageOptions opt = new XpsConverterToImageOptions(ImageFormat.Jpeg); // 입력 파일 경로 추가 opt.addDataSource(new FileDataSource(inputPath)); // 입력 XPS 파일이 다중 페이지인 경우 결과는 다음과 같은 이름의 이미지 파일 집합이 됩니다: [\"outputPath\" without extension][pageNumber started from 0].[extension from \"outputPath\"] opt.addSaveDataSource(new FileDataSource(outputPath)); // 변환 프로세스 시작 converter.process(opt);
+
+이 예제는 XPS 문서를 바이트 배열 출력 이미지로 변환하는 방법을 보여줍니다.
+
+바이트 배열 출력 데이터소스(byte[][])에서는 각 바이트 배열이 한 페이지의 이미지를 포함합니다. 따라서 한 페이지 문서의 경우 결과에 [1][] 배열이 포함되고, 다중 페이지 문서의 경우 결과에 [입력 XPS 문서의 페이지 수][] 배열이 포함됩니다. // XpsConverter 생성 XpsConverter converter = new XpsConverter(); // JPEG 대상 이미지 형식으로 XpsConverterToImageOptions 객체를 생성합니다. 결과 이미지의 기본 형식은 PNG입니다. // 또한 결과 이미지의 크기, 해상도, 스무딩 모드 및 JPEG 결과 이미지 형식의 JPEG 품질 수준을 설정할 수 있습니다. XpsConverterToImageOptions opt = new XpsConverterToImageOptions(ImageFormat.Jpeg); // 입력 파일 경로 추가 opt.addDataSource(new FileDataSource(inputPath)); // 입력 XPS 파일이 다중 페이지인 경우 결과는 다음과 같은 이름의 이미지 파일 집합이 됩니다: [\"outputPath\" without extension][pageNumber started from 1].[extension from \"outputPath\"] opt.addSaveDataSource(new ByteArrayDataSource()); // 변환 프로세스 시작 converter.process(opt); // 결과 바이트 배열 가져오기 byte[][] imagesBytes = (byte [][]) ((ByteArrayResult)results.ResultCollection[0]).Data;
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsConverter()](#XpsConverter--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [dispose()](#dispose--) | IDisposable 구현. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [process(IPluginOptions options)](#process-com.aspose.page.plugins.IPluginOptions-) | 지정된 매개변수로 XpsConverter 처리를 시작합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsConverter() {#XpsConverter--}
+```
+public XpsConverter()
+```
+
+
+### dispose() {#dispose--}
+```
+public final void dispose()
+```
+
+
+IDisposable 구현.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### process(IPluginOptions options) {#process-com.aspose.page.plugins.IPluginOptions-}
+```
+public final ResultContainer process(IPluginOptions options)
+```
+
+
+지정된 매개변수로 XpsConverter 처리를 시작합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [IPluginOptions](../../com.aspose.page.plugins/ipluginoptions) | XpsConverter에 대한 지침을 포함하는 옵션 객체입니다. |
+
+**Returns:**
+[ResultContainer](../../com.aspose.page.plugins/resultcontainer) - An ResultContainer object containing the result of the operation.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.plugins/xpsconverteroptions/_index.md
+++ b/korean/java/com.aspose.xps.plugins/xpsconverteroptions/_index.md
@@ -1,0 +1,213 @@
+---
+title: "XpsConverterOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인 옵션의 기본 클래스를 나타냅니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.plugins/xpsconverteroptions/
+---
+**Inheritance:**
+java.lang.Object
+
+**All Implemented Interfaces:**
+[com.aspose.page.plugins.IPluginOptions](../../com.aspose.page.plugins/ipluginoptions), [com.aspose.page.plugins.IDataContainer](../../com.aspose.page.plugins/idatacontainer), [com.aspose.page.plugins.ISaveInstruction](../../com.aspose.page.plugins/isaveinstruction)
+```
+public class XpsConverterOptions implements IPluginOptions, IDataContainer, ISaveInstruction
+```
+
+플러그인 옵션의 기본 클래스를 나타냅니다 [XpsConverter](../../com.aspose.xps.plugins/xpsconverter) 플러그인.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | 새 데이터 소스를 XpsConverter 플러그인 데이터 컬렉션에 추가합니다. |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | 새 데이터 소스를 XpsConverterOptions 플러그인 데이터 컬렉션에 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | XpsConverterOptions 플러그인 데이터 컬렉션을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOperationName()](#getOperationName--) | 작업 이름을 반환합니다. |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+새 데이터 소스를 XpsConverter 플러그인 데이터 컬렉션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 추가할 데이터 소스입니다. |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+새 데이터 소스를 XpsConverterOptions 플러그인 데이터 컬렉션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 저장 작업 결과를 위한 데이터 소스(파일 또는 스트림)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+XpsConverterOptions 플러그인 데이터 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOperationName() {#getOperationName--}
+```
+public String getOperationName()
+```
+
+
+작업 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.plugins/xpsconvertertoimageoptions/_index.md
+++ b/korean/java/com.aspose.xps.plugins/xpsconvertertoimageoptions/_index.md
@@ -1,0 +1,391 @@
+---
+title: "XpsConverterToImageOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인에 대한 XPS에서 이미지로 변환기 옵션을 나타냅니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.plugins/xpsconvertertoimageoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.plugins.XpsConverterOptions](../../com.aspose.xps.plugins/xpsconverteroptions)
+```
+public class XpsConverterToImageOptions extends XpsConverterOptions
+```
+
+플러그인 [XpsConverter](../../com.aspose.xps.plugins/xpsconverter)에 대한 XPS에서 이미지로 변환기 옵션을 나타냅니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsConverterToImageOptions()](#XpsConverterToImageOptions--) | 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다. |
+| [XpsConverterToImageOptions(ImageFormat imageFormat)](#XpsConverterToImageOptions-com.aspose.page.ImageFormat-) | 이미지 형식이 지정된 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다. |
+| [XpsConverterToImageOptions(Dimension size)](#XpsConverterToImageOptions-java.awt.Dimension-) | 결과 이미지의 크기가 지정된 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다. |
+| [XpsConverterToImageOptions(ImageFormat imageFormat, Dimension size)](#XpsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-) | 이미지 형식이 지정된 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | 새 데이터 소스를 XpsConverter 플러그인 데이터 컬렉션에 추가합니다. |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | 새 데이터 소스를 XpsConverterOptions 플러그인 데이터 컬렉션에 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | XpsConverterOptions 플러그인 데이터 컬렉션을 반환합니다. |
+| [getImageFormat()](#getImageFormat--) | 이미지 형식을 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOperationName()](#getOperationName--) | 작업 이름을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 변환할 XPS 문서의 페이지 번호 배열을 가져옵니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다. |
+| [getSize()](#getSize--) | 결과 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 이미지 렌더링을 위한 스무딩 모드를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setImageFormat(ImageFormat imageFormat)](#setImageFormat-com.aspose.page.ImageFormat-) | 이미지 형식을 가져옵니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] pageNumbers)](#setPageNumbers-int---) | 변환할 XPS 문서의 페이지 수 배열을 설정합니다. |
+| [setResolution(int resolution)](#setResolution-int-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 결과 이미지의 크기를 설정합니다. |
+| [setSmoothingMode(SmoothingMode smoothingMode)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 이미지 렌더링을 위한 스무딩 모드를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsConverterToImageOptions() {#XpsConverterToImageOptions--}
+```
+public XpsConverterToImageOptions()
+```
+
+
+새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다.
+
+### XpsConverterToImageOptions(ImageFormat imageFormat) {#XpsConverterToImageOptions-com.aspose.page.ImageFormat-}
+```
+public XpsConverterToImageOptions(ImageFormat imageFormat)
+```
+
+
+이미지 형식이 지정된 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 결과 이미지의 형식입니다. |
+
+### XpsConverterToImageOptions(Dimension size) {#XpsConverterToImageOptions-java.awt.Dimension-}
+```
+public XpsConverterToImageOptions(Dimension size)
+```
+
+
+결과 이미지의 크기가 지정된 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 결과 이미지의 크기입니다. |
+
+### XpsConverterToImageOptions(ImageFormat imageFormat, Dimension size) {#XpsConverterToImageOptions-com.aspose.page.ImageFormat-java.awt.Dimension-}
+```
+public XpsConverterToImageOptions(ImageFormat imageFormat, Dimension size)
+```
+
+
+이미지 형식이 지정된 새로운 [XpsConverterToImageOptions](../../com.aspose.xps.plugins/xpsconvertertoimageoptions) 객체 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 결과 이미지의 형식입니다. |
+| 크기 | java.awt.Dimension |  |
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+새 데이터 소스를 XpsConverter 플러그인 데이터 컬렉션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 추가할 데이터 소스입니다. |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+새 데이터 소스를 XpsConverterOptions 플러그인 데이터 컬렉션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 저장 작업 결과를 위한 데이터 소스(파일 또는 스트림)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+XpsConverterOptions 플러그인 데이터 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getImageFormat() {#getImageFormat--}
+```
+public ImageFormat getImageFormat()
+```
+
+
+이미지 형식을 가져옵니다.
+
+**Returns:**
+[ImageFormat](../../com.aspose.page/imageformat) - An image format.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+작업 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+변환할 XPS 문서의 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - XPS 문서의 페이지 수 배열입니다.
+### getResolution() {#getResolution--}
+```
+public int getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+int - 이미지 해상도입니다.
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+결과 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 이미지 크기입니다.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+이미지 렌더링을 위한 스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - A smoothing mode.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setImageFormat(ImageFormat imageFormat) {#setImageFormat-com.aspose.page.ImageFormat-}
+```
+public void setImageFormat(ImageFormat imageFormat)
+```
+
+
+이미지 형식을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imageFormat | [ImageFormat](../../com.aspose.page/imageformat) | 결과 이미지의 형식입니다. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] pageNumbers) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] pageNumbers)
+```
+
+
+변환할 XPS 문서의 페이지 수 배열을 설정합니다. 설정하지 않으면 모든 페이지가 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageNumbers | int[] | XPS 문서의 페이지 수 배열. |
+
+### setResolution(int resolution) {#setResolution-int-}
+```
+public void setResolution(int resolution)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 해상도 | int | 결과 이미지의 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+결과 이미지의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 결과 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode smoothingMode) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode smoothingMode)
+```
+
+
+이미지 렌더링을 위한 스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| smoothingMode | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 스무딩 모드. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.plugins/xpsconvertertopdfoptions/_index.md
+++ b/korean/java/com.aspose.xps.plugins/xpsconvertertopdfoptions/_index.md
@@ -1,0 +1,248 @@
+---
+title: "XpsConverterToPdfOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "플러그인에 대한 XPS에서 PDF 변환 옵션을 나타냅니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.plugins/xpsconvertertopdfoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.plugins.XpsConverterOptions](../../com.aspose.xps.plugins/xpsconverteroptions)
+```
+public class XpsConverterToPdfOptions extends XpsConverterOptions
+```
+
+플러그인에 대한 XPS에서 PDF 변환 옵션을 나타냅니다 [XpsConverter](../../com.aspose.xps.plugins/xpsconverter) 플러그인.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsConverterToPdfOptions()](#XpsConverterToPdfOptions--) | 새 인스턴스를 초기화합니다 [XpsConverterToPdfOptions](../../com.aspose.xps.plugins/xpsconvertertopdfoptions) 객체. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [addDataSource(IDataSource dataSource)](#addDataSource-com.aspose.page.plugins.IDataSource-) | 새 데이터 소스를 XpsConverter 플러그인 데이터 컬렉션에 추가합니다. |
+| [addSaveDataSource(IDataSource saveDataSource)](#addSaveDataSource-com.aspose.page.plugins.IDataSource-) | 새 데이터 소스를 XpsConverterOptions 플러그인 데이터 컬렉션에 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDataCollection()](#getDataCollection--) | XpsConverterOptions 플러그인 데이터 컬렉션을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOperationName()](#getOperationName--) | 작업 이름을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 변환할 XPS 문서의 페이지 번호 배열을 가져옵니다. |
+| [getSaveTargetsCollection()](#getSaveTargetsCollection--) | 저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] pageNumbers)](#setPageNumbers-int---) | 변환할 XPS 문서의 페이지 수 배열을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsConverterToPdfOptions() {#XpsConverterToPdfOptions--}
+```
+public XpsConverterToPdfOptions()
+```
+
+
+새 인스턴스를 초기화합니다 [XpsConverterToPdfOptions](../../com.aspose.xps.plugins/xpsconvertertopdfoptions) 객체.
+
+### addDataSource(IDataSource dataSource) {#addDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addDataSource(IDataSource dataSource)
+```
+
+
+새 데이터 소스를 XpsConverter 플러그인 데이터 컬렉션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| dataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 추가할 데이터 소스입니다. |
+
+### addSaveDataSource(IDataSource saveDataSource) {#addSaveDataSource-com.aspose.page.plugins.IDataSource-}
+```
+public final void addSaveDataSource(IDataSource saveDataSource)
+```
+
+
+새 데이터 소스를 XpsConverterOptions 플러그인 데이터 컬렉션에 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| saveDataSource | [IDataSource](../../com.aspose.page.plugins/idatasource) | 저장 작업 결과를 위한 데이터 소스(파일 또는 스트림)입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDataCollection() {#getDataCollection--}
+```
+public final List<IDataSource> getDataCollection()
+```
+
+
+XpsConverterOptions 플러그인 데이터 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOperationName() {#getOperationName--}
+```
+public final String getOperationName()
+```
+
+
+작업 이름을 반환합니다.
+
+**Returns:**
+java.lang.String
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+변환할 XPS 문서의 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - XPS 문서의 페이지 수 배열입니다.
+### getSaveTargetsCollection() {#getSaveTargetsCollection--}
+```
+public final List<IDataSource> getSaveTargetsCollection()
+```
+
+
+저장 작업 결과를 위한 추가된 대상 컬렉션을 가져옵니다.
+
+**Returns:**
+java.util.List<com.aspose.page.plugins.IDataSource>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] pageNumbers) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] pageNumbers)
+```
+
+
+변환할 XPS 문서의 페이지 수 배열을 설정합니다. 설정하지 않으면 모든 페이지가 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageNumbers | int[] | XPS 문서의 페이지 수 배열. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/_index.md
+++ b/korean/java/com.aspose.xps.rendering/_index.md
@@ -1,0 +1,42 @@
+---
+title: "com.aspose.xps.rendering"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.xps.rendering 패키지는 XPS 문서를 다른 형식으로 렌더링하기 위한 기본 클래스를 제공합니다."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.xps.rendering/
+---
+
+**com.aspose.xps.rendering** 패키지는 XPS 문서를 다른 형식으로 렌더링하기 위한 기본 클래스를 제공합니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [BmpSaveOptions](../com.aspose.xps.rendering/bmpsaveoptions) | XPS-as-BMP 저장 옵션에 대한 클래스. |
+| [ImageSaveOptions](../com.aspose.xps.rendering/imagesaveoptions) | XPS-as-image 저장 옵션에 대한 기본 클래스. |
+| [JpegSaveOptions](../com.aspose.xps.rendering/jpegsaveoptions) | XPS-as-JPEG 저장 옵션에 대한 클래스. |
+| [PdfEncryptionDetails](../com.aspose.xps.rendering/pdfencryptiondetails) | pdf 암호화에 대한 세부 정보를 포함합니다. |
+| [PdfSaveOptions](../com.aspose.xps.rendering/pdfsaveoptions) | XPS-as-PDF 저장 옵션에 대한 클래스. |
+| [PngSaveOptions](../com.aspose.xps.rendering/pngsaveoptions) | XPS-as-PNG 저장 옵션에 대한 클래스. |
+| [TiffSaveOptions](../com.aspose.xps.rendering/tiffsaveoptions) | XPS-as-TIFF 저장 옵션에 대한 클래스. |
+
+## 인터페이스
+
+| 인터페이스 | 설명 |
+| --- | --- |
+| [IEventBasedModificationOptions](../com.aspose.xps.rendering/ieventbasedmodificationoptions) | 문서 저장 중 이벤트 기반 수정 처리를 위한 관련 옵션을 정의합니다. |
+| [IPipelineOptions](../com.aspose.xps.rendering/ipipelineoptions) | 파이프라인 구성과 관련된 변환 옵션을 정의합니다. |
+| [IXpsTextConversionOptions](../com.aspose.xps.rendering/ixpstextconversionoptions) | XPS를 다른 형식으로 변환하기 위한 옵션을 정의합니다. |
+
+## 열거형
+
+| 열거형 | 설명 |
+| --- | --- |
+| [InterpolationMode](../com.aspose.xps.rendering/interpolationmode) | 이미지를 확대/축소하거나 회전할 때 사용되는 알고리즘을 지정합니다. |
+| [PdfEncryptionAlgorithm](../com.aspose.xps.rendering/pdfencryptionalgorithm) | 암호화 모드 열거형. |
+| [PdfImageCompression](../com.aspose.xps.rendering/pdfimagecompression) | PDF 파일의 이미지에 적용되는 압축 유형을 지정합니다. |
+| [PdfTextCompression](../com.aspose.xps.rendering/pdftextcompression) | 이미지를 제외한 PDF 파일의 모든 콘텐츠에 적용되는 압축 유형을 지정합니다. |
+| [SmoothingMode](../com.aspose.xps.rendering/smoothingmode) | 선과 곡선 및 채워진 영역의 가장자리에 스무딩(앤티앨리어싱)이 적용되는지 여부를 지정합니다. |
+| [TextRenderingHint](../com.aspose.xps.rendering/textrenderinghint) | 텍스트 렌더링 품질을 지정합니다. |

--- a/korean/java/com.aspose.xps.rendering/bmpsaveoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/bmpsaveoptions/_index.md
@@ -1,0 +1,484 @@
+---
+title: "BmpSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS-as-BMP 저장 옵션에 대한 클래스."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps.rendering/bmpsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class BmpSaveOptions extends ImageSaveOptions
+```
+
+XPS-as-BMP 저장 옵션에 대한 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [BmpSaveOptions()](#BmpSaveOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBatchSize()](#getBatchSize--) | 노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다. |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageSize()](#getImageSize--) | 출력 이미지의 크기를 픽셀 단위로 가져옵니다. |
+| [getInterpolationMode()](#getInterpolationMode--) | 보간 모드를 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 렌더링할 페이지 번호 배열을 가져옵니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 스무딩 모드를 가져옵니다. |
+| [getTextRenderingHint()](#getTextRenderingHint--) | 텍스트 렌더링 힌트를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBatchSize(int value)](#setBatchSize-int-) | 노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 출력 이미지의 크기를 픽셀 단위로 설정합니다. |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 보간 모드를 설정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | 렌더링할 페이지 번호 배열을 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | 텍스트 렌더링 힌트를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BmpSaveOptions() {#BmpSaveOptions--}
+```
+public BmpSaveOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다.
+
+**Returns:**
+int - 노드에서 노드로 전달할 페이지 부분의 크기.
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 출력 이미지의 크기(픽셀).
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+보간 모드를 가져옵니다.
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+렌더링할 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - 페이지 수.
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+float - 이미지 해상도.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+텍스트 렌더링 힌트를 가져옵니다.
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 노드 간에 전달되는 페이지 일부의 크기. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Dimension | 출력 이미지의 크기(픽셀 단위). |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+보간 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 보간 모드. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+렌더링할 페이지 번호 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int[] | 페이지 수. |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 이미지 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 스무딩 모드. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+텍스트 렌더링 힌트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | 텍스트 렌더링 힌트. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/ieventbasedmodificationoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/ieventbasedmodificationoptions/_index.md
@@ -1,0 +1,27 @@
+---
+title: "IEventBasedModificationOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서 저장 중 이벤트 기반 수정 처리를 위한 관련 옵션을 정의합니다."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.xps.rendering/ieventbasedmodificationoptions/
+---```
+public interface IEventBasedModificationOptions
+```
+
+Defines options relevant to handling event-based modifications during document saving.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | Returns the collection of event handlers that performs modifications to an XPS page just before it is saved. |
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public abstract List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+Returns the collection of event handlers that performs modifications to an XPS page just before it is saved.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler> - The collection of event handlers that performs modifications to an XPS page just before it is saved.

--- a/korean/java/com.aspose.xps.rendering/imagesaveoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/imagesaveoptions/_index.md
@@ -1,0 +1,487 @@
+---
+title: "ImageSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS-as-image 저장 옵션에 대한 기본 클래스."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps.rendering/imagesaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+
+**All Implemented Interfaces:**
+[com.aspose.page.IMultiPageSaveOptions](../../com.aspose.page/imultipagesaveoptions), [com.aspose.xps.rendering.IPipelineOptions](../../com.aspose.xps.rendering/ipipelineoptions), [com.aspose.xps.rendering.IEventBasedModificationOptions](../../com.aspose.xps.rendering/ieventbasedmodificationoptions)
+```
+public abstract class ImageSaveOptions extends SaveOptions implements IMultiPageSaveOptions, IPipelineOptions, IEventBasedModificationOptions
+```
+
+XPS-as-image 저장 옵션에 대한 기본 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [ImageSaveOptions()](#ImageSaveOptions--) | 옵션의 새 인스턴스를 생성합니다 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBatchSize()](#getBatchSize--) | 노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다. |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageSize()](#getImageSize--) | 출력 이미지의 크기를 픽셀 단위로 가져옵니다. |
+| [getInterpolationMode()](#getInterpolationMode--) | 보간 모드를 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 렌더링할 페이지 번호 배열을 가져옵니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 스무딩 모드를 가져옵니다. |
+| [getTextRenderingHint()](#getTextRenderingHint--) | 텍스트 렌더링 힌트를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBatchSize(int value)](#setBatchSize-int-) | 노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 출력 이미지의 크기를 픽셀 단위로 설정합니다. |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 보간 모드를 설정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | 렌더링할 페이지 번호 배열을 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | 텍스트 렌더링 힌트를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### ImageSaveOptions() {#ImageSaveOptions--}
+```
+public ImageSaveOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다.
+
+**Returns:**
+int - 노드에서 노드로 전달할 페이지 부분의 크기.
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 출력 이미지의 크기(픽셀).
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+보간 모드를 가져옵니다.
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+렌더링할 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - 페이지 수.
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+float - 이미지 해상도.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+텍스트 렌더링 힌트를 가져옵니다.
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 노드 간에 전달되는 페이지 일부의 크기. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Dimension | 출력 이미지의 크기(픽셀 단위). |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+보간 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 보간 모드. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+렌더링할 페이지 번호 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int[] | 페이지 수. |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 이미지 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 스무딩 모드. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+텍스트 렌더링 힌트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | 텍스트 렌더링 힌트. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/interpolationmode/_index.md
+++ b/korean/java/com.aspose.xps.rendering/interpolationmode/_index.md
@@ -1,0 +1,304 @@
+---
+title: "InterpolationMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이미지를 확대/축소하거나 회전할 때 사용되는 알고리즘을 지정합니다."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.xps.rendering/interpolationmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum InterpolationMode extends Enum<InterpolationMode>
+```
+
+이미지를 확대/축소하거나 회전할 때 사용되는 알고리즘을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Bicubic](#Bicubic) | 바이큐빅 보간을 지정합니다. |
+| [Bilinear](#Bilinear) | 양선형 보간을 지정합니다. |
+| [Default](#Default) | 기본 모드를 지정합니다. |
+| [High](#High) | 고품질 보간을 지정합니다. |
+| [HighQualityBicubic](#HighQualityBicubic) | 고품질 바이큐빅 보간을 지정합니다. |
+| [HighQualityBilinear](#HighQualityBilinear) | 고품질 양선형 보간을 지정합니다. |
+| [Low](#Low) | 저품질 보간을 지정합니다. |
+| [NearestNeighbor](#NearestNeighbor) | 최근접 이웃 보간을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bicubic {#Bicubic}
+```
+public static final InterpolationMode Bicubic
+```
+
+
+바이큐빅 보간을 지정합니다. 사전 필터링이 수행되지 않습니다. 이 모드는 이미지 크기를 원본 크기의 25% 이하로 축소하는 경우에 적합하지 않습니다.
+
+### Bilinear {#Bilinear}
+```
+public static final InterpolationMode Bilinear
+```
+
+
+양선형 보간을 지정합니다. 사전 필터링이 수행되지 않습니다. 이 모드는 이미지 크기를 원본 크기의 50% 이하로 축소하는 경우에 적합하지 않습니다.
+
+### Default {#Default}
+```
+public static final InterpolationMode Default
+```
+
+
+기본 모드를 지정합니다.
+
+### High {#High}
+```
+public static final InterpolationMode High
+```
+
+
+고품질 보간을 지정합니다.
+
+### HighQualityBicubic {#HighQualityBicubic}
+```
+public static final InterpolationMode HighQualityBicubic
+```
+
+
+고품질 바이큐빅 보간을 지정합니다. 고품질 축소를 보장하기 위해 사전 필터링이 수행됩니다. 이 모드는 가장 높은 품질의 변환된 이미지를 생성합니다.
+
+### HighQualityBilinear {#HighQualityBilinear}
+```
+public static final InterpolationMode HighQualityBilinear
+```
+
+
+고품질 양선형 보간을 지정합니다. 고품질 축소를 보장하기 위해 사전 필터링이 수행됩니다.
+
+### Low {#Low}
+```
+public static final InterpolationMode Low
+```
+
+
+저품질 보간을 지정합니다.
+
+### NearestNeighbor {#NearestNeighbor}
+```
+public static final InterpolationMode NearestNeighbor
+```
+
+
+최근접 이웃 보간을 지정합니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static InterpolationMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode)
+### values() {#values--}
+```
+public static InterpolationMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.InterpolationMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/ipipelineoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/ipipelineoptions/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IPipelineOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "파이프라인 구성과 관련된 변환 옵션을 정의합니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.xps.rendering/ipipelineoptions/
+---```
+public interface IPipelineOptions
+```
+
+Defines conversion options related to pipeline configuration.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [getBatchSize()](#getBatchSize--) | Returns the size of a portion of pages to pass from node to node. |
+| [setBatchSize(int value)](#setBatchSize-int-) | Sets the size of a portion of pages to pass from node to node. |
+### getBatchSize() {#getBatchSize--}
+```
+public abstract int getBatchSize()
+```
+
+
+Returns the size of a portion of pages to pass from node to node.
+
+**Returns:**
+int - The size of a portion of pages to pass from node to node.
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public abstract void setBatchSize(int value)
+```
+
+
+Sets the size of a portion of pages to pass from node to node.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | int | The size of a portion of pages to pass from node to node. |
+

--- a/korean/java/com.aspose.xps.rendering/ixpstextconversionoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/ixpstextconversionoptions/_index.md
@@ -1,0 +1,41 @@
+---
+title: "IXpsTextConversionOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS를 다른 형식으로 변환하기 위한 옵션을 정의합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.xps.rendering/ixpstextconversionoptions/
+---```
+public interface IXpsTextConversionOptions
+```
+
+Defines options for conversion of XPS to other formats.
+## Methods
+
+| Method | Description |
+| --- | --- |
+| [preserveText()](#preserveText--) | In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. |
+| [preserveText(boolean value)](#preserveText-boolean-) | In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. |
+### preserveText() {#preserveText--}
+```
+public abstract boolean preserveText()
+```
+
+
+In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. If this flag is set to true, the text from such XPS elements is converted to graphic shapes. Then the text itself appears transparent on top. This leaves the text of such elements selectable. But the side effect is that the output file may be much larger than the original. If this flag is set to false, the characters that should be displayed as alternate forms are replaced with some other characters that become mapped to the alternate glyph forms. Therefore the text, although still selectable, will be modified and likely become unreadable.
+
+**Returns:**
+boolean - The flag value.
+### preserveText(boolean value) {#preserveText-boolean-}
+```
+public abstract void preserveText(boolean value)
+```
+
+
+In XPS, some text elements may contain references to alternate glyph forms that do not correspond to any character code in the font. If this flag is set to true, the text from such XPS elements is converted to graphic shapes. Then the text itself appears transparent on top. This leaves the text of such elements selectable. But the side effect is that the output file may be much larger than the original. If this flag is set to false, the characters that should be displayed as alternate forms are replaced with some other characters that become mapped to the alternate glyph forms. Therefore the text, although still selectable, will be modified and likely become unreadable.
+
+**Parameters:**
+| Parameter | Type | Description |
+| --- | --- | --- |
+| value | boolean | The flag value. |
+

--- a/korean/java/com.aspose.xps.rendering/jpegsaveoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/jpegsaveoptions/_index.md
@@ -1,0 +1,484 @@
+---
+title: "JpegSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS-as-JPEG 저장 옵션에 대한 클래스."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps.rendering/jpegsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class JpegSaveOptions extends ImageSaveOptions
+```
+
+XPS-as-JPEG 저장 옵션에 대한 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [JpegSaveOptions()](#JpegSaveOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBatchSize()](#getBatchSize--) | 노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다. |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageSize()](#getImageSize--) | 출력 이미지의 크기를 픽셀 단위로 가져옵니다. |
+| [getInterpolationMode()](#getInterpolationMode--) | 보간 모드를 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 렌더링할 페이지 번호 배열을 가져옵니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 스무딩 모드를 가져옵니다. |
+| [getTextRenderingHint()](#getTextRenderingHint--) | 텍스트 렌더링 힌트를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBatchSize(int value)](#setBatchSize-int-) | 노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 출력 이미지의 크기를 픽셀 단위로 설정합니다. |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 보간 모드를 설정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | 렌더링할 페이지 번호 배열을 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | 텍스트 렌더링 힌트를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### JpegSaveOptions() {#JpegSaveOptions--}
+```
+public JpegSaveOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다.
+
+**Returns:**
+int - 노드에서 노드로 전달할 페이지 부분의 크기.
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 출력 이미지의 크기(픽셀).
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+보간 모드를 가져옵니다.
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+렌더링할 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - 페이지 수.
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+float - 이미지 해상도.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+텍스트 렌더링 힌트를 가져옵니다.
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 노드 간에 전달되는 페이지 일부의 크기. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Dimension | 출력 이미지의 크기(픽셀 단위). |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+보간 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 보간 모드. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+렌더링할 페이지 번호 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int[] | 페이지 수. |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 이미지 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 스무딩 모드. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+텍스트 렌더링 힌트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | 텍스트 렌더링 힌트. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/pdfencryptionalgorithm/_index.md
+++ b/korean/java/com.aspose.xps.rendering/pdfencryptionalgorithm/_index.md
@@ -1,0 +1,250 @@
+---
+title: "PdfEncryptionAlgorithm"
+second_title: "Aspose.Page용 Java API 참조"
+description: "암호화 모드 열거형."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.xps.rendering/pdfencryptionalgorithm/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PdfEncryptionAlgorithm extends Enum<PdfEncryptionAlgorithm>
+```
+
+암호화 모드 열거형. 알고리즘 및 키 길이를 설명합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [RC4_128](#RC4-128) | 알고리즘, RC4 암호화 키 길이가 128비트이고 고급 권한 집합을 사용합니다; |
+| [RC4_40](#RC4-40) | 알고리즘, RC4 암호화 키 길이가 40비트인 경우; |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### RC4_128 {#RC4-128}
+```
+public static final PdfEncryptionAlgorithm RC4_128
+```
+
+
+알고리즘, RC4 암호화 키 길이가 128비트이고 고급 권한 집합을 사용합니다;
+
+### RC4_40 {#RC4-40}
+```
+public static final PdfEncryptionAlgorithm RC4_40
+```
+
+
+알고리즘, RC4 암호화 키 길이가 40비트인 경우;
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PdfEncryptionAlgorithm valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm)
+### values() {#values--}
+```
+public static PdfEncryptionAlgorithm[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.PdfEncryptionAlgorithm[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/pdfencryptiondetails/_index.md
+++ b/korean/java/com.aspose.xps.rendering/pdfencryptiondetails/_index.md
@@ -1,0 +1,253 @@
+---
+title: "PdfEncryptionDetails"
+second_title: "Aspose.Page용 Java API 참조"
+description: "pdf 암호화에 대한 세부 정보를 포함합니다."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps.rendering/pdfencryptiondetails/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class PdfEncryptionDetails
+```
+
+pdf 암호화에 대한 세부 정보를 포함합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PdfEncryptionDetails(String userPassword, String ownerPassword, int permissions, PdfEncryptionAlgorithm encryptionAlgorithm)](#PdfEncryptionDetails-java.lang.String-java.lang.String-int-com.aspose.xps.rendering.PdfEncryptionAlgorithm-) | PdfEncryptionDetailsCore 클래스의 새 인스턴스를 초기화합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getEncryptionAlgorithm()](#getEncryptionAlgorithm--) | 암호화 모드를 반환합니다. |
+| [getOwnerPassword()](#getOwnerPassword--) | 소유자 비밀번호를 반환합니다. |
+| [getPermissions()](#getPermissions--) | 권한을 반환합니다. |
+| [getUserPassword()](#getUserPassword--) | 사용자 비밀번호를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setEncryptionAlgorithm(PdfEncryptionAlgorithm value)](#setEncryptionAlgorithm-com.aspose.xps.rendering.PdfEncryptionAlgorithm-) | 암호화 모드를 설정합니다. |
+| [setOwnerPassword(String value)](#setOwnerPassword-java.lang.String-) | 소유자 비밀번호를 설정합니다. |
+| [setPermissions(int value)](#setPermissions-int-) | 권한을 설정합니다. |
+| [setUserPassword(String value)](#setUserPassword-java.lang.String-) | 사용자 비밀번호를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfEncryptionDetails(String userPassword, String ownerPassword, int permissions, PdfEncryptionAlgorithm encryptionAlgorithm) {#PdfEncryptionDetails-java.lang.String-java.lang.String-int-com.aspose.xps.rendering.PdfEncryptionAlgorithm-}
+```
+public PdfEncryptionDetails(String userPassword, String ownerPassword, int permissions, PdfEncryptionAlgorithm encryptionAlgorithm)
+```
+
+
+PdfEncryptionDetailsCore 클래스의 새 인스턴스를 초기화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| userPassword | java.lang.String | 사용자 비밀번호입니다. |
+| ownerPassword | java.lang.String | 소유자 비밀번호입니다. |
+| permissions | int | 권한입니다. |
+| encryptionAlgorithm | [PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm) | 암호화 알고리즘입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getEncryptionAlgorithm() {#getEncryptionAlgorithm--}
+```
+public PdfEncryptionAlgorithm getEncryptionAlgorithm()
+```
+
+
+암호화 모드를 반환합니다.
+
+**Returns:**
+[PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm) - The encryption algorithm.
+### getOwnerPassword() {#getOwnerPassword--}
+```
+public String getOwnerPassword()
+```
+
+
+소유자 비밀번호를 반환합니다.
+
+올바른 소유자 비밀번호(사용자 비밀번호와 다르다고 가정)로 문서를 열면 문서에 대한 전체(소유자) 접근 권한이 부여됩니다. 이 무제한 접근 권한에는 문서\u2019의 비밀번호 및 접근 권한을 변경할 수 있는 기능이 포함됩니다.
+
+**Returns:**
+java.lang.String - 소유자 비밀번호.
+### getPermissions() {#getPermissions--}
+```
+public int getPermissions()
+```
+
+
+권한을 반환합니다.
+
+**Returns:**
+int - 권한.
+### getUserPassword() {#getUserPassword--}
+```
+public String getUserPassword()
+```
+
+
+사용자 비밀번호를 반환합니다.
+
+올바른 사용자 비밀번호로 문서를 열면(또는 사용자 비밀번호가 없는 문서를 열 경우) 문서의 암호화 사전에서 지정된 사용자 접근 권한에 따라 추가 작업을 수행할 수 있습니다.
+
+**Returns:**
+java.lang.String - 사용자 비밀번호.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setEncryptionAlgorithm(PdfEncryptionAlgorithm value) {#setEncryptionAlgorithm-com.aspose.xps.rendering.PdfEncryptionAlgorithm-}
+```
+public void setEncryptionAlgorithm(PdfEncryptionAlgorithm value)
+```
+
+
+암호화 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PdfEncryptionAlgorithm](../../com.aspose.xps.rendering/pdfencryptionalgorithm) | 암호화 알고리즘입니다. |
+
+### setOwnerPassword(String value) {#setOwnerPassword-java.lang.String-}
+```
+public void setOwnerPassword(String value)
+```
+
+
+소유자 비밀번호를 설정합니다.
+
+올바른 소유자 비밀번호(사용자 비밀번호와 다르다고 가정)로 문서를 열면 문서에 대한 전체(소유자) 접근 권한이 부여됩니다. 이 무제한 접근 권한에는 문서\u2019의 비밀번호 및 접근 권한을 변경할 수 있는 기능이 포함됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 소유자 비밀번호입니다. |
+
+### setPermissions(int value) {#setPermissions-int-}
+```
+public void setPermissions(int value)
+```
+
+
+권한을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 권한입니다. |
+
+### setUserPassword(String value) {#setUserPassword-java.lang.String-}
+```
+public void setUserPassword(String value)
+```
+
+
+사용자 비밀번호를 설정합니다.
+
+올바른 사용자 비밀번호로 문서를 열면(또는 사용자 비밀번호가 없는 문서를 열 경우) 문서의 암호화 사전에서 지정된 사용자 접근 권한에 따라 추가 작업을 수행할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 사용자 비밀번호입니다. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/pdfimagecompression/_index.md
+++ b/korean/java/com.aspose.xps.rendering/pdfimagecompression/_index.md
@@ -1,0 +1,295 @@
+---
+title: "PdfImageCompression"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PDF 파일의 이미지에 적용되는 압축 유형을 지정합니다."
+type: docs
+weight: 22
+url: /ko/java/com.aspose.xps.rendering/pdfimagecompression/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PdfImageCompression extends Enum<PdfImageCompression>
+```
+
+PDF 파일의 이미지에 적용되는 압축 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Auto](#Auto) | 각 이미지에 가장 적합한 압축을 자동으로 선택합니다. |
+| [Flate](#Flate) | Flate 압축. |
+| [Jpeg](#Jpeg) | JPEG 압축. |
+| [LzwBaselinePredictor](#LzwBaselinePredictor) | 예측기 선택이 PNG Paeth 예측기로 제한되어 프로세스 속도가 빨라집니다. |
+| [LzwOptimizedPredictor](#LzwOptimizedPredictor) | 예측기 선택이 더 복잡해져 이미지 크기가 더 작아지지만 시간이 더 오래 걸립니다. |
+| [None](#None) | 원시 이미지 바이트를 저장하여 PDF 파일 크기가 커집니다. |
+| [Rle](#Rle) | Run Length 압축. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Auto {#Auto}
+```
+public static final PdfImageCompression Auto
+```
+
+
+각 이미지에 가장 적합한 압축을 자동으로 선택합니다.
+
+### Flate {#Flate}
+```
+public static final PdfImageCompression Flate
+```
+
+
+Flate 압축.
+
+### Jpeg {#Jpeg}
+```
+public static final PdfImageCompression Jpeg
+```
+
+
+JPEG 압축. 투명도를 지원하지 않습니다.
+
+### LzwBaselinePredictor {#LzwBaselinePredictor}
+```
+public static final PdfImageCompression LzwBaselinePredictor
+```
+
+
+예측기 선택이 PNG Paeth 예측기로 제한되어 프로세스 속도가 빨라집니다. 실제로는 놀라울 정도로 좋은 성능을 보이며 LzwOptimizedPredictor보다 우수합니다.
+
+### LzwOptimizedPredictor {#LzwOptimizedPredictor}
+```
+public static final PdfImageCompression LzwOptimizedPredictor
+```
+
+
+예측기 선택이 더 복잡해져 이미지 크기가 더 작아지지만 시간이 더 오래 걸립니다.
+
+### None {#None}
+```
+public static final PdfImageCompression None
+```
+
+
+원시 이미지 바이트를 저장하여 PDF 파일 크기가 커집니다.
+
+### Rle {#Rle}
+```
+public static final PdfImageCompression Rle
+```
+
+
+Run Length 압축.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PdfImageCompression valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[PdfImageCompression](../../com.aspose.xps.rendering/pdfimagecompression)
+### values() {#values--}
+```
+public static PdfImageCompression[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.PdfImageCompression[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/pdfsaveoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/pdfsaveoptions/_index.md
@@ -1,0 +1,512 @@
+---
+title: "PdfSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS-as-PDF 저장 옵션에 대한 클래스."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps.rendering/pdfsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions)
+
+**All Implemented Interfaces:**
+[com.aspose.page.IMultiPageSaveOptions](../../com.aspose.page/imultipagesaveoptions), [com.aspose.xps.rendering.IXpsTextConversionOptions](../../com.aspose.xps.rendering/ixpstextconversionoptions), [com.aspose.xps.rendering.IPipelineOptions](../../com.aspose.xps.rendering/ipipelineoptions), [com.aspose.xps.rendering.IEventBasedModificationOptions](../../com.aspose.xps.rendering/ieventbasedmodificationoptions)
+```
+public class PdfSaveOptions extends SaveOptions implements IMultiPageSaveOptions, IXpsTextConversionOptions, IPipelineOptions, IEventBasedModificationOptions
+```
+
+XPS-as-PDF 저장 옵션에 대한 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PdfSaveOptions()](#PdfSaveOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBatchSize()](#getBatchSize--) | 노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다. |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getEncryptionDetails()](#getEncryptionDetails--) | 암호화 세부 정보를 반환합니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageCompression()](#getImageCompression--) | 문서의 모든 이미지에 사용될 압축 유형을 반환합니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getOutlineTreeExpansionLevel()](#getOutlineTreeExpansionLevel--) | PDF 파일을 뷰어에서 열었을 때 문서 개요가 확장될 최대 수준을 가져옵니다. 1 - 첫 번째 수준 개요 항목만 표시되고, 2 - 첫 번째와 두 번째 수준 개요 항목만 표시되며, 이하 동일. |
+| [getOutlineTreeHeight()](#getOutlineTreeHeight--) | 저장할 문서 개요 트리의 높이를 가져옵니다. 0 - 개요 트리가 변환되지 않으며, 1 - 첫 번째 수준 개요 항목만 변환되고, 이하 동일. |
+| [getPageNumbers()](#getPageNumbers--) | 렌더링할 페이지 번호 배열을 가져옵니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getTextCompression()](#getTextCompression--) | 이미지를 제외한 모든 콘텐츠 스트림에 사용될 압축 유형을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [preserveText()](#preserveText--) | XPS에서는 일부 텍스트 요소가 글꼴의 문자 코드와 일치하지 않는 대체 글리프 형태에 대한 참조를 포함할 수 있습니다. |
+| [preserveText(boolean value)](#preserveText-boolean-) | XPS에서는 일부 텍스트 요소가 글꼴의 문자 코드와 일치하지 않는 대체 글리프 형태에 대한 참조를 포함할 수 있습니다. |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBatchSize(int value)](#setBatchSize-int-) | 노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setEncryptionDetails(PdfEncryptionDetails value)](#setEncryptionDetails-com.aspose.xps.rendering.PdfEncryptionDetails-) | 암호화 세부 정보를 설정합니다. |
+| [setImageCompression(PdfImageCompression value)](#setImageCompression-com.aspose.xps.rendering.PdfImageCompression-) | 문서의 모든 이미지에 사용될 압축 유형을 설정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setOutlineTreeExpansionLevel(int value)](#setOutlineTreeExpansionLevel-int-) | PDF 파일을 뷰어에서 열었을 때 문서 개요가 확장될 최대 수준을 설정합니다. 1 - 첫 번째 수준 개요 항목만 표시되고, 2 - 첫 번째와 두 번째 수준 개요 항목만 표시되며, 이하 동일. |
+| [setOutlineTreeHeight(int value)](#setOutlineTreeHeight-int-) | 저장할 문서 개요 트리의 높이를 설정합니다. 0 - 개요 트리가 변환되지 않으며, 1 - 첫 번째 수준 개요 항목만 변환되고, 이하 동일. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | 렌더링할 페이지 번호 배열을 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTextCompression(PdfTextCompression value)](#setTextCompression-com.aspose.xps.rendering.PdfTextCompression-) | 이미지를 제외한 모든 콘텐츠 스트림에 사용될 압축 유형을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PdfSaveOptions() {#PdfSaveOptions--}
+```
+public PdfSaveOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다.
+
+**Returns:**
+int - 노드에서 노드로 전달할 페이지 부분의 크기.
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler> - 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getEncryptionDetails() {#getEncryptionDetails--}
+```
+public PdfEncryptionDetails getEncryptionDetails()
+```
+
+
+암호화 세부 정보를 반환합니다. 설정되지 않은 경우 암호화가 수행되지 않습니다.
+
+**Returns:**
+[PdfEncryptionDetails](../../com.aspose.xps.rendering/pdfencryptiondetails) - The encryption details.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageCompression() {#getImageCompression--}
+```
+public PdfImageCompression getImageCompression()
+```
+
+
+문서의 모든 이미지에 사용될 압축 유형을 반환합니다. 기본값은 PdfImageCompression.Auto 입니다.
+
+**Returns:**
+[PdfImageCompression](../../com.aspose.xps.rendering/pdfimagecompression) - The compression type.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getOutlineTreeExpansionLevel() {#getOutlineTreeExpansionLevel--}
+```
+public int getOutlineTreeExpansionLevel()
+```
+
+
+PDF 파일을 뷰어에서 열었을 때 문서 개요가 확장될 최대 수준을 가져옵니다. 1 - 첫 번째 수준 개요 항목만 표시되고, 2 - 첫 번째와 두 번째 수준 개요 항목만 표시되며, 이하 동일.
+
+**Returns:**
+int - 개요 트리 확장 수준.
+### getOutlineTreeHeight() {#getOutlineTreeHeight--}
+```
+public int getOutlineTreeHeight()
+```
+
+
+저장할 문서 개요 트리의 높이를 가져옵니다. 0 - 개요 트리가 변환되지 않으며, 1 - 첫 번째 수준 개요 항목만 변환되고, 이하 동일합니다. 기본값은 10입니다.
+
+**Returns:**
+int - 개요 트리 높이.
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+렌더링할 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - 페이지 수.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getTextCompression() {#getTextCompression--}
+```
+public PdfTextCompression getTextCompression()
+```
+
+
+이미지를 제외한 모든 콘텐츠 스트림에 사용될 압축 유형을 반환합니다. 기본값은 PdfTextCompression.Flate 입니다.
+
+**Returns:**
+[PdfTextCompression](../../com.aspose.xps.rendering/pdftextcompression) - The compression type.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### preserveText() {#preserveText--}
+```
+public boolean preserveText()
+```
+
+
+XPS에서는 일부 텍스트 요소가 글꼴의 어떤 문자 코드와도 일치하지 않는 대체 글리프 형태에 대한 참조를 포함할 수 있습니다. 이 플래그가 true로 설정되면 해당 XPS 요소의 텍스트가 그래픽 형태로 변환됩니다. 그런 다음 텍스트 자체는 위에 투명하게 표시됩니다. 이렇게 하면 해당 요소의 텍스트를 선택할 수 있게 됩니다. 그러나 부작용으로 출력 파일이 원본보다 훨씬 커질 수 있습니다. 이 플래그가 false로 설정되면 대체 형태로 표시되어야 하는 문자가 다른 문자로 교체되어 대체 글리프 형태에 매핑됩니다. 따라서 텍스트는 여전히 선택 가능하지만 수정되어 읽기 어려워질 가능성이 높습니다.
+
+**Returns:**
+boolean - 플래그 값.
+### preserveText(boolean value) {#preserveText-boolean-}
+```
+public void preserveText(boolean value)
+```
+
+
+XPS에서는 일부 텍스트 요소가 글꼴의 어떤 문자 코드와도 일치하지 않는 대체 글리프 형태에 대한 참조를 포함할 수 있습니다. 이 플래그가 true로 설정되면 해당 XPS 요소의 텍스트가 그래픽 형태로 변환됩니다. 그런 다음 텍스트 자체는 위에 투명하게 표시됩니다. 이렇게 하면 해당 요소의 텍스트를 선택할 수 있게 됩니다. 그러나 부작용으로 출력 파일이 원본보다 훨씬 커질 수 있습니다. 이 플래그가 false로 설정되면 대체 형태로 표시되어야 하는 문자가 다른 문자로 교체되어 대체 글리프 형태에 매핑됩니다. 따라서 텍스트는 여전히 선택 가능하지만 수정되어 읽기 어려워질 가능성이 높습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 노드 간에 전달되는 페이지 일부의 크기. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setEncryptionDetails(PdfEncryptionDetails value) {#setEncryptionDetails-com.aspose.xps.rendering.PdfEncryptionDetails-}
+```
+public void setEncryptionDetails(PdfEncryptionDetails value)
+```
+
+
+암호화 세부 정보를 설정합니다. 설정되지 않으면 암호화가 수행되지 않습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PdfEncryptionDetails](../../com.aspose.xps.rendering/pdfencryptiondetails) | 암호화 세부 정보. |
+
+### setImageCompression(PdfImageCompression value) {#setImageCompression-com.aspose.xps.rendering.PdfImageCompression-}
+```
+public void setImageCompression(PdfImageCompression value)
+```
+
+
+문서의 모든 이미지에 사용될 압축 유형을 설정합니다. 기본값은 PdfImageCompression.Auto 입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PdfImageCompression](../../com.aspose.xps.rendering/pdfimagecompression) | 압축 유형. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setOutlineTreeExpansionLevel(int value) {#setOutlineTreeExpansionLevel-int-}
+```
+public void setOutlineTreeExpansionLevel(int value)
+```
+
+
+PDF 파일을 뷰어에서 열었을 때 문서 개요가 확장될 최대 수준을 설정합니다. 1 - 첫 번째 수준 개요 항목만 표시되고, 2 - 첫 번째와 두 번째 수준 개요 항목만 표시되며, 이하 동일.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 개요 트리 확장 수준. |
+
+### setOutlineTreeHeight(int value) {#setOutlineTreeHeight-int-}
+```
+public void setOutlineTreeHeight(int value)
+```
+
+
+저장할 문서 개요 트리의 높이를 설정합니다. 0 - 개요 트리가 변환되지 않으며, 1 - 첫 번째 수준 개요 항목만 변환되고, 이하 동일.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 개요 트리 높이. |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+렌더링할 페이지 번호 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int[] | 페이지 수. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTextCompression(PdfTextCompression value) {#setTextCompression-com.aspose.xps.rendering.PdfTextCompression-}
+```
+public void setTextCompression(PdfTextCompression value)
+```
+
+
+이미지를 제외한 모든 콘텐츠 스트림에 사용될 압축 유형을 설정합니다. 기본값은 PdfTextCompression.Flate 입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [PdfTextCompression](../../com.aspose.xps.rendering/pdftextcompression) | 압축 유형. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/pdftextcompression/_index.md
+++ b/korean/java/com.aspose.xps.rendering/pdftextcompression/_index.md
@@ -1,0 +1,268 @@
+---
+title: "PdfTextCompression"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이미지를 제외한 PDF 파일의 모든 콘텐츠에 적용되는 압축 유형을 지정합니다."
+type: docs
+weight: 23
+url: /ko/java/com.aspose.xps.rendering/pdftextcompression/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum PdfTextCompression extends Enum<PdfTextCompression>
+```
+
+이미지를 제외한 PDF 파일의 모든 콘텐츠에 적용되는 압축 유형을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Flate](#Flate) | Flate 압축 유형 |
+| [Lzw](#Lzw) | Lzw 압축 유형 |
+| [None](#None) | 압축 유형 없음 |
+| [Rle](#Rle) | Rle 압축 유형 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Flate {#Flate}
+```
+public static final PdfTextCompression Flate
+```
+
+
+Flate 압축 유형
+
+### Lzw {#Lzw}
+```
+public static final PdfTextCompression Lzw
+```
+
+
+Lzw 압축 유형
+
+### None {#None}
+```
+public static final PdfTextCompression None
+```
+
+
+압축 유형 없음
+
+### Rle {#Rle}
+```
+public static final PdfTextCompression Rle
+```
+
+
+Rle 압축 유형
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static PdfTextCompression valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[PdfTextCompression](../../com.aspose.xps.rendering/pdftextcompression)
+### values() {#values--}
+```
+public static PdfTextCompression[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.PdfTextCompression[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/pngsaveoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/pngsaveoptions/_index.md
@@ -1,0 +1,484 @@
+---
+title: "PngSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS-as-PNG 저장 옵션에 대한 클래스."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.xps.rendering/pngsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class PngSaveOptions extends ImageSaveOptions
+```
+
+XPS-as-PNG 저장 옵션에 대한 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [PngSaveOptions()](#PngSaveOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBatchSize()](#getBatchSize--) | 노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다. |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageSize()](#getImageSize--) | 출력 이미지의 크기를 픽셀 단위로 가져옵니다. |
+| [getInterpolationMode()](#getInterpolationMode--) | 보간 모드를 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 렌더링할 페이지 번호 배열을 가져옵니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 스무딩 모드를 가져옵니다. |
+| [getTextRenderingHint()](#getTextRenderingHint--) | 텍스트 렌더링 힌트를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBatchSize(int value)](#setBatchSize-int-) | 노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 출력 이미지의 크기를 픽셀 단위로 설정합니다. |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 보간 모드를 설정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | 렌더링할 페이지 번호 배열을 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | 텍스트 렌더링 힌트를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### PngSaveOptions() {#PngSaveOptions--}
+```
+public PngSaveOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다.
+
+**Returns:**
+int - 노드에서 노드로 전달할 페이지 부분의 크기.
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 출력 이미지의 크기(픽셀).
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+보간 모드를 가져옵니다.
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+렌더링할 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - 페이지 수.
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+float - 이미지 해상도.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+텍스트 렌더링 힌트를 가져옵니다.
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 노드 간에 전달되는 페이지 일부의 크기. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Dimension | 출력 이미지의 크기(픽셀 단위). |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+보간 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 보간 모드. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+렌더링할 페이지 번호 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int[] | 페이지 수. |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 이미지 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 스무딩 모드. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+텍스트 렌더링 힌트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | 텍스트 렌더링 힌트. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/smoothingmode/_index.md
+++ b/korean/java/com.aspose.xps.rendering/smoothingmode/_index.md
@@ -1,0 +1,277 @@
+---
+title: "SmoothingMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "선과 곡선 및 채워진 영역의 가장자리에 스무딩 안티앨리어싱이 적용되는지 지정합니다."
+type: docs
+weight: 24
+url: /ko/java/com.aspose.xps.rendering/smoothingmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum SmoothingMode extends Enum<SmoothingMode>
+```
+
+선과 곡선 및 채워진 영역의 가장자리에 스무딩(앤티앨리어싱)이 적용되는지 여부를 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AntiAlias](#AntiAlias) | 안티앨리어싱 렌더링을 지정합니다. |
+| [Default](#Default) | 안티앨리어싱을 사용하지 않음을 지정합니다. |
+| [HighQuality](#HighQuality) | 안티앨리어싱 렌더링을 지정합니다. |
+| [HighSpeed](#HighSpeed) | 안티앨리어싱을 사용하지 않음을 지정합니다. |
+| [None](#None) | 안티앨리어싱을 사용하지 않음을 지정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AntiAlias {#AntiAlias}
+```
+public static final SmoothingMode AntiAlias
+```
+
+
+안티앨리어싱 렌더링을 지정합니다.
+
+### Default {#Default}
+```
+public static final SmoothingMode Default
+```
+
+
+안티앨리어싱을 사용하지 않음을 지정합니다.
+
+### HighQuality {#HighQuality}
+```
+public static final SmoothingMode HighQuality
+```
+
+
+안티앨리어싱 렌더링을 지정합니다.
+
+### HighSpeed {#HighSpeed}
+```
+public static final SmoothingMode HighSpeed
+```
+
+
+안티앨리어싱을 사용하지 않음을 지정합니다.
+
+### None {#None}
+```
+public static final SmoothingMode None
+```
+
+
+안티앨리어싱을 사용하지 않음을 지정합니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static SmoothingMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode)
+### values() {#values--}
+```
+public static SmoothingMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.SmoothingMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/textrenderinghint/_index.md
+++ b/korean/java/com.aspose.xps.rendering/textrenderinghint/_index.md
@@ -1,0 +1,286 @@
+---
+title: "TextRenderingHint"
+second_title: "Aspose.Page용 Java API 참조"
+description: "텍스트 렌더링 품질을 지정합니다."
+type: docs
+weight: 25
+url: /ko/java/com.aspose.xps.rendering/textrenderinghint/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum TextRenderingHint extends Enum<TextRenderingHint>
+```
+
+텍스트 렌더링 품질을 지정합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [AntiAlias](#AntiAlias) | 각 문자는 힌팅 없이 안티앨리어싱된 글리프 비트맵을 사용하여 그려집니다. |
+| [AntiAliasGridFit](#AntiAliasGridFit) | 각 문자는 힌팅을 사용하여 안티앨리어싱된 글리프 비트맵을 사용해 그려집니다. |
+| [ClearTypeGridFit](#ClearTypeGridFit) | 각 문자는 힌팅을 사용하여 글리프 ClearType 비트맵을 사용해 그려집니다. |
+| [SingleBitPerPixel](#SingleBitPerPixel) | 각 문자는 글리프 비트맵을 사용해 그려집니다. |
+| [SingleBitPerPixelGridFit](#SingleBitPerPixelGridFit) | 각 문자는 글리프 비트맵을 사용해 그려집니다. |
+| [SystemDefault](#SystemDefault) | 각 문자는 시스템 기본 렌더링 힌트를 사용하여 글리프 비트맵을 그립니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### AntiAlias {#AntiAlias}
+```
+public static final TextRenderingHint AntiAlias
+```
+
+
+각 문자는 힌팅 없이 안티앨리어싱된 글리프 비트맵을 사용해 그려집니다. 안티앨리어싱으로 인해 품질이 향상됩니다. 힌팅이 꺼져 있어 줄기 너비 차이가 눈에 띌 수 있습니다.
+
+### AntiAliasGridFit {#AntiAliasGridFit}
+```
+public static final TextRenderingHint AntiAliasGridFit
+```
+
+
+각 문자는 힌팅을 사용하여 안티앨리어싱된 글리프 비트맵을 사용해 그려집니다. 안티앨리어싱으로 인해 품질이 크게 향상되지만 성능 비용이 더 높습니다.
+
+### ClearTypeGridFit {#ClearTypeGridFit}
+```
+public static final TextRenderingHint ClearTypeGridFit
+```
+
+
+각 문자는 힌팅을 사용하여 글리프 ClearType 비트맵을 사용해 그려집니다. 최고 품질 설정이며 ClearType 글꼴 기능을 활용합니다.
+
+### SingleBitPerPixel {#SingleBitPerPixel}
+```
+public static final TextRenderingHint SingleBitPerPixel
+```
+
+
+각 문자는 글리프 비트맵을 사용해 그려집니다. 힌팅이 사용되지 않습니다.
+
+### SingleBitPerPixelGridFit {#SingleBitPerPixelGridFit}
+```
+public static final TextRenderingHint SingleBitPerPixelGridFit
+```
+
+
+각 문자는 글리프 비트맵을 사용해 그려집니다. 힌팅은 줄기와 곡선에서 문자 모양을 개선하기 위해 사용됩니다.
+
+### SystemDefault {#SystemDefault}
+```
+public static final TextRenderingHint SystemDefault
+```
+
+
+각 문자는 시스템 기본 렌더링 힌트를 사용하여 글리프 비트맵을 그립니다. 텍스트는 사용자가 시스템에 선택한 폰트 부드럽게 처리 설정에 따라 그려집니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static TextRenderingHint valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint)
+### values() {#values--}
+```
+public static TextRenderingHint[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.rendering.TextRenderingHint[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps.rendering/tiffsaveoptions/_index.md
+++ b/korean/java/com.aspose.xps.rendering/tiffsaveoptions/_index.md
@@ -1,0 +1,509 @@
+---
+title: "TiffSaveOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS-as-TIFF 저장 옵션에 대한 클래스."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.xps.rendering/tiffsaveoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.SaveOptions](../../com.aspose.page/saveoptions), [com.aspose.xps.rendering.ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions)
+```
+public class TiffSaveOptions extends ImageSaveOptions
+```
+
+XPS-as-TIFF 저장 옵션에 대한 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [TiffSaveOptions()](#TiffSaveOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getAdditionalFontsFolders()](#getAdditionalFontsFolders--) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 반환합니다. |
+| [getBatchSize()](#getBatchSize--) | 노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다. |
+| [getBeforePageSavingEventHandlers()](#getBeforePageSavingEventHandlers--) | 저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getConvertFontsToTTF()](#getConvertFontsToTTF--) | 비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다. |
+| [getExceptions()](#getExceptions--) | 비치명적 오류 목록을 반환합니다. |
+| [getImageSize()](#getImageSize--) | 출력 이미지의 크기를 픽셀 단위로 가져옵니다. |
+| [getInterpolationMode()](#getInterpolationMode--) | 보간 모드를 가져옵니다. |
+| [getJpegQualityLevel()](#getJpegQualityLevel--) | 이미지 압축 수준을 지정하는 값을 반환합니다. |
+| [getPageNumbers()](#getPageNumbers--) | 렌더링할 페이지 번호 배열을 가져옵니다. |
+| [getResolution()](#getResolution--) | 이미지 해상도를 가져옵니다. |
+| [getSize()](#getSize--) | 페이지 또는 이미지의 크기를 가져옵니다. |
+| [getSmoothingMode()](#getSmoothingMode--) | 스무딩 모드를 가져옵니다. |
+| [getTextRenderingHint()](#getTextRenderingHint--) | 텍스트 렌더링 힌트를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [isDebug()](#isDebug--) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다. |
+| [isSupressErrors()](#isSupressErrors--) | 변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다. |
+| [multipage()](#multipage--) | 여러 이미지를 단일 다중 페이지 TIFF 파일에 저장할지 여부를 정의하는 플래그를 가져옵니다. |
+| [multipage(boolean value)](#multipage-boolean-) | 여러 이미지를 단일 다중 페이지 TIFF 파일에 저장할지 여부를 정의하는 플래그를 설정합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setAdditionalFontsFolders(String[] fontsFolders)](#setAdditionalFontsFolders-java.lang.String---) | 변환기가 입력 문서의 글꼴을 찾을 수 있는 추가 글꼴 폴더를 지정합니다. |
+| [setBatchSize(int value)](#setBatchSize-int-) | 노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다. |
+| [setConvertFontsToTTF(boolean value)](#setConvertFontsToTTF-boolean-) | 비 TrueType 글꼴을 TTF로 저장할지 여부를 지정합니다. |
+| [setDebug(boolean debug)](#setDebug-boolean-) | 변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다. |
+| [setImageSize(Dimension value)](#setImageSize-java.awt.Dimension-) | 출력 이미지의 크기를 픽셀 단위로 설정합니다. |
+| [setInterpolationMode(InterpolationMode value)](#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-) | 보간 모드를 설정합니다. |
+| [setJpegQualityLevel(int value)](#setJpegQualityLevel-int-) | 이미지 압축 수준을 지정하는 값을 설정합니다. |
+| [setPageNumbers(int[] value)](#setPageNumbers-int---) | 렌더링할 페이지 번호 배열을 설정합니다. |
+| [setResolution(float value)](#setResolution-float-) | 이미지 해상도를 설정합니다. |
+| [setSize(Dimension size)](#setSize-java.awt.Dimension-) | 페이지 또는 이미지의 크기를 지정합니다. |
+| [setSmoothingMode(SmoothingMode value)](#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-) | 스무딩 모드를 설정합니다. |
+| [setSupressErrors(boolean supressErrors)](#setSupressErrors-boolean-) | 변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다. |
+| [setTextRenderingHint(TextRenderingHint value)](#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-) | 텍스트 렌더링 힌트를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### TiffSaveOptions() {#TiffSaveOptions--}
+```
+public TiffSaveOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getAdditionalFontsFolders() {#getAdditionalFontsFolders--}
+```
+public String[] getAdditionalFontsFolders()
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 반환합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Returns:**
+java.lang.String[] - 글꼴 폴더 배열.
+### getBatchSize() {#getBatchSize--}
+```
+public int getBatchSize()
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 반환합니다.
+
+**Returns:**
+int - 노드에서 노드로 전달할 페이지 부분의 크기.
+### getBeforePageSavingEventHandlers() {#getBeforePageSavingEventHandlers--}
+```
+public List<EventBasedModifications.BeforePageSavingEventHandler> getBeforePageSavingEventHandlers()
+```
+
+
+저장되기 직전에 XPS 페이지를 수정하는 이벤트 핸들러 컬렉션을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.features.EventBasedModifications.BeforePageSavingEventHandler>
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getConvertFontsToTTF() {#getConvertFontsToTTF--}
+```
+public boolean getConvertFontsToTTF()
+```
+
+
+비 TrueType 글꼴을 TTF로 저장해야 하는지 표시하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 플래그 값.
+### getExceptions() {#getExceptions--}
+```
+public List<Exception> getExceptions()
+```
+
+
+비치명적 오류 목록을 반환합니다.
+
+**Returns:**
+java.util.List<java.lang.Exception> - 예외 목록
+### getImageSize() {#getImageSize--}
+```
+public Dimension getImageSize()
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 출력 이미지의 크기(픽셀).
+### getInterpolationMode() {#getInterpolationMode--}
+```
+public InterpolationMode getInterpolationMode()
+```
+
+
+보간 모드를 가져옵니다.
+
+**Returns:**
+[InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) - The interpolation mode.
+### getJpegQualityLevel() {#getJpegQualityLevel--}
+```
+public int getJpegQualityLevel()
+```
+
+
+이미지 압축 수준을 지정하는 값을 반환합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Returns:**
+int - 이미지 압축 수준을 지정하는 값입니다.
+### getPageNumbers() {#getPageNumbers--}
+```
+public int[] getPageNumbers()
+```
+
+
+렌더링할 페이지 번호 배열을 가져옵니다.
+
+**Returns:**
+int[] - 페이지 수.
+### getResolution() {#getResolution--}
+```
+public float getResolution()
+```
+
+
+이미지 해상도를 가져옵니다.
+
+**Returns:**
+float - 이미지 해상도.
+### getSize() {#getSize--}
+```
+public Dimension getSize()
+```
+
+
+페이지 또는 이미지의 크기를 가져옵니다.
+
+**Returns:**
+java.awt.Dimension - 페이지 또는 이미지의 크기.
+### getSmoothingMode() {#getSmoothingMode--}
+```
+public SmoothingMode getSmoothingMode()
+```
+
+
+스무딩 모드를 가져옵니다.
+
+**Returns:**
+[SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) - The smoothing mode.
+### getTextRenderingHint() {#getTextRenderingHint--}
+```
+public TextRenderingHint getTextRenderingHint()
+```
+
+
+텍스트 렌더링 힌트를 가져옵니다.
+
+**Returns:**
+[TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) - The text rendering hint.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isDebug() {#isDebug--}
+```
+public boolean isDebug()
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 디버그 값.
+### isSupressErrors() {#isSupressErrors--}
+```
+public boolean isSupressErrors()
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - boolean 값
+### multipage() {#multipage--}
+```
+public boolean multipage()
+```
+
+
+여러 이미지를 단일 다중 페이지 TIFF 파일에 저장할지 여부를 정의하는 플래그를 가져옵니다.
+
+**Returns:**
+boolean - 여러 이미지가 단일 다중 페이지 TIFF 파일에 저장되는지를 정의하는 플래그.
+### multipage(boolean value) {#multipage-boolean-}
+```
+public void multipage(boolean value)
+```
+
+
+여러 이미지를 단일 다중 페이지 TIFF 파일에 저장할지 여부를 정의하는 플래그를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 여러 이미지가 단일 다중 페이지 TIFF 파일에 저장되는지를 정의하는 플래그. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setAdditionalFontsFolders(String[] fontsFolders) {#setAdditionalFontsFolders-java.lang.String---}
+```
+public void setAdditionalFontsFolders(String[] fontsFolders)
+```
+
+
+컨버터가 입력 문서의 글꼴을 찾을 추가 글꼴 폴더를 지정합니다. 기본 폴더는 운영 체제가 내부 용도로 글꼴을 찾는 표준 글꼴 폴더입니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontsFolders | java.lang.String[] | 글꼴 폴더 배열. |
+
+### setBatchSize(int value) {#setBatchSize-int-}
+```
+public void setBatchSize(int value)
+```
+
+
+노드에서 노드로 전달할 페이지 부분의 크기를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 노드 간에 전달되는 페이지 일부의 크기. |
+
+### setConvertFontsToTTF(boolean value) {#setConvertFontsToTTF-boolean-}
+```
+public void setConvertFontsToTTF(boolean value)
+```
+
+
+TrueType이 아닌 글꼴을 TTF로 저장할지 여부를 지정합니다. 이는 PS에서 PDF 변환 시 결과 문서의 용량을 크게 줄이고, TrueType이 아닌 글꼴이 많이 포함된 PS 파일을 어떤 출력 형식으로든 변환할 때 속도를 높입니다. 그러나 PostScript 파일을 이미지로 변환할 때 텍스트가 약간 수직으로 이동하는 현상이 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 플래그 값. |
+
+### setDebug(boolean debug) {#setDebug-boolean-}
+```
+public void setDebug(boolean debug)
+```
+
+
+변환 중 경고 및 메시지 출력을 허용하는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| debug | boolean | Boolean 값. |
+
+### setImageSize(Dimension value) {#setImageSize-java.awt.Dimension-}
+```
+public void setImageSize(Dimension value)
+```
+
+
+출력 이미지의 크기를 픽셀 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.Dimension | 출력 이미지의 크기(픽셀 단위). |
+
+### setInterpolationMode(InterpolationMode value) {#setInterpolationMode-com.aspose.xps.rendering.InterpolationMode-}
+```
+public void setInterpolationMode(InterpolationMode value)
+```
+
+
+보간 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [InterpolationMode](../../com.aspose.xps.rendering/interpolationmode) | 보간 모드. |
+
+### setJpegQualityLevel(int value) {#setJpegQualityLevel-int-}
+```
+public void setJpegQualityLevel(int value)
+```
+
+
+이미지 압축 수준을 지정하는 값을 설정합니다. 사용 가능한 값은 0에서 100까지입니다. 지정된 숫자가 낮을수록 압축이 높아지고 따라서 이미지 품질이 낮아집니다. 0 값은 가장 낮은 품질의 이미지를 생성하고, 100은 가장 높은 품질을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | 이미지 압축 수준을 지정하는 값입니다. |
+
+### setPageNumbers(int[] value) {#setPageNumbers-int---}
+```
+public void setPageNumbers(int[] value)
+```
+
+
+렌더링할 페이지 번호 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int[] | 페이지 수. |
+
+### setResolution(float value) {#setResolution-float-}
+```
+public void setResolution(float value)
+```
+
+
+이미지 해상도를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 이미지 해상도. |
+
+### setSize(Dimension size) {#setSize-java.awt.Dimension-}
+```
+public void setSize(Dimension size)
+```
+
+
+페이지 또는 이미지의 크기를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 크기 | java.awt.Dimension | 페이지 또는 이미지의 크기. |
+
+### setSmoothingMode(SmoothingMode value) {#setSmoothingMode-com.aspose.xps.rendering.SmoothingMode-}
+```
+public void setSmoothingMode(SmoothingMode value)
+```
+
+
+스무딩 모드를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [SmoothingMode](../../com.aspose.xps.rendering/smoothingmode) | 스무딩 모드. |
+
+### setSupressErrors(boolean supressErrors) {#setSupressErrors-boolean-}
+```
+public void setSupressErrors(boolean supressErrors)
+```
+
+
+변환 중 오류가 억제될지 여부를 나타내는 플래그를 지정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| supressErrors | boolean | Boolean 값. |
+
+### setTextRenderingHint(TextRenderingHint value) {#setTextRenderingHint-com.aspose.xps.rendering.TextRenderingHint-}
+```
+public void setTextRenderingHint(TextRenderingHint value)
+```
+
+
+텍스트 렌더링 힌트를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [TextRenderingHint](../../com.aspose.xps.rendering/textrenderinghint) | 텍스트 렌더링 힌트. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/_index.md
+++ b/korean/java/com.aspose.xps/_index.md
@@ -1,0 +1,79 @@
+---
+title: "com.aspose.xps"
+second_title: "Aspose.Page용 Java API 참조"
+description: "com.aspose.xps는 XPS 문서를 다루는 모든 클래스의 루트 패키지입니다."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.xps/
+---
+
+**com.aspose.xps**는 XPS 문서를 다루는 모든 클래스의 루트 패키지입니다.
+
+
+## 클래스
+
+| 클래스 | 설명 |
+| --- | --- |
+| [DocumentUtils](../com.aspose.xps/documentutils) | 이 클래스는 공식 XPS 조작 API를 넘어서는 유틸리티를 제공합니다. |
+| [LoadOptions](../com.aspose.xps/loadoptions) | 문서 로드 옵션을 위한 기본 클래스입니다. |
+| [Size2D](../com.aspose.xps/size2d) | `Size2D` 클래스는 차원 (w x h)을 설명합니다. |
+| [Size2D.Float](../com.aspose.xps/size2d.float) | `Float` 클래스는 부동 소수점 좌표로 지정된 차원을 정의합니다. |
+| [XpsArcSegment](../com.aspose.xps/xpsarcsegment) | ArcSegment 요소 기능을 캡슐화하는 클래스. |
+| [XpsArray<T>](../com.aspose.xps/xpsarray) | 공통 XPS 모델 배열 객체 기능을 캡슐화하는 클래스. |
+| [XpsBrush](../com.aspose.xps/xpsbrush) | 모든 브러시 요소의 공통 기능을 캡슐화하는 클래스. |
+| [XpsCanvas](../com.aspose.xps/xpscanvas) | Canvas 요소 기능을 캡슐화하는 클래스. |
+| [XpsColor](../com.aspose.xps/xpscolor) | 공통 색상 기능을 캡슐화하는 기본 클래스. |
+| [XpsContentElement](../com.aspose.xps/xpscontentelement) | XPS 콘텐츠 요소인 Canvas, Path 및 Glyphs의 기능을 캡슐화합니다. |
+| [XpsDocument](../com.aspose.xps/xpsdocument) | XPS 문서의 주요 엔터티를 캡슐화하며, 모든 XPS 요소에 대한 조작 메서드를 제공합니다. |
+| [XpsElement](../com.aspose.xps/xpselement) | 공통 XPS 요소 기능을 캡슐화하는 클래스. |
+| [XpsElementLinkTarget](../com.aspose.xps/xpselementlinktarget) | 상대 명명 주소 하이퍼링크 대상을 캡슐화하는 클래스. |
+| [XpsExternalLinkTarget](../com.aspose.xps/xpsexternallinktarget) | 외부 하이퍼링크 대상을 캡슐화하는 클래스. |
+| [XpsFileResource](../com.aspose.xps/xpsfileresource) | 모든 파일 리소스의 공통 기능을 캡슐화하는 클래스. |
+| [XpsFont](../com.aspose.xps/xpsfont) | TrueType 글꼴 리소스를 캡슐화하는 클래스. |
+| [XpsGlyphs](../com.aspose.xps/xpsglyphs) | Glyphs 요소 기능을 캡슐화하는 클래스. |
+| [XpsGradientBrush](../com.aspose.xps/xpsgradientbrush) | LinerGradientBrush 및 RadialGradientBrush 요소의 공통 기능을 캡슐화하는 클래스. |
+| [XpsGradientStop](../com.aspose.xps/xpsgradientstop) | GradientStop 요소 기능을 캡슐화하는 클래스. |
+| [XpsHyperlinkElement](../com.aspose.xps/xpshyperlinkelement) | 하이퍼링크가 될 수 있는 XPS 요소의 공통 기능을 캡슐화합니다. |
+| [XpsHyperlinkTarget](../com.aspose.xps/xpshyperlinktarget) | 하이퍼링크 대상의 기본 클래스. |
+| [XpsIccBasedColor](../com.aspose.xps/xpsiccbasedcolor) | ICC 기반 색상을 캡슐화합니다. |
+| [XpsIccProfile](../com.aspose.xps/xpsiccprofile) | ICC 프로파일 리소스를 캡슐화하는 클래스. |
+| [XpsImage](../com.aspose.xps/xpsimage) | 이미지 리소스를 캡슐화하는 클래스. |
+| [XpsImageBrush](../com.aspose.xps/xpsimagebrush) | ImageBrush 속성 요소 기능을 캡슐화하는 클래스. |
+| [XpsLinearGradientBrush](../com.aspose.xps/xpslineargradientbrush) | LinearGradientBrush 속성 요소 기능을 캡슐화하는 클래스. |
+| [XpsLoadOptions](../com.aspose.xps/xpsloadoptions) | XPS 문서 로드 옵션. |
+| [XpsMatrix](../com.aspose.xps/xpsmatrix) | MatrixTransform 속성 요소 기능을 캡슐화하는 클래스. |
+| [XpsObject](../com.aspose.xps/xpsobject) | 공통 XPS 모델 객체 기능을 캡슐화하는 클래스. |
+| [XpsPage](../com.aspose.xps/xpspage) | FixedPage 요소 기능을 캡슐화하는 클래스. |
+| [XpsPageLinkTarget](../com.aspose.xps/xpspagelinktarget) | 페이지 하이퍼링크 대상을 캡슐화하는 클래스. |
+| [XpsPath](../com.aspose.xps/xpspath) | Path 요소 기능을 캡슐화하는 클래스. |
+| [XpsPathFigure](../com.aspose.xps/xpspathfigure) | PathFigure 요소 기능을 캡슐화하는 클래스. |
+| [XpsPathGeometry](../com.aspose.xps/xpspathgeometry) | PathGeometry 속성 요소 기능을 캡슐화하는 클래스. |
+| [XpsPathPolySegment](../com.aspose.xps/xpspathpolysegment) | PolyLineSegment, PolyBezierSegment 및 PolyQuadraticBezierSegment 요소의 공통 기능을 캡슐화하는 클래스. |
+| [XpsPathSegment](../com.aspose.xps/xpspathsegment) | 모든 경로 세그먼트 요소의 공통 기능을 캡슐화하는 클래스. |
+| [XpsPolyBezierSegment](../com.aspose.xps/xpspolybeziersegment) | PolyBezierSegment 요소 기능을 캡슐화하는 클래스. |
+| [XpsPolyLineSegment](../com.aspose.xps/xpspolylinesegment) | PolyLineSegment 요소 기능을 캡슐화하는 클래스. |
+| [XpsPolyQuadraticBezierSegment](../com.aspose.xps/xpspolyquadraticbeziersegment) | PolyQuadraticBezierSegment 요소 기능을 캡슐화하는 클래스. |
+| [XpsRadialGradientBrush](../com.aspose.xps/xpsradialgradientbrush) | RadialGradientBrush 속성 요소 기능을 캡슐화하는 클래스. |
+| [XpsRgbColor](../com.aspose.xps/xpsrgbcolor) | RGB 색상(모든 색 공간, sRGB 또는 scRGB)을 캡슐화합니다. |
+| [XpsSolidColorBrush](../com.aspose.xps/xpssolidcolorbrush) | SolidColorBrush 속성 요소 기능을 캡슐화하는 클래스. |
+| [XpsTilingBrush](../com.aspose.xps/xpstilingbrush) | 타일링 브러시 요소(VisualBrush 및 ImageBrush)의 공통 기능을 캡슐화하는 클래스. |
+| [XpsTransformableBrush](../com.aspose.xps/xpstransformablebrush) | 변환 가능한 브러시 요소(모두 SolidColorBrush 제외)의 공통 기능을 캡슐화하는 클래스. |
+| [XpsVisual](../com.aspose.xps/xpsvisual) | Visual 요소 기능을 캡슐화하는 클래스. |
+| [XpsVisualBrush](../com.aspose.xps/xpsvisualbrush) | VisualBrush 속성 요소 기능을 캡슐화하는 클래스. |
+
+## 열거형
+
+| 열거형 | 설명 |
+| --- | --- |
+| [ImageMode](../com.aspose.xps/imagemode) | 이미지를 상자에 맞추는 옵션을 나열합니다. |
+| [XpsColorInterpolationMode](../com.aspose.xps/xpscolorinterpolationmode) | 그라디언트 브러시의 ColorInterpolationMode 속성에 대한 유효한 값. |
+| [XpsDashCap](../com.aspose.xps/xpsdashcap) | Path 요소의 StrokeDashCap 속성에 대한 유효한 값. |
+| [XpsEdgeMode](../com.aspose.xps/xpsedgemode) | Canvas 요소의 RenderOptions.EdgeMode 속성에 대한 유효한 값. |
+| [XpsFillRule](../com.aspose.xps/xpsfillrule) | PathGeometry 요소의 FillRule 속성에 대한 유효한 값. |
+| [XpsFontStyle](../com.aspose.xps/xpsfontstyle) | 글꼴 스타일에 대한 유효한 값입니다. |
+| [XpsLineCap](../com.aspose.xps/xpslinecap) | Path 요소의 StrokeStartLineCap 및 StrokeEndLineCap 속성에 대한 유효한 값입니다. |
+| [XpsLineJoin](../com.aspose.xps/xpslinejoin) | Path 요소의 StrokeLineJoin 속성에 대한 유효한 값입니다. |
+| [XpsSpreadMethod](../com.aspose.xps/xpsspreadmethod) | 그라디언트 브러시의 SpreadMethod 속성에 대한 유효한 값입니다. |
+| [XpsStyleSimulations](../com.aspose.xps/xpsstylesimulations) | Glyphs 요소의 StyleSimulations 속성에 대한 유효한 값입니다. |
+| [XpsSweepDirection](../com.aspose.xps/xpssweepdirection) | ArcSegment 요소의 SweepDirection 속성에 대한 유효한 값입니다. |
+| [XpsTileMode](../com.aspose.xps/xpstilemode) | 타일링 브러시의 TileMode 속성에 대한 유효한 값입니다. |

--- a/korean/java/com.aspose.xps/documentutils/_index.md
+++ b/korean/java/com.aspose.xps/documentutils/_index.md
@@ -1,0 +1,284 @@
+---
+title: "DocumentUtils"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이 클래스는 공식 XPS 조작 API를 넘어서는 유틸리티를 제공합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps/documentutils/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class DocumentUtils
+```
+
+이 클래스는 공식 XPS 조작 API를 넘어서는 유틸리티를 제공합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [createCircle(Point2D center, float radius)](#createCircle-java.awt.geom.Point2D-float-) | 원을 나타내는 경로 기하학을 생성합니다. |
+| [createCircularSegment(Point2D center, float radius, float startAngle, float endAngle)](#createCircularSegment-java.awt.geom.Point2D-float-float-float-) | 두 각도 사이의 원호 구간을 나타내는 경로 기하학을 생성합니다. |
+| [createEllipse(Point2D center, float radiusX, float radiusY)](#createEllipse-java.awt.geom.Point2D-float-float-) | 타원을 나타내는 경로 기하학을 생성합니다. |
+| [createImage(String fileName, Rectangle2D imageBox)](#createImage-java.lang.String-java.awt.geom.Rectangle2D-) | 이미지로 채워진 사각형 경로를 생성합니다. |
+| [createImage(String fileName, Rectangle2D imageBox, ImageMode mode)](#createImage-java.lang.String-java.awt.geom.Rectangle2D-com.aspose.xps.ImageMode-) | 이미지로 채워진 사각형 경로를 생성합니다. |
+| [createPieSlice(Point2D center, float radius, float startAngle, float endAngle)](#createPieSlice-java.awt.geom.Point2D-float-float-float-) | 두 방사선 사이의 원 조각을 나타내는 경로 기하학을 생성합니다. |
+| [createRectangle(Rectangle2D rectangle)](#createRectangle-java.awt.geom.Rectangle2D-) | 사각형을 나타내는 경로 기하학을 생성합니다. |
+| [createRegularCircumscribedNGon(int n, Point2D center, float radius)](#createRegularCircumscribedNGon-int-java.awt.geom.Point2D-float-) | 원을 외접하는 정n각형을 나타내는 경로 기하학을 생성합니다. |
+| [createRegularInscribedNGon(int n, Point2D center, float radius)](#createRegularInscribedNGon-int-java.awt.geom.Point2D-float-) | 원을 내접하는 정n각형을 나타내는 경로 기하학을 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### createCircle(Point2D center, float radius) {#createCircle-java.awt.geom.Point2D-float-}
+```
+public XpsPathGeometry createCircle(Point2D center, float radius)
+```
+
+
+원을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 원의 중심점. |
+| 반지름 | float | 원의 반지름. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createCircularSegment(Point2D center, float radius, float startAngle, float endAngle) {#createCircularSegment-java.awt.geom.Point2D-float-float-float-}
+```
+public XpsPathGeometry createCircularSegment(Point2D center, float radius, float startAngle, float endAngle)
+```
+
+
+두 각도 사이의 원호 구간을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 원의 중심. |
+| 반지름 | float | 원의 반지름. |
+| startAngle | float | 시작 광선의 각도(도). |
+| endAngle | float | 끝 광선의 각도(도). |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createEllipse(Point2D center, float radiusX, float radiusY) {#createEllipse-java.awt.geom.Point2D-float-float-}
+```
+public XpsPathGeometry createEllipse(Point2D center, float radiusX, float radiusY)
+```
+
+
+타원을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 타원의 중심점. |
+| radiusX | float | 타원의 가로 반지름. |
+| radiusY | float | 타원의 세로 반지름. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createImage(String fileName, Rectangle2D imageBox) {#createImage-java.lang.String-java.awt.geom.Rectangle2D-}
+```
+public XpsPath createImage(String fileName, Rectangle2D imageBox)
+```
+
+
+이미지로 채워진 사각형 경로를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | java.lang.String | 이미지 파일의 이름. |
+| imageBox | java.awt.geom.Rectangle2D | 이미지를 채울 이미지 박스. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - The XPS path.
+### createImage(String fileName, Rectangle2D imageBox, ImageMode mode) {#createImage-java.lang.String-java.awt.geom.Rectangle2D-com.aspose.xps.ImageMode-}
+```
+public XpsPath createImage(String fileName, Rectangle2D imageBox, ImageMode mode)
+```
+
+
+이미지로 채워진 사각형 경로를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fileName | java.lang.String | 이미지 파일의 이름. |
+| imageBox | java.awt.geom.Rectangle2D | 이미지를 채울 이미지 박스. |
+| mode | [ImageMode](../../com.aspose.xps/imagemode) | 이미지 맞춤 모드. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - The XPS path.
+### createPieSlice(Point2D center, float radius, float startAngle, float endAngle) {#createPieSlice-java.awt.geom.Point2D-float-float-float-}
+```
+public XpsPathGeometry createPieSlice(Point2D center, float radius, float startAngle, float endAngle)
+```
+
+
+두 방사선 사이의 원 조각을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 원의 중심. |
+| 반지름 | float | 원의 반지름. |
+| startAngle | float | 시작 광선의 각도(도). |
+| endAngle | float | 끝 광선의 각도(도). |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createRectangle(Rectangle2D rectangle) {#createRectangle-java.awt.geom.Rectangle2D-}
+```
+public XpsPathGeometry createRectangle(Rectangle2D rectangle)
+```
+
+
+사각형을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| rectangle | java.awt.geom.Rectangle2D | 사각형. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createRegularCircumscribedNGon(int n, Point2D center, float radius) {#createRegularCircumscribedNGon-int-java.awt.geom.Point2D-float-}
+```
+public XpsPathGeometry createRegularCircumscribedNGon(int n, Point2D center, float radius)
+```
+
+
+원을 외접하는 정n각형을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| n | int | 정점의 수. |
+| center | java.awt.geom.Point2D | 원의 중심. |
+| 반지름 | float | 원의 반지름. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### createRegularInscribedNGon(int n, Point2D center, float radius) {#createRegularInscribedNGon-int-java.awt.geom.Point2D-float-}
+```
+public XpsPathGeometry createRegularInscribedNGon(int n, Point2D center, float radius)
+```
+
+
+원을 내접하는 정n각형을 나타내는 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| n | int | 정점의 수. |
+| center | java.awt.geom.Point2D | 원의 중심. |
+| 반지름 | float | 원의 반지름. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The XPS path geometry.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/float/_index.md
+++ b/korean/java/com.aspose.xps/float/_index.md
@@ -1,0 +1,254 @@
+---
+title: "Size2D.Float"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Float 클래스는 float 좌표로 지정된 차원을 정의합니다."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps/size2d.float/
+---
+**Inheritance:**
+java.lang.Object, java.awt.geom.Dimension2D, [com.aspose.xps.Size2D](../../com.aspose.xps/size2d)
+
+**All Implemented Interfaces:**
+java.io.Serializable
+```
+public static class Size2D.Float extends Size2D implements Serializable
+```
+
+`Float` 클래스는 부동 소수점 좌표로 지정된 차원을 정의합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Float()](#Float--) | Size2D 인스턴스를 생성합니다. |
+| [Float(float width, float height)](#Float-float-float-) | Size2D 인스턴스를 생성합니다. |
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [height](#height) | `Size2D`의 높이. |
+| [width](#width) | `Size2D`의 너비. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | \{@inheritDoc\} |
+| [getWidth()](#getWidth--) | \{@inheritDoc\} |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double w, double h)](#setSize-double-double-) | \{@inheritDoc\} |
+| [setSize(float w, float h)](#setSize-float-float-) | 이 `Size2D`의 차원을 지정된 `float` 값으로 설정합니다. |
+| [setSize(Dimension2D arg0)](#setSize-java.awt.geom.Dimension2D-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Float() {#Float--}
+```
+public Float()
+```
+
+
+Size2D 인스턴스를 생성합니다.
+
+### Float(float width, float height) {#Float-float-float-}
+```
+public Float(float width, float height)
+```
+
+
+Size2D 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 너비. |
+| 높이 | float | 높이. |
+
+### height {#height}
+```
+public float height
+```
+
+
+`Size2D`의 높이.
+
+### width {#width}
+```
+public float width
+```
+
+
+`Size2D`의 너비.
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public double getHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getWidth() {#getWidth--}
+```
+public double getWidth()
+```
+
+
+
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double w, double h) {#setSize-double-double-}
+```
+public void setSize(double w, double h)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| w | double |  |
+| h | double |  |
+
+### setSize(float w, float h) {#setSize-float-float-}
+```
+public void setSize(float w, float h)
+```
+
+
+이 `Size2D`의 차원을 지정된 `float` 값으로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| w | float | `Size2D`의 너비 |
+| h | float | `Size2D`의 높이 |
+
+### setSize(Dimension2D arg0) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.awt.geom.Dimension2D |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/imagemode/_index.md
+++ b/korean/java/com.aspose.xps/imagemode/_index.md
@@ -1,0 +1,259 @@
+---
+title: "ImageMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이미지를 상자에 맞추는 옵션을 나열합니다."
+type: docs
+weight: 55
+url: /ko/java/com.aspose.xps/imagemode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum ImageMode extends Enum<ImageMode>
+```
+
+이미지를 상자에 맞추는 옵션을 나열합니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FitToBox](#FitToBox) | 이미지가 상자에 맞게 조정됩니다. |
+| [FitToHeight](#FitToHeight) | 이미지가 높이에 맞게 조정됩니다. |
+| [FitToWidth](#FitToWidth) | 이미지가 너비에 맞게 조정됩니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FitToBox {#FitToBox}
+```
+public static final ImageMode FitToBox
+```
+
+
+이미지가 상자에 맞게 조정됩니다.
+
+### FitToHeight {#FitToHeight}
+```
+public static final ImageMode FitToHeight
+```
+
+
+이미지가 높이에 맞게 조정됩니다.
+
+### FitToWidth {#FitToWidth}
+```
+public static final ImageMode FitToWidth
+```
+
+
+이미지가 너비에 맞게 조정됩니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static ImageMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[ImageMode](../../com.aspose.xps/imagemode)
+### values() {#values--}
+```
+public static ImageMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.ImageMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/loadoptions/_index.md
+++ b/korean/java/com.aspose.xps/loadoptions/_index.md
@@ -1,0 +1,124 @@
+---
+title: "LoadOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "문서 로드 옵션을 위한 기본 클래스입니다."
+type: docs
+weight: 11
+url: /ko/java/com.aspose.xps/loadoptions/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class LoadOptions
+```
+
+문서 로드 옵션을 위한 기본 클래스입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/matrixorder/_index.md
+++ b/korean/java/com.aspose.xps/matrixorder/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsMatrix.MatrixOrder"
+second_title: "Aspose.Page용 Java API 참조"
+description: "행렬 연산 순서를 정의하는 열거형."
+type: docs
+weight: 10
+url: /ko/java/com.aspose.xps/xpsmatrix.matrixorder/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsMatrix.MatrixOrder extends Enum<XpsMatrix.MatrixOrder>
+```
+
+행렬 연산 순서를 정의하는 열거형.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Append](#Append) | 추가 순서. |
+| [Prepend](#Prepend) | 앞에 추가 순서. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Append {#Append}
+```
+public static final XpsMatrix.MatrixOrder Append
+```
+
+
+추가 순서.
+
+### Prepend {#Prepend}
+```
+public static final XpsMatrix.MatrixOrder Prepend
+```
+
+
+앞에 추가 순서.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsMatrix.MatrixOrder valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[MatrixOrder](../../com.aspose.xps/matrixorder)
+### values() {#values--}
+```
+public static XpsMatrix.MatrixOrder[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsMatrix.MatrixOrder[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/size2d/_index.md
+++ b/korean/java/com.aspose.xps/size2d/_index.md
@@ -1,0 +1,199 @@
+---
+title: "Size2D"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Size2D 클래스는 w x h 차원을 설명합니다."
+type: docs
+weight: 12
+url: /ko/java/com.aspose.xps/size2d/
+---
+**Inheritance:**
+java.lang.Object, java.awt.geom.Dimension2D
+```
+public abstract class Size2D extends Dimension2D
+```
+
+`Size2D` 클래스는 차원 (w x h)을 설명합니다.
+
+이 클래스는 2D 차원을 저장하는 모든 객체의 추상 상위 클래스일 뿐이며, 차원의 실제 저장 방식은 하위 클래스에 맡겨집니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [Size2D()](#Size2D--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [clone()](#clone--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) |  |
+| [getWidth()](#getWidth--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setSize(double arg0, double arg1)](#setSize-double-double-) |  |
+| [setSize(Dimension2D arg0)](#setSize-java.awt.geom.Dimension2D-) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Size2D() {#Size2D--}
+```
+public Size2D()
+```
+
+
+### clone() {#clone--}
+```
+public Object clone()
+```
+
+
+
+
+**Returns:**
+java.lang.Object
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public abstract double getHeight()
+```
+
+
+
+
+**Returns:**
+double
+### getWidth() {#getWidth--}
+```
+public abstract double getWidth()
+```
+
+
+
+
+**Returns:**
+double
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setSize(double arg0, double arg1) {#setSize-double-double-}
+```
+public abstract void setSize(double arg0, double arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | double |  |
+| arg1 | double |  |
+
+### setSize(Dimension2D arg0) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.awt.geom.Dimension2D |  |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsarcsegment/_index.md
+++ b/korean/java/com.aspose.xps/xpsarcsegment/_index.md
@@ -1,0 +1,285 @@
+---
+title: "XpsArcSegment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ArcSegment 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 13
+url: /ko/java/com.aspose.xps/xpsarcsegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment)
+```
+public class XpsArcSegment extends XpsPathSegment
+```
+
+ArcSegment 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 타원형 호를 설명합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 호 세그먼트를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getPoint()](#getPoint--) | 타원형 호의 끝점을 반환합니다. |
+| [getRotationAngle()](#getRotationAngle--) | 타원이 현재 좌표계에 대해 어떻게 회전했는지를 나타내는 값을 반환합니다. |
+| [getSize()](#getSize--) | 타원형 호의 x 및 y 반경을 x,y 쌍으로 반환합니다. |
+| [getSweepDirection()](#getSweepDirection--) | 호가 그려지는 방향을 지정하는 값을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isLargeArc()](#isLargeArc--) | 호가 180도 이상 스윕으로 그려지는지를 결정하는 값을 반환합니다. |
+| [isStroked()](#isStroked--) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setLargeArc(boolean value)](#setLargeArc-boolean-) | 호가 180도 이상으로 그려지는지를 결정하는 값을 설정합니다. |
+| [setPoint(Point2D value)](#setPoint-java.awt.geom.Point2D-) | 타원 호의 끝점을 설정합니다. |
+| [setRotationAngle(float value)](#setRotationAngle-float-) | 타원이 현재 좌표계에 대해 어떻게 회전되는지를 나타내는 값을 설정합니다. |
+| [setSize(Dimension2D value)](#setSize-java.awt.geom.Dimension2D-) | 타원 호의 x 및 y 반경을 x,y 쌍으로 설정합니다. |
+| [setStroked(boolean value)](#setStroked-boolean-) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다. |
+| [setSweepDirection(XpsSweepDirection value)](#setSweepDirection-com.aspose.xps.XpsSweepDirection-) | 호가 그려지는 방향을 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsArcSegment deepClone()
+```
+
+
+이 호 세그먼트를 복제합니다.
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - Clone of this arc segment.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getPoint() {#getPoint--}
+```
+public Point2D getPoint()
+```
+
+
+타원형 호의 끝점을 반환합니다.
+
+**Returns:**
+java.awt.geom.Point2D - 타원 호의 끝점.
+### getRotationAngle() {#getRotationAngle--}
+```
+public float getRotationAngle()
+```
+
+
+타원이 현재 좌표계에 대해 어떻게 회전했는지를 나타내는 값을 반환합니다.
+
+**Returns:**
+float - 타원이 현재 좌표계에 대해 어떻게 회전되는지를 나타내는 값.
+### getSize() {#getSize--}
+```
+public Dimension2D getSize()
+```
+
+
+타원형 호의 x 및 y 반경을 x,y 쌍으로 반환합니다.
+
+**Returns:**
+java.awt.geom.Dimension2D - 타원 호의 x 및 y 반경을 x,y 쌍으로 나타냅니다.
+### getSweepDirection() {#getSweepDirection--}
+```
+public XpsSweepDirection getSweepDirection()
+```
+
+
+호가 그려지는 방향을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) - The value specifying the direction in which the arc is drawn.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isLargeArc() {#isLargeArc--}
+```
+public boolean isLargeArc()
+```
+
+
+호가 180도 이상 스윕으로 그려지는지를 결정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 호가 180도 이상으로 그려지는지를 결정하는 값.
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setLargeArc(boolean value) {#setLargeArc-boolean-}
+```
+public void setLargeArc(boolean value)
+```
+
+
+호가 180도 이상으로 그려지는지를 결정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 호가 180도 이상으로 그려지는지를 결정하는 값. |
+
+### setPoint(Point2D value) {#setPoint-java.awt.geom.Point2D-}
+```
+public void setPoint(Point2D value)
+```
+
+
+타원 호의 끝점을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Point2D | 타원 호의 끝점. |
+
+### setRotationAngle(float value) {#setRotationAngle-float-}
+```
+public void setRotationAngle(float value)
+```
+
+
+타원이 현재 좌표계에 대해 어떻게 회전되는지를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 타원이 현재 좌표계에 대해 어떻게 회전되는지를 나타내는 값. |
+
+### setSize(Dimension2D value) {#setSize-java.awt.geom.Dimension2D-}
+```
+public void setSize(Dimension2D value)
+```
+
+
+타원 호의 x 및 y 반경을 x,y 쌍으로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Dimension2D | 타원 호의 x와 y 반지름을 x,y 쌍으로 나타냅니다. |
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값. |
+
+### setSweepDirection(XpsSweepDirection value) {#setSweepDirection-com.aspose.xps.XpsSweepDirection-}
+```
+public void setSweepDirection(XpsSweepDirection value)
+```
+
+
+호가 그려지는 방향을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 호가 그려지는 방향을 지정하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsarray/_index.md
+++ b/korean/java/com.aspose.xps/xpsarray/_index.md
@@ -1,0 +1,216 @@
+---
+title: "XpsArray"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 XPS 모델 배열 객체 기능을 캡슐화하는 클래스."
+type: docs
+weight: 14
+url: /ko/java/com.aspose.xps/xpsarray/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public abstract class XpsArray<T> extends XpsObject
+```
+
+공통 XPS 모델 배열 객체 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(T obj)](#add-T-) | 배열에 새 객체를 추가합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 배열 요소에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [insert(int index, T obj)](#insert-int-T-) | 지정된 위치에 새 객체를 배열에 삽입합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(T obj)](#remove-T-) | 배열에서 객체를 제거합니다. |
+| [removeAt(int index)](#removeAt-int-) | 지정된 위치에서 배열의 객체를 제거합니다. |
+| [size()](#size--) | 요소 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(T obj) {#add-T-}
+```
+public T add(T obj)
+```
+
+
+배열에 새 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T | 추가할 객체. |
+
+**Returns:**
+T - 추가된 객체.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public T get(int i)
+```
+
+
+인덱스 i 로 배열 요소에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 요소의 인덱스. |
+
+**Returns:**
+T - i 위치에 있는 요소.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insert(int index, T obj) {#insert-int-T-}
+```
+public T insert(int index, T obj)
+```
+
+
+지정된 위치에 새 객체를 배열에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 객체를 삽입할 위치. |
+| obj | T | 삽입할 객체. |
+
+**Returns:**
+T - 삽입된 객체.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(T obj) {#remove-T-}
+```
+public T remove(T obj)
+```
+
+
+배열에서 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T | 제거할 객체. |
+
+**Returns:**
+T - 제거된 객체.
+### removeAt(int index) {#removeAt-int-}
+```
+public T removeAt(int index)
+```
+
+
+지정된 위치에서 배열의 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 객체를 제거할 위치. |
+
+**Returns:**
+T - 제거된 객체.
+### size() {#size--}
+```
+public int size()
+```
+
+
+요소 수를 반환합니다.
+
+**Returns:**
+int - 요소의 개수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpsbrush/_index.md
@@ -1,0 +1,149 @@
+---
+title: "XpsBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 브러시 요소의 공통 기능을 캡슐화하는 클래스."
+type: docs
+weight: 15
+url: /ko/java/com.aspose.xps/xpsbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public abstract class XpsBrush extends XpsObject
+```
+
+모든 브러시 요소의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpscanvas/_index.md
+++ b/korean/java/com.aspose.xps/xpscanvas/_index.md
@@ -1,0 +1,459 @@
+---
+title: "XpsCanvas"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Canvas 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 16
+url: /ko/java/com.aspose.xps/xpscanvas/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement), [com.aspose.xps.XpsContentElement](../../com.aspose.xps/xpscontentelement)
+```
+public final class XpsCanvas extends XpsContentElement
+```
+
+Canvas 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 요소들을 함께 그룹화합니다. 예를 들어, Glyphs와 Path 요소를 캔버스에 그룹화하여 단위(하이퍼링크 대상)로 식별하거나 각 자식 및 조상 요소에 복합 속성 값을 적용할 수 있습니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>add(T element)](#-T-add-T-) | 이 캔버스의 자식 목록에 요소를 추가합니다. |
+| [<T>insert(int index, T element)](#-T-insert-int-T-) | 이 캔버스의 자식 목록에 요소를 인덱스 위치에 삽입합니다. |
+| [addCanvas()](#addCanvas--) | 이 캔버스의 자식 목록에 새 캔버스를 추가합니다. |
+| [addGlyphs(String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 이 캔버스의 자식 목록에 새 글리프를 추가합니다. |
+| [addPath(XpsPathGeometry data)](#addPath-com.aspose.xps.XpsPathGeometry-) | 이 캔버스의 자식 목록에 새 경로를 추가합니다. |
+| [deepClone()](#deepClone--) | 이 캔버스를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다. |
+| [getEdgeMode()](#getEdgeMode--) | 캔버스 내 경로 가장자리의 렌더링 방식을 제어하는 값을 반환합니다. |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | 하이퍼링크 대상 객체를 반환합니다. |
+| [getOpacity()](#getOpacity--) | 요소의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다. |
+| [getRenderTransform()](#getRenderTransform--) | 요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [insertCanvas(int index)](#insertCanvas-int-) | 이 캔버스의 자식 목록에 새 캔버스를 인덱스 위치에 삽입합니다. |
+| [insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 이 캔버스의 자식 목록에 새 글리프를 인덱스 위치에 삽입합니다. |
+| [insertPath(int index, XpsPathGeometry data)](#insertPath-int-com.aspose.xps.XpsPathGeometry-) | 이 캔버스의 자식 목록에 새 경로를 인덱스 위치에 삽입합니다. |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다. |
+| [setEdgeMode(XpsEdgeMode value)](#setEdgeMode-com.aspose.xps.XpsEdgeMode-) | 캔버스 내 경로 가장자리의 렌더링 방식을 제어하는 값을 설정합니다. |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | 하이퍼링크 대상 객체를 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 요소의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다. |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다. |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### <T>add(T element) {#-T-add-T-}
+```
+public T <T>add(T element)
+```
+
+
+이 캔버스의 자식 목록에 요소를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 요소 | T | 추가할 요소입니다. |
+
+**Returns:**
+T - 추가된 요소.
+### <T>insert(int index, T element) {#-T-insert-int-T-}
+```
+public T <T>insert(int index, T element)
+```
+
+
+이 캔버스의 자식 목록에 요소를 인덱스 위치에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소가 삽입되어야 할 위치. |
+| 요소 | T | 삽입할 요소. |
+
+**Returns:**
+T - 삽입된 요소.
+### addCanvas() {#addCanvas--}
+```
+public XpsCanvas addCanvas()
+```
+
+
+이 캔버스의 자식 목록에 새 캔버스를 추가합니다.
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Added canvas.
+### addGlyphs(String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+이 캔버스의 자식 목록에 새 글리프를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 T 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addPath(XpsPathGeometry data) {#addPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath addPath(XpsPathGeometry data)
+```
+
+
+이 캔버스의 자식 목록에 새 경로를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Added path.
+### deepClone() {#deepClone--}
+```
+public XpsCanvas deepClone()
+```
+
+
+이 캔버스를 복제합니다.
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Clone of this canvas.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다.
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getEdgeMode() {#getEdgeMode--}
+```
+public XpsEdgeMode getEdgeMode()
+```
+
+
+캔버스 내 경로 가장자리의 렌더링 방식을 제어하는 값을 반환합니다.
+
+**Returns:**
+[XpsEdgeMode](../../com.aspose.xps/xpsedgemode) - The edge rendering mode.
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+하이퍼링크 대상 객체를 반환합니다.
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 요소의 균일한 투명성을 정의하는 값.
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insertCanvas(int index) {#insertCanvas-int-}
+```
+public XpsCanvas insertCanvas(int index)
+```
+
+
+이 캔버스의 자식 목록에 새 캔버스를 인덱스 위치에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 캔버스를 삽입해야 하는 위치. |
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Inserted canvas.
+### insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+이 캔버스의 자식 목록에 새 글리프를 인덱스 위치에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 글리프를 삽입해야 하는 위치. |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 T 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### insertPath(int index, XpsPathGeometry data) {#insertPath-int-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath insertPath(int index, XpsPathGeometry data)
+```
+
+
+이 캔버스의 자식 목록에 새 경로를 인덱스 위치에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 경로를 삽입해야 하는 위치. |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Inserted path.
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 요소의 렌더링 영역을 제한하는 경로 기하학. |
+
+### setEdgeMode(XpsEdgeMode value) {#setEdgeMode-com.aspose.xps.XpsEdgeMode-}
+```
+public void setEdgeMode(XpsEdgeMode value)
+```
+
+
+캔버스 내 경로 가장자리의 렌더링 방식을 제어하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsEdgeMode](../../com.aspose.xps/xpsedgemode) | 가장자리 렌더링 모드. |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+하이퍼링크 대상 객체를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | 하이퍼링크 대상 객체. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 요소의 균일한 투명성을 정의하는 값. |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 마스크를 지정하는 브러시. |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 아핀 변환 행렬. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpscolor/_index.md
+++ b/korean/java/com.aspose.xps/xpscolor/_index.md
@@ -1,0 +1,135 @@
+---
+title: "XpsColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 색상 기능을 캡슐화하는 기본 클래스."
+type: docs
+weight: 17
+url: /ko/java/com.aspose.xps/xpscolor/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class XpsColor
+```
+
+공통 색상 기능을 캡슐화하는 기본 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toColor()](#toColor--) | 임의의 색에 대한 네이티브 표현을 가져오는 편리한 메서드. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toColor() {#toColor--}
+```
+public abstract Color toColor()
+```
+
+
+임의의 색에 대한 네이티브 표현을 가져오는 편리한 메서드.
+
+**Returns:**
+java.awt.Color -  System.Drawing.Color  structure
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpscolorinterpolationmode/_index.md
+++ b/korean/java/com.aspose.xps/xpscolorinterpolationmode/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsColorInterpolationMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "그라디언트 브러시의 ColorInterpolationMode 속성에 대한 유효한 값."
+type: docs
+weight: 56
+url: /ko/java/com.aspose.xps/xpscolorinterpolationmode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsColorInterpolationMode extends Enum<XpsColorInterpolationMode>
+```
+
+그라디언트 브러시의 ColorInterpolationMode 속성에 대한 유효한 값.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [SRgbLinearInterpolation](#SRgbLinearInterpolation) | SRgbLinearInterpolation 모드. |
+| [ScRgbLinearInterpolation](#ScRgbLinearInterpolation) | ScRgbLinearInterpolation 모드. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### SRgbLinearInterpolation {#SRgbLinearInterpolation}
+```
+public static final XpsColorInterpolationMode SRgbLinearInterpolation
+```
+
+
+SRgbLinearInterpolation 모드.
+
+### ScRgbLinearInterpolation {#ScRgbLinearInterpolation}
+```
+public static final XpsColorInterpolationMode ScRgbLinearInterpolation
+```
+
+
+ScRgbLinearInterpolation 모드.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsColorInterpolationMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode)
+### values() {#values--}
+```
+public static XpsColorInterpolationMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsColorInterpolationMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpscontentelement/_index.md
+++ b/korean/java/com.aspose.xps/xpscontentelement/_index.md
@@ -1,0 +1,287 @@
+---
+title: "XpsContentElement"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS 콘텐츠 요소인 Canvas, Path 및 Glyphs의 기능을 캡슐화합니다."
+type: docs
+weight: 18
+url: /ko/java/com.aspose.xps/xpscontentelement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement)
+```
+public abstract class XpsContentElement extends XpsHyperlinkElement
+```
+
+XPS 콘텐츠 요소인 Canvas, Path 및 Glyphs의 기능을 캡슐화합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다. |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | 하이퍼링크 대상 객체를 반환합니다. |
+| [getOpacity()](#getOpacity--) | 요소의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다. |
+| [getRenderTransform()](#getRenderTransform--) | 요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다. |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | 하이퍼링크 대상 객체를 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 요소의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다. |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다. |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다.
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+하이퍼링크 대상 객체를 반환합니다.
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 요소의 균일한 투명성을 정의하는 값.
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 요소의 렌더링 영역을 제한하는 경로 기하학. |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+하이퍼링크 대상 객체를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | 하이퍼링크 대상 객체. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 요소의 균일한 투명성을 정의하는 값. |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 마스크를 지정하는 브러시. |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 아핀 변환 행렬. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsdashcap/_index.md
+++ b/korean/java/com.aspose.xps/xpsdashcap/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsDashCap"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Path 요소의 StrokeDashCap 속성에 대한 유효한 값."
+type: docs
+weight: 57
+url: /ko/java/com.aspose.xps/xpsdashcap/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsDashCap extends Enum<XpsDashCap>
+```
+
+Path 요소의 StrokeDashCap 속성에 대한 유효한 값.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Flat](#Flat) | 플랫 대시 캡. |
+| [Round](#Round) | 라운드 대시 캡. |
+| [Square](#Square) | 스퀘어 대시 캡. |
+| [Triangle](#Triangle) | 트라이앵글 대시 캡. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Flat {#Flat}
+```
+public static final XpsDashCap Flat
+```
+
+
+플랫 대시 캡.
+
+### Round {#Round}
+```
+public static final XpsDashCap Round
+```
+
+
+라운드 대시 캡.
+
+### Square {#Square}
+```
+public static final XpsDashCap Square
+```
+
+
+스퀘어 대시 캡.
+
+### Triangle {#Triangle}
+```
+public static final XpsDashCap Triangle
+```
+
+
+트라이앵글 대시 캡.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsDashCap valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsDashCap](../../com.aspose.xps/xpsdashcap)
+### values() {#values--}
+```
+public static XpsDashCap[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsDashCap[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsdocument/_index.md
+++ b/korean/java/com.aspose.xps/xpsdocument/_index.md
@@ -1,0 +1,1938 @@
+---
+title: "XpsDocument"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS 문서의 주요 엔터티를 캡슐화하며, 모든 XPS 요소에 대한 조작 메서드를 제공합니다."
+type: docs
+weight: 19
+url: /ko/java/com.aspose.xps/xpsdocument/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.page.Document](../../com.aspose.page/document)
+
+**All Implemented Interfaces:**
+java.io.Closeable
+```
+public final class XpsDocument extends Document implements Closeable
+```
+
+XPS 문서의 주요 엔터티를 캡슐화하며, 모든 XPS 요소에 대한 조작 메서드를 제공합니다.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsDocument()](#XpsDocument--) | 기본 페이지 크기로 빈 XPS 문서를 생성합니다. |
+| [XpsDocument(String path)](#XpsDocument-java.lang.String-) | 지정된  path  에 있는 기존 XPS 문서를 엽니다. |
+| [XpsDocument(InputStream stream, LoadOptions options)](#XpsDocument-java.io.InputStream-com.aspose.xps.LoadOptions-) | 스토어된  stream  에서 기존 문서를 XPS 문서로 로드합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>add(T element)](#-T-add-T-) | 콘텐츠 요소 (Canvas, Path, 또는 Glyphs)를 추가합니다 |
+| [<T>insert(int index, T element)](#-T-insert-int-T-) | 활성 페이지에 요소 (Canvas, Path, 또는 Glyphs)를  index  위치에 삽입합니다. |
+| [<T>remove(T element)](#-T-remove-T-) | 활성 페이지에서 요소를 제거합니다. |
+| [addCanvas()](#addCanvas--) | 활성 페이지에 새 캔버스를 추가합니다. |
+| [addDocument()](#addDocument--) | 기본 페이지 크기로 빈 문서를 추가하고 추가된 문서를 활성으로 선택합니다. |
+| [addDocument(boolean activate)](#addDocument-boolean-) | 기본 페이지 크기로 빈 문서를 추가합니다. |
+| [addDocument(float width, float height)](#addDocument-float-float-) | 첫 페이지의  width  및  height  차원으로 빈 문서를 추가하고 추가된 문서를 활성으로 선택합니다. |
+| [addDocument(float width, float height, boolean activate)](#addDocument-float-float-boolean-) | 첫 페이지 차원 width와 height로 빈 문서를 추가합니다. |
+| [addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 활성 페이지에 새로운 글리프를 추가합니다. |
+| [addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 활성 페이지에 새로운 글리프를 추가합니다. |
+| [addOutlineEntry(String description, int outlineLevel, XpsHyperlinkTarget target)](#addOutlineEntry-java.lang.String-int-com.aspose.xps.XpsHyperlinkTarget-) | 문서에 개요 항목을 추가합니다 |
+| [addPage()](#addPage--) | 기본 페이지 크기로 문서에 빈 페이지를 추가합니다. |
+| [addPage(boolean activate)](#addPage-boolean-) | 기본 페이지 크기로 문서에 빈 페이지를 추가합니다. |
+| [addPage(XpsPage page)](#addPage-com.aspose.xps.XpsPage-) | 문서에 페이지를 추가하고 추가된 페이지를 활성화합니다. |
+| [addPage(XpsPage page, boolean activate)](#addPage-com.aspose.xps.XpsPage-boolean-) | 문서에 페이지를 추가합니다. |
+| [addPage(float width, float height)](#addPage-float-float-) | 지정된 width와 height로 문서에 빈 페이지를 추가합니다. |
+| [addPage(float width, float height, boolean activate)](#addPage-float-float-boolean-) | 지정된 width와 height로 문서에 빈 페이지를 추가합니다. |
+| [addPath(XpsPathGeometry data)](#addPath-com.aspose.xps.XpsPathGeometry-) | 활성 페이지에 새로운 경로를 추가합니다. |
+| [close()](#close--) | 인스턴스를 해제합니다. |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-) | 새 스트로크된 타원 호 세그먼트를 생성합니다 |
+| [createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)](#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-) | 새 타원 호 세그먼트를 생성합니다 |
+| [createCanvas()](#createCanvas--) | 새 canvas를 생성합니다 |
+| [createColor(XpsIccProfile iccProfile, float[] components)](#createColor-com.aspose.xps.XpsIccProfile-float...-) | ICC 기반 색 공간에서 새 색을 생성합니다 |
+| [createColor(float r, float g, float b)](#createColor-float-float-float-) | scRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(float a, float r, float g, float b)](#createColor-float-float-float-float-) | scRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(int r, int g, int b)](#createColor-int-int-int-) | sRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(int a, int r, int g, int b)](#createColor-int-int-int-int-) | sRGB 색 공간에서 새 색을 생성합니다 |
+| [createColor(Color color)](#createColor-java.awt.Color-) | 새 색을 생성합니다 |
+| [createColor(String path, float[] components)](#createColor-java.lang.String-float...-) | ICC 기반 색 공간에서 새 색을 생성합니다 |
+| [createFont(InputStream stream)](#createFont-java.io.InputStream-) | 스트림에서 새로운 TrueType 글꼴 리소스를 생성합니다. |
+| [createFont(String fontFamily, XpsFontStyle fontStyle)](#createFont-java.lang.String-com.aspose.xps.XpsFontStyle-) | 새로운 TrueType 글꼴 리소스를 생성합니다. |
+| [createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)](#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 새 glyphs를 생성합니다 |
+| [createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 새 glyphs를 생성합니다 |
+| [createGradientStop(XpsColor color, float offset)](#createGradientStop-com.aspose.xps.XpsColor-float-) | 새 그라디언트 스톱을 생성합니다 |
+| [createGradientStop(Color color, float offset)](#createGradientStop-java.awt.Color-float-) | 새 그라디언트 스톱을 생성합니다 |
+| [createIccProfile(InputStream stream)](#createIccProfile-java.io.InputStream-) | 스트림에서 새로운 ICC 프로파일 리소스를 생성합니다. |
+| [createIccProfile(String iccProfilePath)](#createIccProfile-java.lang.String-) | iccProfilePath에 위치한 ICC 프로파일 파일에서 새로운 ICC 프로파일 리소스를 생성합니다. |
+| [createImage(InputStream stream)](#createImage-java.io.InputStream-) | 스트림에서 새로운 이미지 리소스를 생성합니다. |
+| [createImage(String imagePath)](#createImage-java.lang.String-) | imagePath에 위치한 이미지 파일에서 새로운 이미지 리소스를 생성합니다. |
+| [createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 새 이미지 브러시를 생성합니다 |
+| [createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)](#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 새 이미지 브러시를 생성합니다 |
+| [createLinearGradientBrush(Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-) | 새 선형 그라디언트 브러시를 생성합니다 |
+| [createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)](#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-) | 새 선형 그라디언트 브러시를 생성합니다 |
+| [createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)](#createMatrix-float-float-float-float-float-float-) | 새 어파인 변환 행렬을 생성합니다 |
+| [createPath(XpsPathGeometry data)](#createPath-com.aspose.xps.XpsPathGeometry-) | 새 path를 생성합니다 |
+| [createPathFigure(Point2D startPoint)](#createPathFigure-java.awt.geom.Point2D-) | 새 열린 path 피규어를 생성합니다 |
+| [createPathFigure(Point2D startPoint, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-boolean-) | 새 path 피규어를 생성합니다 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--) | 새 열린 path 피규어를 생성합니다 |
+| [createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)](#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-) | 새 path 피규어를 생성합니다 |
+| [createPathGeometry()](#createPathGeometry--) | 새 path 기하학을 생성합니다 |
+| [createPathGeometry(String abbreviatedGeometry)](#createPathGeometry-java.lang.String-) | 축약형으로 지정된 새로운 경로 기하학을 생성합니다. |
+| [createPathGeometry(List<XpsPathFigure> pathFigures)](#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--) | 지정된 경로 도형 목록으로 새로운 경로 기하학을 생성합니다. |
+| [createPolyBezierSegment(Point2D[] points)](#createPolyBezierSegment-java.awt.geom.Point2D---) | 새로운 스트로크된 3차 베지어 곡선 집합을 생성합니다. |
+| [createPolyBezierSegment(Point2D[] points, boolean isStroked)](#createPolyBezierSegment-java.awt.geom.Point2D---boolean-) | 새로운 3차 베지어 곡선 집합을 생성합니다. |
+| [createPolyLineSegment(Point2D[] points)](#createPolyLineSegment-java.awt.geom.Point2D---) | 임의 개수의 개별 정점을 포함하는 새로운 스트로크된 다각형 그리기를 생성합니다. |
+| [createPolyLineSegment(Point2D[] points, boolean isStroked)](#createPolyLineSegment-java.awt.geom.Point2D---boolean-) | 임의 개수의 개별 정점을 포함하는 새로운 다각형 그리기를 생성합니다. |
+| [createPolyQuadraticBezierSegment(Point2D[] points)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---) | 지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 스트로크된 2차 베지어 곡선 집합을 생성합니다. |
+| [createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)](#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-) | 지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 2차 베지어 곡선 집합을 생성합니다. |
+| [createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 새로운 방사형 그라디언트 브러시를 생성합니다. |
+| [createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)](#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-) | 새로운 방사형 그라디언트 브러시를 생성합니다. |
+| [createSolidColorBrush(XpsColor color)](#createSolidColorBrush-com.aspose.xps.XpsColor-) | 새로운 단색 브러시를 생성합니다. |
+| [createSolidColorBrush(Color color)](#createSolidColorBrush-java.awt.Color-) | 새로운 단색 브러시를 생성합니다. |
+| [createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)](#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-) | 새로운 비주얼 브러시를 생성합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getActiveDocument()](#getActiveDocument--) | 활성 문서 번호를 반환합니다. |
+| [getActivePage()](#getActivePage--) | 활성 문서 내의 활성 페이지 번호를 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getDocumentCount()](#getDocumentCount--) | XPS 패키지 내부의 문서 수를 반환합니다. |
+| [getDocumentPrintTicket(int documentIndex)](#getDocumentPrintTicket-int-) | documentIndex로 인덱싱된 문서의 인쇄 티켓을 가져옵니다. |
+| [getJobPrintTicket()](#getJobPrintTicket--) | 문서의 작업 인쇄 티켓을 반환합니다. |
+| [getPage()](#getPage--) | 활성 페이지에 대한 XpsPage 인스턴스를 반환합니다. |
+| [getPageCount()](#getPageCount--) | 활성 문서의 페이지 수를 반환합니다. |
+| [getPagePrintTicket(int documentIndex, int pageIndex)](#getPagePrintTicket-int-int-) | documentIndex로 인덱싱된 문서 내 pageIndex로 인덱싱된 페이지의 인쇄 티켓을 가져옵니다. |
+| [getTotalPageCount()](#getTotalPageCount--) | XPS 문서 내부 모든 문서의 전체 페이지 수를 반환합니다. |
+| [getUtils()](#getUtils--) | 공식 XPS 조작 API를 넘어서는 유틸리티를 제공하는 객체를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [insertCanvas(int index)](#insertCanvas-int-) | index 위치에 새로운 캔버스를 활성 페이지에 삽입합니다. |
+| [insertDocument(int index)](#insertDocument-int-) | index 위치에 기본 페이지 크기의 빈 문서를 삽입하고 삽입된 문서를 활성화합니다. |
+| [insertDocument(int index, boolean activate)](#insertDocument-int-boolean-) | index 위치에 기본 페이지 크기의 빈 문서를 삽입합니다. |
+| [insertDocument(int index, float width, float height)](#insertDocument-int-float-float-) | index 위치에 첫 페이지 차원 width와 height를 가진 빈 문서를 삽입하고 삽입된 문서를 활성화합니다. |
+| [insertDocument(int index, float width, float height, boolean activate)](#insertDocument-int-float-float-boolean-) | 첫 페이지 차원인  width  와  height  로 빈 문서를 인덱스  position 에 삽입합니다. |
+| [insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)](#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-) | 활성 페이지에 새 글리프를 인덱스  position 에 삽입합니다. |
+| [insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)](#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-) | 활성 페이지에 새 글리프를 인덱스  position 에 삽입합니다. |
+| [insertPage(int index)](#insertPage-int-) | 기본 페이지 크기로 빈 페이지를 인덱스  position 에 문서에 삽입하고 삽입된 페이지를 활성화합니다. |
+| [insertPage(int index, boolean activate)](#insertPage-int-boolean-) | 기본 페이지 크기로 빈 페이지를 인덱스  position 에 문서에 삽입합니다. |
+| [insertPage(int index, XpsPage page)](#insertPage-int-com.aspose.xps.XpsPage-) | 페이지를 인덱스  position 에 문서에 삽입하고 삽입된 페이지를 활성화합니다. |
+| [insertPage(int index, XpsPage page, boolean activate)](#insertPage-int-com.aspose.xps.XpsPage-boolean-) | 페이지를 인덱스  position 에 문서에 삽입합니다. |
+| [insertPage(int index, float width, float height)](#insertPage-int-float-float-) | 지정된  width  와  height  로 빈 페이지를 인덱스  position 에 문서에 삽입하고 삽입된 페이지를 활성화합니다. |
+| [insertPage(int index, float width, float height, boolean activate)](#insertPage-int-float-float-boolean-) | 지정된  width  와  height  로 빈 페이지를 인덱스  position 에 문서에 삽입합니다. |
+| [insertPath(int index, XpsPathGeometry data)](#insertPath-int-com.aspose.xps.XpsPathGeometry-) | 새 경로를 활성 페이지에 인덱스  position 에 삽입합니다. |
+| [isLicensed()](#isLicensed--) | Aspose.Page for Java 제품 라이선스에 접근했는지 및 유효한지 여부를 나타냅니다. |
+| [merge(String[] filesForMerge, OutputStream outStream)](#merge-java.lang.String---java.io.OutputStream-) | 여러 XPS 파일을 하나의 XPS 문서로 병합합니다. |
+| [merge(String[] filesForMerge, String outXpsFilePath)](#merge-java.lang.String---java.lang.String-) | 여러 XPS 파일을 하나의 XPS 문서로 병합합니다. |
+| [mergeToPdf(String outPdfFilePath, String[] filesForMerge, PdfSaveOptions options)](#mergeToPdf-java.lang.String-java.lang.String---com.aspose.xps.rendering.PdfSaveOptions-) | Device 인스턴스를 사용하여 XPS 문서를 PDF로 병합합니다. |
+| [mergeToPdf(String[] filesForMerge, OutputStream pdfStream, PdfSaveOptions options)](#mergeToPdf-java.lang.String---java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-) | Device 인스턴스를 사용하여 XPS 문서를 PDF로 병합합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [removeAt(int index)](#removeAt-int-) | 활성 페이지에서 인덱스  position 에 있는 요소를 제거합니다. |
+| [removeDocumentAt(int index)](#removeDocumentAt-int-) | 인덱스  position 에 있는 문서를 제거합니다. |
+| [removePage(XpsPage page)](#removePage-com.aspose.xps.XpsPage-) | 문서에서 페이지를 제거합니다. |
+| [removePageAt(int index)](#removePageAt-int-) | 문서에서 인덱스  position 에 있는 페이지를 제거합니다. |
+| [save(Device device, SaveOptions options)](#save-com.aspose.page.Device-com.aspose.page.SaveOptions-) | Device 인스턴스를 사용하여 문서를 저장합니다. |
+| [save(OutputStream stream)](#save-java.io.OutputStream-) | XPS 문서를 스트림에 저장합니다. |
+| [save(String path)](#save-java.lang.String-) | XPS 문서를 경로  path 에 있는 XPS 파일에 저장합니다. |
+| [saveAsImage(ImageSaveOptions options)](#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-) | 문서를 이미지 파일에 저장합니다. 출력 디렉터리와 파일 이름은 입력 XPS 파일과 동일합니다. |
+| [saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)](#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-java.lang.String-java.lang.String-) | 문서를 지정된 디렉터리와 지정된 파일 이름으로 이미지 파일에 저장합니다. |
+| [saveAsImageBytes(ImageSaveOptions options)](#saveAsImageBytes-com.aspose.xps.rendering.ImageSaveOptions-) | 문서를 비트맵 이미지 형식으로 바이트 배열로 저장합니다. |
+| [saveAsPdf(OutputStream stream, PdfSaveOptions options)](#saveAsPdf-java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-) | 문서를 PDF 형식으로 저장합니다. |
+| [saveAsPdf(String outPdfFilePath, PdfSaveOptions options)](#saveAsPdf-java.lang.String-com.aspose.xps.rendering.PdfSaveOptions-) | 문서를 PDF 형식으로 저장합니다. |
+| [saveAsPs(OutputStream stream, PsSaveOptions options)](#saveAsPs-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-) | 문서를 PS 형식으로 저장합니다. |
+| [saveAsPs(String outPsFilePath, PsSaveOptions options)](#saveAsPs-java.lang.String-com.aspose.eps.device.PsSaveOptions-) | 문서를 PostSscript 형식으로 저장합니다. |
+| [selectActiveDocument(int documentNumber)](#selectActiveDocument-int-) | 편집을 위해 활성 문서를 선택합니다. |
+| [selectActivePage(int pageNumber)](#selectActivePage-int-) | 편집을 위해 활성 문서 페이지를 선택합니다. |
+| [setDocumentPrintTicket(int documentIndex, DocumentPrintTicket printTicket)](#setDocumentPrintTicket-int-com.aspose.xps.metadata.DocumentPrintTicket-) | printTicket을 documentIndex로 인덱싱된 문서에 연결합니다. |
+| [setJobPrintTicket(JobPrintTicket value)](#setJobPrintTicket-com.aspose.xps.metadata.JobPrintTicket-) | 문서의 작업 인쇄 티켓을 설정합니다. |
+| [setPagePrintTicket(int documentIndex, int pageIndex, PagePrintTicket printTicket)](#setPagePrintTicket-int-int-com.aspose.xps.metadata.PagePrintTicket-) | printTicket을 documentIndex로 인덱싱된 문서의 pageIndex로 인덱싱된 페이지에 연결합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsDocument() {#XpsDocument--}
+```
+public XpsDocument()
+```
+
+
+기본 페이지 크기로 빈 XPS 문서를 생성합니다.
+
+### XpsDocument(String path) {#XpsDocument-java.lang.String-}
+```
+public XpsDocument(String path)
+```
+
+
+지정된  path  에 있는 기존 XPS 문서를 엽니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.lang.String | 문서의 위치. |
+
+### XpsDocument(InputStream stream, LoadOptions options) {#XpsDocument-java.io.InputStream-com.aspose.xps.LoadOptions-}
+```
+public XpsDocument(InputStream stream, LoadOptions options)
+```
+
+
+스토어된  stream  에서 기존 문서를 XPS 문서로 로드합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 문서 스트림. |
+| options | [LoadOptions](../../com.aspose.xps/loadoptions) | 문서 로드 옵션. |
+
+### <T>add(T element) {#-T-add-T-}
+```
+public T <T>add(T element)
+```
+
+
+콘텐츠 요소 (Canvas, Path, 또는 Glyphs)를 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 요소 | T | 추가할 요소입니다. |
+
+**Returns:**
+T - 추가된 요소.
+### <T>insert(int index, T element) {#-T-insert-int-T-}
+```
+public T <T>insert(int index, T element)
+```
+
+
+활성 페이지에 요소 (Canvas, Path, 또는 Glyphs)를  index  위치에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소를 삽입해야 하는 위치. |
+| 요소 | T | 삽입할 요소. |
+
+**Returns:**
+T - 삽입된 요소.
+### <T>remove(T element) {#-T-remove-T-}
+```
+public T <T>remove(T element)
+```
+
+
+활성 페이지에서 요소를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 요소 | T | 제거할 요소. |
+
+**Returns:**
+T - 제거된 요소.
+### addCanvas() {#addCanvas--}
+```
+public XpsCanvas addCanvas()
+```
+
+
+활성 페이지에 새 캔버스를 추가합니다.
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Added canvas.
+### addDocument() {#addDocument--}
+```
+public void addDocument()
+```
+
+
+기본 페이지 크기로 빈 문서를 추가하고 추가된 문서를 활성으로 선택합니다.
+
+### addDocument(boolean activate) {#addDocument-boolean-}
+```
+public void addDocument(boolean activate)
+```
+
+
+기본 페이지 크기로 빈 문서를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 활성화 | boolean | 추가된 문서를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+### addDocument(float width, float height) {#addDocument-float-float-}
+```
+public void addDocument(float width, float height)
+```
+
+
+첫 페이지의  width  및  height  차원으로 빈 문서를 추가하고 추가된 문서를 활성으로 선택합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 첫 번째 페이지의 너비. |
+| 높이 | float | 첫 번째 페이지의 높이. |
+
+### addDocument(float width, float height, boolean activate) {#addDocument-float-float-boolean-}
+```
+public void addDocument(float width, float height, boolean activate)
+```
+
+
+첫 페이지 차원 width와 height로 빈 문서를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 첫 번째 페이지의 너비. |
+| 높이 | float | 첫 번째 페이지의 높이. |
+| 활성화 | boolean | 추가된 문서를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+### addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#addGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+활성 페이지에 새로운 글리프를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | 폰트 리소스. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#addGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs addGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+활성 페이지에 새로운 글리프를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Added glyphs.
+### addOutlineEntry(String description, int outlineLevel, XpsHyperlinkTarget target) {#addOutlineEntry-java.lang.String-int-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void addOutlineEntry(String description, int outlineLevel, XpsHyperlinkTarget target)
+```
+
+
+문서에 개요 항목을 추가합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 설명 | java.lang.String | 항목 설명. |
+| outlineLevel | int | 개요 수준. |
+| target | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | 엔트리 대상. |
+
+### addPage() {#addPage--}
+```
+public XpsPage addPage()
+```
+
+
+기본 페이지 크기로 문서에 빈 페이지를 추가합니다.
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(boolean activate) {#addPage-boolean-}
+```
+public XpsPage addPage(boolean activate)
+```
+
+
+기본 페이지 크기로 문서에 빈 페이지를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 활성화 | boolean | 추가된 페이지를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(XpsPage page) {#addPage-com.aspose.xps.XpsPage-}
+```
+public XpsPage addPage(XpsPage page)
+```
+
+
+문서에 페이지를 추가하고 추가된 페이지를 활성화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 추가될 페이지. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(XpsPage page, boolean activate) {#addPage-com.aspose.xps.XpsPage-boolean-}
+```
+public XpsPage addPage(XpsPage page, boolean activate)
+```
+
+
+문서에 페이지를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 추가될 페이지. |
+| 활성화 | boolean | 추가된 페이지를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(float width, float height) {#addPage-float-float-}
+```
+public XpsPage addPage(float width, float height)
+```
+
+
+지정된 width와 height로 문서에 빈 페이지를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 새 페이지의 너비. |
+| 높이 | float | 새 페이지의 높이. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPage(float width, float height, boolean activate) {#addPage-float-float-boolean-}
+```
+public XpsPage addPage(float width, float height, boolean activate)
+```
+
+
+지정된 width와 height로 문서에 빈 페이지를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 너비 | float | 새 페이지의 너비. |
+| 높이 | float | 새 페이지의 높이. |
+| 활성화 | boolean | 추가된 페이지를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Added page.
+### addPath(XpsPathGeometry data) {#addPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath addPath(XpsPathGeometry data)
+```
+
+
+활성 페이지에 새로운 경로를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Added path.
+### close() {#close--}
+```
+public void close()
+```
+
+
+인스턴스를 해제합니다.
+
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection)
+```
+
+
+새 스트로크된 타원 호 세그먼트를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | java.awt.geom.Point2D | 타원 호의 끝점. |
+| 크기 | java.awt.geom.Dimension2D | 타원 호의 x와 y 반지름을 x,y 쌍으로 나타냅니다. |
+| rotationAngle | float | 현재 좌표계에 대해 타원이 어떻게 회전되는지를 나타냅니다. |
+| isLargeArc | boolean | 호가 180도 이상을 휘어 그려지는지 여부를 결정합니다. |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 호가 그려지는 방향입니다. |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked) {#createArcSegment-java.awt.geom.Point2D-java.awt.geom.Dimension2D-float-boolean-com.aspose.xps.XpsSweepDirection-boolean-}
+```
+public XpsArcSegment createArcSegment(Point2D point, Dimension2D size, float rotationAngle, boolean isLargeArc, XpsSweepDirection sweepDirection, boolean isStroked)
+```
+
+
+새 타원 호 세그먼트를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | java.awt.geom.Point2D | 타원 호의 끝점. |
+| 크기 | java.awt.geom.Dimension2D | 타원 호의 x와 y 반지름을 x,y 쌍으로 나타냅니다. |
+| rotationAngle | float | 현재 좌표계에 대해 타원이 어떻게 회전되는지를 나타냅니다. |
+| isLargeArc | boolean | 호가 180도 이상을 휘어 그려지는지 여부를 결정합니다. |
+| sweepDirection | [XpsSweepDirection](../../com.aspose.xps/xpssweepdirection) | 호가 그려지는 방향입니다. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsArcSegment](../../com.aspose.xps/xpsarcsegment) - New elliptical arc segment.
+### createCanvas() {#createCanvas--}
+```
+public XpsCanvas createCanvas()
+```
+
+
+새 canvas를 생성합니다
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - New canvas.
+### createColor(XpsIccProfile iccProfile, float[] components) {#createColor-com.aspose.xps.XpsIccProfile-float...-}
+```
+public XpsColor createColor(XpsIccProfile iccProfile, float[] components)
+```
+
+
+ICC 기반 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| iccProfile | [XpsIccProfile](../../com.aspose.xps/xpsiccprofile) | ICC 프로파일 리소스입니다. |
+| components | float[] | 색상 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float r, float g, float b) {#createColor-float-float-float-}
+```
+public XpsColor createColor(float r, float g, float b)
+```
+
+
+scRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| r | float | 빨간색 구성 요소입니다. |
+| g | float | 녹색 구성 요소입니다. |
+| b | float | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(float a, float r, float g, float b) {#createColor-float-float-float-float-}
+```
+public XpsColor createColor(float a, float r, float g, float b)
+```
+
+
+scRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | float | 알파 색상 구성 요소입니다. |
+| r | float | 빨간색 구성 요소입니다. |
+| g | float | 녹색 구성 요소입니다. |
+| b | float | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int r, int g, int b) {#createColor-int-int-int-}
+```
+public XpsColor createColor(int r, int g, int b)
+```
+
+
+sRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| r | int | 빨간색 구성 요소입니다. |
+| g | int | 녹색 구성 요소입니다. |
+| b | int | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(int a, int r, int g, int b) {#createColor-int-int-int-int-}
+```
+public XpsColor createColor(int a, int r, int g, int b)
+```
+
+
+sRGB 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | int | 알파 색상 구성 요소입니다. |
+| r | int | 빨간색 구성 요소입니다. |
+| g | int | 녹색 구성 요소입니다. |
+| b | int | 파란색 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(Color color) {#createColor-java.awt.Color-}
+```
+public XpsColor createColor(Color color)
+```
+
+
+새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | java.awt.Color | RGB 색상에 대한 네이티브 색상 인스턴스입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createColor(String path, float[] components) {#createColor-java.lang.String-float...-}
+```
+public XpsColor createColor(String path, float[] components)
+```
+
+
+ICC 기반 색 공간에서 새 색을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.lang.String | ICC 프로파일 경로입니다. |
+| components | float[] | 색상 구성 요소입니다. |
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - New color.
+### createFont(InputStream stream) {#createFont-java.io.InputStream-}
+```
+public XpsFont createFont(InputStream stream)
+```
+
+
+스트림에서 새로운 TrueType 글꼴 리소스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 리소스로 사용할 ICC 프로파일을 포함하는 스트림. |
+
+**Returns:**
+[XpsFont](../../com.aspose.xps/xpsfont) - New TrueType font resource.
+### createFont(String fontFamily, XpsFontStyle fontStyle) {#createFont-java.lang.String-com.aspose.xps.XpsFontStyle-}
+```
+public XpsFont createFont(String fontFamily, XpsFontStyle fontStyle)
+```
+
+
+새로운 TrueType 글꼴 리소스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 폰트 스타일. 결합 가능한 값에 대해서는 XpsFont 클래스 상수(비트 플래그)를 참조하십시오. |
+
+**Returns:**
+[XpsFont](../../com.aspose.xps/xpsfont) - New TrueType font resource.
+### createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString) {#createGlyphs-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(XpsFont font, float fontRenderingEmSize, float originX, float originY, String unicodeString)
+```
+
+
+새 glyphs를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | 폰트 리소스. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#createGlyphs-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs createGlyphs(String fontFamily, float fontRenderingEmSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+새 glyphs를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontRenderingEmSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - New glyphs.
+### createGradientStop(XpsColor color, float offset) {#createGradientStop-com.aspose.xps.XpsColor-float-}
+```
+public XpsGradientStop createGradientStop(XpsColor color, float offset)
+```
+
+
+새 그라디언트 스톱을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | 그라디언트 정지 색상입니다. |
+| 오프셋 | float | 그라디언트 오프셋. |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createGradientStop(Color color, float offset) {#createGradientStop-java.awt.Color-float-}
+```
+public XpsGradientStop createGradientStop(Color color, float offset)
+```
+
+
+새 그라디언트 스톱을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | java.awt.Color | 그라디언트 정지 색상입니다. |
+| 오프셋 | float | 그라디언트 오프셋. |
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - New gradient stop.
+### createIccProfile(InputStream stream) {#createIccProfile-java.io.InputStream-}
+```
+public XpsIccProfile createIccProfile(InputStream stream)
+```
+
+
+스트림에서 새로운 ICC 프로파일 리소스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 리소스로 사용할 ICC 프로파일을 포함하는 스트림. |
+
+**Returns:**
+[XpsIccProfile](../../com.aspose.xps/xpsiccprofile) - New ICC profile resource.
+### createIccProfile(String iccProfilePath) {#createIccProfile-java.lang.String-}
+```
+public XpsIccProfile createIccProfile(String iccProfilePath)
+```
+
+
+iccProfilePath에 위치한 ICC 프로파일 파일에서 새로운 ICC 프로파일 리소스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| iccProfilePath | java.lang.String | 리소스로 사용할 ICC 프로파일 경로. |
+
+**Returns:**
+[XpsIccProfile](../../com.aspose.xps/xpsiccprofile) - New ICC profile resource.
+### createImage(InputStream stream) {#createImage-java.io.InputStream-}
+```
+public XpsImage createImage(InputStream stream)
+```
+
+
+스트림에서 새로운 이미지 리소스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.InputStream | 리소스로 사용할 이미지를 포함하는 스트림. |
+
+**Returns:**
+[XpsImage](../../com.aspose.xps/xpsimage) - New image resource.
+### createImage(String imagePath) {#createImage-java.lang.String-}
+```
+public XpsImage createImage(String imagePath)
+```
+
+
+imagePath에 위치한 이미지 파일에서 새로운 이미지 리소스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imagePath | java.lang.String | 리소스로 사용할 이미지 경로. |
+
+**Returns:**
+[XpsImage](../../com.aspose.xps/xpsimage) - New image resource.
+### createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-com.aspose.xps.XpsImage-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(XpsImage image, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+새 이미지 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| image | [XpsImage](../../com.aspose.xps/xpsimage) | 이미지 리소스입니다. |
+| 뷰박스 | java.awt.geom.Rectangle2D | 브러시 소스 콘텐츠의 위치와 차원입니다. |
+| 뷰포트 | java.awt.geom.Rectangle2D | 프라임 브러시 타일이 포함된 좌표 공간에서 (반복적으로) 적용되어 브러시가 적용되는 영역을 채우는 영역. |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport) {#createImageBrush-java.lang.String-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsImageBrush createImageBrush(String imagePath, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+새 이미지 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| imagePath | java.lang.String | 브러시 타일로 사용할 이미지의 경로입니다. |
+| 뷰박스 | java.awt.geom.Rectangle2D | 브러시 소스 콘텐츠의 위치와 차원입니다. |
+| 뷰포트 | java.awt.geom.Rectangle2D | 프라임 브러시 타일이 포함된 좌표 공간에서 (반복적으로) 적용되어 브러시가 적용되는 영역을 채우는 영역. |
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - New image brush.
+### createLinearGradientBrush(Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(Point2D startPoint, Point2D endPoint)
+```
+
+
+새 선형 그라디언트 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 선형 그라디언트의 시작점입니다. |
+| endPoint | java.awt.geom.Point2D | 선형 그라디언트의 끝점입니다. |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint) {#createLinearGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-}
+```
+public XpsLinearGradientBrush createLinearGradientBrush(List<XpsGradientStop> gradientStops, Point2D startPoint, Point2D endPoint)
+```
+
+
+새 선형 그라디언트 브러시를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| gradientStops | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트 스톱 목록입니다. |
+| startPoint | java.awt.geom.Point2D | 선형 그라디언트의 시작점입니다. |
+| endPoint | java.awt.geom.Point2D | 선형 그라디언트의 끝점입니다. |
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - New linear gradient brush.
+### createMatrix(float m11, float m12, float m21, float m22, float m31, float m32) {#createMatrix-float-float-float-float-float-float-}
+```
+public XpsMatrix createMatrix(float m11, float m12, float m21, float m22, float m31, float m32)
+```
+
+
+새 어파인 변환 행렬을 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| m11 | float | 요소 11. |
+| m12 | float | 요소 12. |
+| m21 | float | 요소 21. |
+| m22 | float | 요소 22. |
+| m31 | float | 요소 31. |
+| m32 | float | 요소 32. |
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - New affine transformation matrix.
+### createPath(XpsPathGeometry data) {#createPath-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath createPath(XpsPathGeometry data)
+```
+
+
+새 path를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - New path.
+### createPathFigure(Point2D startPoint) {#createPathFigure-java.awt.geom.Point2D-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint)
+```
+
+
+새 열린 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, boolean isClosed)
+```
+
+
+새 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+| isClosed | boolean | 경로가 닫혀 있는지 여부를 지정합니다. true로 설정하면 스트로크가 "closed"로 그려지며, 즉 경로 도형의 마지막 세그먼트의 마지막 점이 StartPoint 속성에 지정된 점과 연결됩니다. 그렇지 않으면 스트로크가 "open"으로 그려지고 마지막 점이 시작점과 연결되지 않습니다. 이 속성은 스트로크를 지정하는 Path 요소에서 경로 도형이 사용될 때만 적용됩니다. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments)
+```
+
+
+새 열린 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | 경로 세그먼트 목록. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed) {#createPathFigure-java.awt.geom.Point2D-java.util.List-com.aspose.xps.XpsPathSegment--boolean-}
+```
+public XpsPathFigure createPathFigure(Point2D startPoint, List<XpsPathSegment> segments, boolean isClosed)
+```
+
+
+새 path 피규어를 생성합니다
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| startPoint | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+| segments | java.util.List<com.aspose.xps.XpsPathSegment> | 경로 세그먼트 목록. |
+| isClosed | boolean | 경로가 닫혀 있는지 여부를 지정합니다. true로 설정하면 스트로크가 "closed"로 그려지며, 즉 경로 도형의 마지막 세그먼트의 마지막 점이 StartPoint 속성에 지정된 점과 연결됩니다. 그렇지 않으면 스트로크가 "open"으로 그려지고 마지막 점이 시작점과 연결되지 않습니다. 이 속성은 스트로크를 지정하는 Path 요소에서 경로 도형이 사용될 때만 적용됩니다. |
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - New path figure.
+### createPathGeometry() {#createPathGeometry--}
+```
+public XpsPathGeometry createPathGeometry()
+```
+
+
+새 path 기하학을 생성합니다
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(String abbreviatedGeometry) {#createPathGeometry-java.lang.String-}
+```
+public XpsPathGeometry createPathGeometry(String abbreviatedGeometry)
+```
+
+
+축약형으로 지정된 새로운 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| abbreviatedGeometry | java.lang.String | 경로 기하학의 축약형. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPathGeometry(List<XpsPathFigure> pathFigures) {#createPathGeometry-java.util.List-com.aspose.xps.XpsPathFigure--}
+```
+public XpsPathGeometry createPathGeometry(List<XpsPathFigure> pathFigures)
+```
+
+
+지정된 경로 도형 목록으로 새로운 경로 기하학을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pathFigures | java.util.List<com.aspose.xps.XpsPathFigure> | 경로 도형 목록. |
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - New path geometry.
+### createPolyBezierSegment(Point2D[] points) {#createPolyBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points)
+```
+
+
+새로운 스트로크된 3차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 B?베지어 세그먼트에 대한 제어점. |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyBezierSegment(Point2D[] points, boolean isStroked) {#createPolyBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyBezierSegment createPolyBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+새로운 3차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 B?베지어 세그먼트에 대한 제어점. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - New cubic B?zier curves segment.
+### createPolyLineSegment(Point2D[] points) {#createPolyLineSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points)
+```
+
+
+임의 개수의 개별 정점을 포함하는 새로운 스트로크된 다각형 그리기를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 폴리라인 세그먼트를 정의하는 다중 세그먼트에 대한 좌표 집합. |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyLineSegment(Point2D[] points, boolean isStroked) {#createPolyLineSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyLineSegment createPolyLineSegment(Point2D[] points, boolean isStroked)
+```
+
+
+임의 개수의 개별 정점을 포함하는 새로운 다각형 그리기를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 폴리라인 세그먼트를 정의하는 다중 세그먼트에 대한 좌표 집합. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - New polygonal drawing segment.
+### createPolyQuadraticBezierSegment(Point2D[] points) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points)
+```
+
+
+지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 스트로크된 2차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 2차 B?베지어 세그먼트에 대한 제어점. |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked) {#createPolyQuadraticBezierSegment-java.awt.geom.Point2D---boolean-}
+```
+public XpsPolyQuadraticBezierSegment createPolyQuadraticBezierSegment(Point2D[] points, boolean isStroked)
+```
+
+
+지정된 제어점을 사용하여 경로 도형의 이전 점에서 정점 집합을 통해 2차 베지어 곡선 집합을 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 다중 2차 B?베지어 세그먼트에 대한 제어점. |
+| isStroked | boolean | 경로의 이 구간에 대한 스트로크가 그려지는지 여부를 지정합니다. |
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - New quadratic B?zier curves segment.
+### createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+새로운 방사형 그라디언트 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| center | java.awt.geom.Point2D | 방사형 그라디언트의 중심점(즉, 타원의 중심). |
+| gradientOrigin | java.awt.geom.Point2D | 방사형 그라디언트의 원점. |
+| radiusX | float | 방사형 그라디언트를 정의하는 타원의 x 차원 반경. |
+| radiusY | float | 방사형 그라디언트를 정의하는 타원의 y 차원 반경. |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY) {#createRadialGradientBrush-java.util.List-com.aspose.xps.XpsGradientStop--java.awt.geom.Point2D-java.awt.geom.Point2D-float-float-}
+```
+public XpsRadialGradientBrush createRadialGradientBrush(List<XpsGradientStop> gradientStops, Point2D center, Point2D gradientOrigin, float radiusX, float radiusY)
+```
+
+
+새로운 방사형 그라디언트 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| gradientStops | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트 스톱 목록입니다. |
+| center | java.awt.geom.Point2D | 방사형 그라디언트의 중심점(즉, 타원의 중심). |
+| gradientOrigin | java.awt.geom.Point2D | 방사형 그라디언트의 원점. |
+| radiusX | float | 방사형 그라디언트를 정의하는 타원의 x 차원 반경. |
+| radiusY | float | 방사형 그라디언트를 정의하는 타원의 y 차원 반경. |
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - New radial gradient brush.
+### createSolidColorBrush(XpsColor color) {#createSolidColorBrush-com.aspose.xps.XpsColor-}
+```
+public XpsSolidColorBrush createSolidColorBrush(XpsColor color)
+```
+
+
+새로운 단색 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | [XpsColor](../../com.aspose.xps/xpscolor) | 채워진 요소의 색상. |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createSolidColorBrush(Color color) {#createSolidColorBrush-java.awt.Color-}
+```
+public XpsSolidColorBrush createSolidColorBrush(Color color)
+```
+
+
+새로운 단색 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| color | java.awt.Color | 채워진 요소의 색상. |
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - New solid color brush.
+### createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport) {#createVisualBrush-com.aspose.xps.XpsContentElement-java.awt.geom.Rectangle2D-java.awt.geom.Rectangle2D-}
+```
+public XpsVisualBrush createVisualBrush(XpsContentElement element, Rectangle2D viewbox, Rectangle2D viewport)
+```
+
+
+새로운 비주얼 브러시를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| element | [XpsContentElement](../../com.aspose.xps/xpscontentelement) | Visual 속성의 시각적 브러시를 위한 XPS 요소(Canvas, Path 또는 Glyphs). |
+| 뷰박스 | java.awt.geom.Rectangle2D | 브러시 소스 콘텐츠의 위치와 차원입니다. |
+| 뷰포트 | java.awt.geom.Rectangle2D | 프라임 브러시 타일이 포함된 좌표 공간에서 (반복적으로) 적용되어 브러시가 적용되는 영역을 채우는 영역. |
+
+**Returns:**
+[XpsVisualBrush](../../com.aspose.xps/xpsvisualbrush) - New visual brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getActiveDocument() {#getActiveDocument--}
+```
+public int getActiveDocument()
+```
+
+
+활성 문서 번호를 반환합니다.
+
+**Returns:**
+int - 정수 값.
+### getActivePage() {#getActivePage--}
+```
+public int getActivePage()
+```
+
+
+활성 문서 내의 활성 페이지 번호를 반환합니다.
+
+**Returns:**
+int - 정수 값.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDocumentCount() {#getDocumentCount--}
+```
+public int getDocumentCount()
+```
+
+
+XPS 패키지 내부의 문서 수를 반환합니다.
+
+**Returns:**
+int - XPS 패키지 내부에 있는 문서 수.
+### getDocumentPrintTicket(int documentIndex) {#getDocumentPrintTicket-int-}
+```
+public DocumentPrintTicket getDocumentPrintTicket(int documentIndex)
+```
+
+
+documentIndex로 인덱싱된 문서의 인쇄 티켓을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentIndex | int | 반환할 인쇄 티켓이 있는 문서의 인덱스. |
+
+**Returns:**
+[DocumentPrintTicket](../../com.aspose.xps.metadata/documentprintticket) - Document's print ticket.
+### getJobPrintTicket() {#getJobPrintTicket--}
+```
+public JobPrintTicket getJobPrintTicket()
+```
+
+
+문서의 작업 인쇄 티켓을 반환합니다.
+
+**Returns:**
+[JobPrintTicket](../../com.aspose.xps.metadata/jobprintticket) - The document's job print ticket.
+### getPage() {#getPage--}
+```
+public XpsPage getPage()
+```
+
+
+활성 페이지에 대한 XpsPage 인스턴스를 반환합니다.
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - The  XpsPage  instance for active page.
+### getPageCount() {#getPageCount--}
+```
+public int getPageCount()
+```
+
+
+활성 문서의 페이지 수를 반환합니다.
+
+**Returns:**
+int - 활성 문서의 페이지 수.
+### getPagePrintTicket(int documentIndex, int pageIndex) {#getPagePrintTicket-int-int-}
+```
+public PagePrintTicket getPagePrintTicket(int documentIndex, int pageIndex)
+```
+
+
+documentIndex로 인덱싱된 문서 내 pageIndex로 인덱싱된 페이지의 인쇄 티켓을 가져옵니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentIndex | int | 문서의 인덱스. |
+| pageIndex | int | 반환할 인쇄 티켓이 있는 페이지의 인덱스. |
+
+**Returns:**
+[PagePrintTicket](../../com.aspose.xps.metadata/pageprintticket) - Page's print ticket.
+### getTotalPageCount() {#getTotalPageCount--}
+```
+public int getTotalPageCount()
+```
+
+
+XPS 문서 내부 모든 문서의 전체 페이지 수를 반환합니다.
+
+**Returns:**
+int - XPS 문서 내 모든 문서의 총 페이지 수.
+### getUtils() {#getUtils--}
+```
+public DocumentUtils getUtils()
+```
+
+
+공식 XPS 조작 API를 넘어서는 유틸리티를 제공하는 객체를 가져옵니다.
+
+**Returns:**
+[DocumentUtils](../../com.aspose.xps/documentutils) - The utilities object.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insertCanvas(int index) {#insertCanvas-int-}
+```
+public XpsCanvas insertCanvas(int index)
+```
+
+
+index 위치에 새로운 캔버스를 활성 페이지에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 캔버스를 삽입해야 하는 위치. |
+
+**Returns:**
+[XpsCanvas](../../com.aspose.xps/xpscanvas) - Inserted canvas.
+### insertDocument(int index) {#insertDocument-int-}
+```
+public void insertDocument(int index)
+```
+
+
+index 위치에 기본 페이지 크기의 빈 문서를 삽입하고 삽입된 문서를 활성화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 문서를 삽입해야 하는 위치. |
+
+### insertDocument(int index, boolean activate) {#insertDocument-int-boolean-}
+```
+public void insertDocument(int index, boolean activate)
+```
+
+
+index 위치에 기본 페이지 크기의 빈 문서를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 문서를 삽입해야 하는 위치. |
+| 활성화 | boolean | 삽입된 문서를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+### insertDocument(int index, float width, float height) {#insertDocument-int-float-float-}
+```
+public void insertDocument(int index, float width, float height)
+```
+
+
+index 위치에 첫 페이지 차원 width와 height를 가진 빈 문서를 삽입하고 삽입된 문서를 활성화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 문서를 삽입해야 하는 위치. |
+| 너비 | float | 첫 번째 페이지의 너비. |
+| 높이 | float | 첫 번째 페이지의 높이. |
+
+### insertDocument(int index, float width, float height, boolean activate) {#insertDocument-int-float-float-boolean-}
+```
+public void insertDocument(int index, float width, float height, boolean activate)
+```
+
+
+첫 페이지 차원인  width  와  height  로 빈 문서를 인덱스  position 에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 문서를 삽입해야 하는 위치. |
+| 너비 | float | 첫 번째 페이지의 너비. |
+| 높이 | float | 첫 번째 페이지의 높이. |
+| 활성화 | boolean | 삽입된 문서를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+### insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString) {#insertGlyphs-int-com.aspose.xps.XpsFont-float-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, XpsFont font, float fontSize, float originX, float originY, String unicodeString)
+```
+
+
+활성 페이지에 새 글리프를 인덱스  position 에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 글리프를 삽입해야 하는 위치. |
+| font | [XpsFont](../../com.aspose.xps/xpsfont) | 폰트 리소스. |
+| fontSize | float | 폰트 크기. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString) {#insertGlyphs-int-java.lang.String-float-com.aspose.xps.XpsFontStyle-float-float-java.lang.String-}
+```
+public XpsGlyphs insertGlyphs(int index, String fontFamily, float fontSize, XpsFontStyle fontStyle, float originX, float originY, String unicodeString)
+```
+
+
+활성 페이지에 새 글리프를 인덱스  position 에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 글리프를 삽입해야 하는 위치. |
+| fontFamily | java.lang.String | 폰트 패밀리. |
+| fontSize | float | 폰트 크기. |
+| fontStyle | [XpsFontStyle](../../com.aspose.xps/xpsfontstyle) | 글꼴 스타일. |
+| originX | float | 글리프 원점 X 좌표. |
+| originY | float | 글리프 원점 Y 좌표. |
+| unicodeString | java.lang.String | 출력할 문자열. |
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Inserted glyphs.
+### insertPage(int index) {#insertPage-int-}
+```
+public XpsPage insertPage(int index)
+```
+
+
+기본 페이지 크기로 빈 페이지를 인덱스  position 에 문서에 삽입하고 삽입된 페이지를 활성화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 삽입해야 하는 위치. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, boolean activate) {#insertPage-int-boolean-}
+```
+public XpsPage insertPage(int index, boolean activate)
+```
+
+
+기본 페이지 크기로 빈 페이지를 인덱스  position 에 문서에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 삽입해야 하는 위치. |
+| 활성화 | boolean | 삽입된 페이지를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, XpsPage page) {#insertPage-int-com.aspose.xps.XpsPage-}
+```
+public XpsPage insertPage(int index, XpsPage page)
+```
+
+
+페이지를 인덱스  position 에 문서에 삽입하고 삽입된 페이지를 활성화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 추가해야 하는 위치. |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 삽입될 페이지. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, XpsPage page, boolean activate) {#insertPage-int-com.aspose.xps.XpsPage-boolean-}
+```
+public XpsPage insertPage(int index, XpsPage page, boolean activate)
+```
+
+
+페이지를 인덱스  position 에 문서에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 추가해야 하는 위치. |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 삽입될 페이지. |
+| 활성화 | boolean | 삽입된 페이지를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, float width, float height) {#insertPage-int-float-float-}
+```
+public XpsPage insertPage(int index, float width, float height)
+```
+
+
+지정된  width  와  height  로 빈 페이지를 인덱스  position 에 문서에 삽입하고 삽입된 페이지를 활성화합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 삽입해야 하는 위치. |
+| 너비 | float | 새 페이지의 너비. |
+| 높이 | float | 새 페이지의 높이. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPage(int index, float width, float height, boolean activate) {#insertPage-int-float-float-boolean-}
+```
+public XpsPage insertPage(int index, float width, float height, boolean activate)
+```
+
+
+지정된  width  와  height  로 빈 페이지를 인덱스  position 에 문서에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 삽입해야 하는 위치. |
+| 너비 | float | 새 페이지의 너비. |
+| 높이 | float | 새 페이지의 높이. |
+| 활성화 | boolean | 삽입된 페이지를 활성으로 선택할지 여부를 나타내는 플래그. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Inserted page.
+### insertPath(int index, XpsPathGeometry data) {#insertPath-int-com.aspose.xps.XpsPathGeometry-}
+```
+public XpsPath insertPath(int index, XpsPathGeometry data)
+```
+
+
+새 경로를 활성 페이지에 인덱스  position 에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 새 경로를 삽입해야 하는 위치. |
+| data | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Inserted path.
+### isLicensed() {#isLicensed--}
+```
+public boolean isLicensed()
+```
+
+
+Aspose.Page for Java 제품 라이선스에 접근했는지 및 유효한지 여부를 나타냅니다.
+
+**Returns:**
+boolean - boolean 값
+### merge(String[] filesForMerge, OutputStream outStream) {#merge-java.lang.String---java.io.OutputStream-}
+```
+public void merge(String[] filesForMerge, OutputStream outStream)
+```
+
+
+여러 XPS 파일을 하나의 XPS 문서로 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | 이 문서와 병합할 XPS 파일. |
+| outStream | java.io.OutputStream | 병합된 XPS 문서를 저장할 출력 스트림. |
+
+### merge(String[] filesForMerge, String outXpsFilePath) {#merge-java.lang.String---java.lang.String-}
+```
+public void merge(String[] filesForMerge, String outXpsFilePath)
+```
+
+
+여러 XPS 파일을 하나의 XPS 문서로 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | 이 문서와 병합할 XPS 파일. |
+| outXpsFilePath | java.lang.String | 출력 XPS 파일 경로. |
+
+### mergeToPdf(String outPdfFilePath, String[] filesForMerge, PdfSaveOptions options) {#mergeToPdf-java.lang.String-java.lang.String---com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void mergeToPdf(String outPdfFilePath, String[] filesForMerge, PdfSaveOptions options)
+```
+
+
+Device 인스턴스를 사용하여 XPS 문서를 PDF로 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 출력 PDF 파일 경로. |
+| filesForMerge | java.lang.String[] | 이 문서를 출력 장치와 병합할 XPS 파일. |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | 문서 저장 옵션. |
+
+### mergeToPdf(String[] filesForMerge, OutputStream pdfStream, PdfSaveOptions options) {#mergeToPdf-java.lang.String---java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void mergeToPdf(String[] filesForMerge, OutputStream pdfStream, PdfSaveOptions options)
+```
+
+
+Device 인스턴스를 사용하여 XPS 문서를 PDF로 병합합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| filesForMerge | java.lang.String[] | 이 문서를 출력 장치와 병합할 XPS 파일. |
+| pdfStream | java.io.OutputStream | 결과 PDF를 쓸 출력 스트림. |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | 문서 저장 옵션. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### removeAt(int index) {#removeAt-int-}
+```
+public XpsContentElement removeAt(int index)
+```
+
+
+활성 페이지에서 인덱스  position 에 있는 요소를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 요소를 제거해야 하는 위치. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Removed element.
+### removeDocumentAt(int index) {#removeDocumentAt-int-}
+```
+public void removeDocumentAt(int index)
+```
+
+
+인덱스  position 에 있는 문서를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 문서를 제거해야 하는 위치. |
+
+### removePage(XpsPage page) {#removePage-com.aspose.xps.XpsPage-}
+```
+public XpsPage removePage(XpsPage page)
+```
+
+
+문서에서 페이지를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| page | [XpsPage](../../com.aspose.xps/xpspage) | 제거될 페이지. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Removed page.
+### removePageAt(int index) {#removePageAt-int-}
+```
+public XpsPage removePageAt(int index)
+```
+
+
+문서에서 인덱스  position 에 있는 페이지를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 페이지를 제거해야 하는 위치. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Removed page.
+### save(Device device, SaveOptions options) {#save-com.aspose.page.Device-com.aspose.page.SaveOptions-}
+```
+public void save(Device device, SaveOptions options)
+```
+
+
+Device 인스턴스를 사용하여 문서를 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| device | [Device](../../com.aspose.page/device) | 그  Device  인스턴스. |
+| options | [SaveOptions](../../com.aspose.page/saveoptions) | 문서 저장 옵션. |
+
+### save(OutputStream stream) {#save-java.io.OutputStream-}
+```
+public void save(OutputStream stream)
+```
+
+
+XPS 문서를 스트림에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 스트림 XPS 문서를 저장할 대상. |
+
+### save(String path) {#save-java.lang.String-}
+```
+public void save(String path)
+```
+
+
+XPS 문서를 경로  path 에 있는 XPS 파일에 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| path | java.lang.String | 문서의 위치. |
+
+### saveAsImage(ImageSaveOptions options) {#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-}
+```
+public void saveAsImage(ImageSaveOptions options)
+```
+
+
+문서를 이미지 파일로 저장합니다. 출력 디렉터리와 파일 이름은 입력 XPS 파일과 동일합니다. 파일 확장자는 "options" 매개변수에 지정된 이미지 형식에 따라 결정됩니다. 문서가 FileInputStream이 아닌 스트림으로 초기화된 경우, 이미지 파일은 현재 폴더에 기본 파일 이름 템플릿으로 저장됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions) | 비트맵 이미지 형식으로 문서를 저장하기 위한 옵션. |
+
+### saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate) {#saveAsImage-com.aspose.xps.rendering.ImageSaveOptions-java.lang.String-java.lang.String-}
+```
+public void saveAsImage(ImageSaveOptions options, String outDir, String fileNameTemplate)
+```
+
+
+문서를 지정된 디렉터리와 지정된 파일 이름으로 이미지 파일에 저장합니다. 파일 확장자는 "options" 매개변수에 지정된 이미지 형식에 따라 결정됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions) | 비트맵 이미지 형식으로 문서를 저장하기 위한 옵션. |
+| outDir | java.lang.String | 이미지 파일이 저장될 출력 디렉터리. |
+| fileNameTemplate | java.lang.String | 이미지 파일 이름 템플릿(확장자 제외)입니다. 입력 XPS 파일이 1페이지인 경우 정확히 해당 파일 이름이 사용되고, 그렇지 않으면 "\_[n]" 형태가 되며, 여기서 "n"은 1부터 시작하는 페이지 번호를 의미하고 접미사가 추가됩니다. 파일 확장자는 "option" 매개변수에 지정된 이미지 형식에 따라 결정됩니다. |
+
+### saveAsImageBytes(ImageSaveOptions options) {#saveAsImageBytes-com.aspose.xps.rendering.ImageSaveOptions-}
+```
+public byte[][][] saveAsImageBytes(ImageSaveOptions options)
+```
+
+
+문서를 비트맵 이미지 형식으로 바이트 배열로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| options | [ImageSaveOptions](../../com.aspose.xps.rendering/imagesaveoptions) | 비트맵 이미지 형식으로 문서를 저장하기 위한 옵션. |
+
+**Returns:**
+byte[][][] - 결과 이미지 바이트 배열입니다. 첫 번째 차원은 내부 문서를, 두 번째 차원은 내부 문서 내 페이지를 나타냅니다.
+### saveAsPdf(OutputStream stream, PdfSaveOptions options) {#saveAsPdf-java.io.OutputStream-com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void saveAsPdf(OutputStream stream, PdfSaveOptions options)
+```
+
+
+문서를 PDF 형식으로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 출력 PDF 파일을 기록할 스트림. |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | PDF 형식으로 문서를 저장하기 위한 옵션. |
+
+### saveAsPdf(String outPdfFilePath, PdfSaveOptions options) {#saveAsPdf-java.lang.String-com.aspose.xps.rendering.PdfSaveOptions-}
+```
+public void saveAsPdf(String outPdfFilePath, PdfSaveOptions options)
+```
+
+
+문서를 PDF 형식으로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPdfFilePath | java.lang.String | 출력 PDF 파일 경로. |
+| options | [PdfSaveOptions](../../com.aspose.xps.rendering/pdfsaveoptions) | PDF 형식으로 문서를 저장하기 위한 옵션. |
+
+### saveAsPs(OutputStream stream, PsSaveOptions options) {#saveAsPs-java.io.OutputStream-com.aspose.eps.device.PsSaveOptions-}
+```
+public void saveAsPs(OutputStream stream, PsSaveOptions options)
+```
+
+
+문서를 PS 형식으로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 스트림 | java.io.OutputStream | 출력 PS 파일을 기록할 스트림. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PS 형식으로 문서를 저장하기 위한 옵션. |
+
+### saveAsPs(String outPsFilePath, PsSaveOptions options) {#saveAsPs-java.lang.String-com.aspose.eps.device.PsSaveOptions-}
+```
+public void saveAsPs(String outPsFilePath, PsSaveOptions options)
+```
+
+
+문서를 PostSscript 형식으로 저장합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| outPsFilePath | java.lang.String | 출력 PostScript 파일 경로. |
+| options | [PsSaveOptions](../../com.aspose.eps.device/pssaveoptions) | PDF 형식으로 문서를 저장하기 위한 옵션. |
+
+### selectActiveDocument(int documentNumber) {#selectActiveDocument-int-}
+```
+public void selectActiveDocument(int documentNumber)
+```
+
+
+편집을 위해 활성 문서를 선택합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentNumber | int | 문서 번호. |
+
+### selectActivePage(int pageNumber) {#selectActivePage-int-}
+```
+public XpsPage selectActivePage(int pageNumber)
+```
+
+
+편집을 위해 활성 문서 페이지를 선택합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| pageNumber | int | 페이지 번호. |
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) -  XpsPage  instance for active page.
+### setDocumentPrintTicket(int documentIndex, DocumentPrintTicket printTicket) {#setDocumentPrintTicket-int-com.aspose.xps.metadata.DocumentPrintTicket-}
+```
+public void setDocumentPrintTicket(int documentIndex, DocumentPrintTicket printTicket)
+```
+
+
+printTicket을 documentIndex로 인덱싱된 문서에 연결합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentIndex | int | 인쇄 티켓을 연결할 문서의 인덱스. |
+| printTicket | [DocumentPrintTicket](../../com.aspose.xps.metadata/documentprintticket) | 연결할 인쇄 티켓. |
+
+### setJobPrintTicket(JobPrintTicket value) {#setJobPrintTicket-com.aspose.xps.metadata.JobPrintTicket-}
+```
+public void setJobPrintTicket(JobPrintTicket value)
+```
+
+
+문서의 작업 인쇄 티켓을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [JobPrintTicket](../../com.aspose.xps.metadata/jobprintticket) | 문서의 작업 인쇄 티켓. |
+
+### setPagePrintTicket(int documentIndex, int pageIndex, PagePrintTicket printTicket) {#setPagePrintTicket-int-int-com.aspose.xps.metadata.PagePrintTicket-}
+```
+public void setPagePrintTicket(int documentIndex, int pageIndex, PagePrintTicket printTicket)
+```
+
+
+printTicket을 documentIndex로 인덱싱된 문서의 pageIndex로 인덱싱된 페이지에 연결합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| documentIndex | int | 문서의 인덱스. |
+| pageIndex | int | 인쇄 티켓을 연결할 페이지의 인덱스. |
+| printTicket | [PagePrintTicket](../../com.aspose.xps.metadata/pageprintticket) | 연결할 인쇄 티켓. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsedgemode/_index.md
+++ b/korean/java/com.aspose.xps/xpsedgemode/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsEdgeMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Canvas 요소의 RenderOptions.EdgeMode 속성에 대한 유효한 값."
+type: docs
+weight: 58
+url: /ko/java/com.aspose.xps/xpsedgemode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsEdgeMode extends Enum<XpsEdgeMode>
+```
+
+Canvas 요소의 RenderOptions.EdgeMode 속성에 대한 유효한 값.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Aliased](#Aliased) | 모서리를 앨리어싱 처리합니다. |
+| [None](#None) | 모서리를 사용자의 기본 방식으로 렌더링합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Aliased {#Aliased}
+```
+public static final XpsEdgeMode Aliased
+```
+
+
+모서리를 앨리어싱 처리합니다.
+
+### None {#None}
+```
+public static final XpsEdgeMode None
+```
+
+
+모서리를 사용자의 기본 방식으로 렌더링합니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsEdgeMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsEdgeMode](../../com.aspose.xps/xpsedgemode)
+### values() {#values--}
+```
+public static XpsEdgeMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsEdgeMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpselement/_index.md
+++ b/korean/java/com.aspose.xps/xpselement/_index.md
@@ -1,0 +1,165 @@
+---
+title: "XpsElement"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 XPS 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 20
+url: /ko/java/com.aspose.xps/xpselement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+
+**All Implemented Interfaces:**
+java.lang.Iterable
+```
+public abstract class XpsElement extends XpsObject implements Iterable<XpsContentElement>
+```
+
+공통 XPS 요소 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpselementlinktarget/_index.md
+++ b/korean/java/com.aspose.xps/xpselementlinktarget/_index.md
@@ -1,0 +1,184 @@
+---
+title: "XpsElementLinkTarget"
+second_title: "Aspose.Page용 Java API 참조"
+description: "상대 명명 주소 하이퍼링크 대상을 캡슐화하는 클래스."
+type: docs
+weight: 21
+url: /ko/java/com.aspose.xps/xpselementlinktarget/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget)
+```
+public final class XpsElementLinkTarget extends XpsHyperlinkTarget
+```
+
+상대 명명 주소 하이퍼링크 대상을 캡슐화하는 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsElementLinkTarget(XpsPage targetPage)](#XpsElementLinkTarget-com.aspose.xps.XpsPage-) | 새 인스턴스를 생성합니다. |
+| [XpsElementLinkTarget(XpsCanvas targetCanvas)](#XpsElementLinkTarget-com.aspose.xps.XpsCanvas-) | 새 인스턴스를 생성합니다. |
+| [XpsElementLinkTarget(XpsPath targetPath)](#XpsElementLinkTarget-com.aspose.xps.XpsPath-) | 새 인스턴스를 생성합니다. |
+| [XpsElementLinkTarget(XpsGlyphs targetGlyphs)](#XpsElementLinkTarget-com.aspose.xps.XpsGlyphs-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsElementLinkTarget(XpsPage targetPage) {#XpsElementLinkTarget-com.aspose.xps.XpsPage-}
+```
+public XpsElementLinkTarget(XpsPage targetPage)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| targetPage | [XpsPage](../../com.aspose.xps/xpspage) | 활성 고정 문서 내에 있는 페이지 요소입니다. |
+
+### XpsElementLinkTarget(XpsCanvas targetCanvas) {#XpsElementLinkTarget-com.aspose.xps.XpsCanvas-}
+```
+public XpsElementLinkTarget(XpsCanvas targetCanvas)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| targetCanvas | [XpsCanvas](../../com.aspose.xps/xpscanvas) | 활성 고정 문서 내에 있는 캔버스 요소입니다. |
+
+### XpsElementLinkTarget(XpsPath targetPath) {#XpsElementLinkTarget-com.aspose.xps.XpsPath-}
+```
+public XpsElementLinkTarget(XpsPath targetPath)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| targetPath | [XpsPath](../../com.aspose.xps/xpspath) | 활성 고정 문서 내에 있는 경로 요소입니다. |
+
+### XpsElementLinkTarget(XpsGlyphs targetGlyphs) {#XpsElementLinkTarget-com.aspose.xps.XpsGlyphs-}
+```
+public XpsElementLinkTarget(XpsGlyphs targetGlyphs)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| targetGlyphs | [XpsGlyphs](../../com.aspose.xps/xpsglyphs) | 활성 고정 문서 내에 있는 글리프 요소입니다. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsexternallinktarget/_index.md
+++ b/korean/java/com.aspose.xps/xpsexternallinktarget/_index.md
@@ -1,0 +1,153 @@
+---
+title: "XpsExternalLinkTarget"
+second_title: "Aspose.Page용 Java API 참조"
+description: "외부 하이퍼링크 대상을 캡슐화하는 클래스."
+type: docs
+weight: 22
+url: /ko/java/com.aspose.xps/xpsexternallinktarget/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget)
+```
+public final class XpsExternalLinkTarget extends XpsHyperlinkTarget
+```
+
+외부 하이퍼링크 대상을 캡슐화하는 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsExternalLinkTarget(String targetUri)](#XpsExternalLinkTarget-java.lang.String-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getTargetUri()](#getTargetUri--) | 대상 URI를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsExternalLinkTarget(String targetUri) {#XpsExternalLinkTarget-java.lang.String-}
+```
+public XpsExternalLinkTarget(String targetUri)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| targetUri | java.lang.String | 외부 대상 URI. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTargetUri() {#getTargetUri--}
+```
+public String getTargetUri()
+```
+
+
+대상 URI를 가져옵니다.
+
+**Returns:**
+java.lang.String - 대상 URI.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsfileresource/_index.md
+++ b/korean/java/com.aspose.xps/xpsfileresource/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsFileResource"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 파일 리소스의 공통 기능을 캡슐화하는 클래스."
+type: docs
+weight: 23
+url: /ko/java/com.aspose.xps/xpsfileresource/
+---
+**Inheritance:**
+java.lang.Object
+```
+public class XpsFileResource
+```
+
+모든 파일 리소스의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsfillrule/_index.md
+++ b/korean/java/com.aspose.xps/xpsfillrule/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsFillRule"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PathGeometry 요소의 FillRule 속성에 대한 유효한 값."
+type: docs
+weight: 59
+url: /ko/java/com.aspose.xps/xpsfillrule/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsFillRule extends Enum<XpsFillRule>
+```
+
+PathGeometry 요소의 FillRule 속성에 대한 유효한 값.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [EvenOdd](#EvenOdd) | 이 규칙은 캔버스상의 점에 대한 “inside” 여부를, 점에서 무한대까지 임의의 방향으로 광선을 그린 뒤 해당 형태의 세그먼트가 광선을 교차하는 횟수를 계산하여 결정합니다. |
+| [NonZero](#NonZero) | 이 규칙은 캔버스상의 점에 대한 “inside” 여부를, 점에서 무한대까지 임의의 방향으로 광선을 그린 뒤 형태의 세그먼트가 광선을 교차하는 위치를 검사하여 결정합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### EvenOdd {#EvenOdd}
+```
+public static final XpsFillRule EvenOdd
+```
+
+
+이 규칙은 캔버스상의 점에 대한 “inside” 여부를, 점에서 무한대까지 임의의 방향으로 광선을 그린 뒤 해당 형태의 세그먼트가 광선을 교차하는 횟수를 계산하여 결정합니다. 이 횟수가 홀수이면 점은 내부에 있고, 짝수이면 외부에 있습니다.
+
+### NonZero {#NonZero}
+```
+public static final XpsFillRule NonZero
+```
+
+
+이 규칙은 캔버스상의 점에 대한 “inside” 여부를, 점에서 무한대까지 임의의 방향으로 광선을 그린 뒤 형태의 세그먼트가 광선을 교차하는 위치를 검사하여 결정합니다. 카운트를 0으로 시작하여, 세그먼트가 왼쪽에서 오른쪽으로 광선을 통과할 때마다 1을 더하고, 오른쪽에서 왼쪽으로 통과할 때마다 1을 빼십시오. 교차 횟수를 계산한 후 결과가 0이면 점은 경로 밖에 있으며, 그렇지 않으면 내부에 있습니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsFillRule valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsFillRule](../../com.aspose.xps/xpsfillrule)
+### values() {#values--}
+```
+public static XpsFillRule[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsFillRule[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsfont/_index.md
+++ b/korean/java/com.aspose.xps/xpsfont/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsFont"
+second_title: "Aspose.Page용 Java API 참조"
+description: "TrueType 글꼴 리소스를 캡슐화하는 클래스."
+type: docs
+weight: 24
+url: /ko/java/com.aspose.xps/xpsfont/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsFileResource](../../com.aspose.xps/xpsfileresource)
+```
+public final class XpsFont extends XpsFileResource
+```
+
+TrueType 글꼴 리소스를 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsfontstyle/_index.md
+++ b/korean/java/com.aspose.xps/xpsfontstyle/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsFontStyle"
+second_title: "Aspose.Page용 Java API 참조"
+description: "글꼴 스타일에 대한 유효한 값입니다."
+type: docs
+weight: 60
+url: /ko/java/com.aspose.xps/xpsfontstyle/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsFontStyle extends Enum<XpsFontStyle>
+```
+
+글꼴 스타일에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Bold](#Bold) | 굵은 텍스트. |
+| [BoldItalic](#BoldItalic) | 굵은 이탤릭 텍스트. |
+| [Italic](#Italic) | 이탤릭 텍스트. |
+| [Regular](#Regular) | 보통 텍스트. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bold {#Bold}
+```
+public static final XpsFontStyle Bold
+```
+
+
+굵은 텍스트.
+
+### BoldItalic {#BoldItalic}
+```
+public static final XpsFontStyle BoldItalic
+```
+
+
+굵은 이탤릭 텍스트.
+
+### Italic {#Italic}
+```
+public static final XpsFontStyle Italic
+```
+
+
+이탤릭 텍스트.
+
+### Regular {#Regular}
+```
+public static final XpsFontStyle Regular
+```
+
+
+보통 텍스트.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsFontStyle valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsFontStyle](../../com.aspose.xps/xpsfontstyle)
+### values() {#values--}
+```
+public static XpsFontStyle[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsFontStyle[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsglyphs/_index.md
+++ b/korean/java/com.aspose.xps/xpsglyphs/_index.md
@@ -1,0 +1,509 @@
+---
+title: "XpsGlyphs"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Glyphs 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 25
+url: /ko/java/com.aspose.xps/xpsglyphs/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement), [com.aspose.xps.XpsContentElement](../../com.aspose.xps/xpscontentelement)
+```
+public final class XpsGlyphs extends XpsContentElement
+```
+
+Glyphs 요소의 기능을 캡슐화하는 클래스입니다. 이 요소는 단일 폰트에서 균일하게 형식이 지정된 텍스트 실행을 나타냅니다. 정확한 렌더링에 필요한 정보를 제공하며, 뷰어에서 검색 및 선택 기능을 지원합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 글리프를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getBidiLevel()](#getBidiLevel--) | Unicode 알고리즘 양방향 중첩 수준을 지정하는 값을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다. |
+| [getFill()](#getFill--) | 렌더링된 글리프의 형태를 채우는 브러시를 반환합니다. |
+| [getFont()](#getFont--) | 요소 텍스트를 조판하는 데 사용되는 TrueType 폰트의 폰트 리소스를 반환합니다. |
+| [getFontRenderingEmSize()](#getFontRenderingEmSize--) | 그리기 표면 단위로 표현된 폰트 크기를 부동 소수점 값으로 반환합니다(유효 좌표 공간 단위). |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | 하이퍼링크 대상 객체를 반환합니다. |
+| [getOpacity()](#getOpacity--) | 요소의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다. |
+| [getOriginX()](#getOriginX--) | 실행에서 첫 번째 글리프의 x 좌표를 유효 좌표 공간 단위로 반환합니다. |
+| [getOriginY()](#getOriginY--) | 실행에서 첫 번째 글리프의 y 좌표를 유효 좌표 공간 단위로 반환합니다. |
+| [getRenderTransform()](#getRenderTransform--) | 요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다. |
+| [getStyleSimulations()](#getStyleSimulations--) | 스타일 시뮬레이션을 지정하는 값을 반환합니다. |
+| [getUnicodeString()](#getUnicodeString--) | Glyphs 요소에 의해 렌더링된 텍스트 문자열을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [isSideways()](#isSideways--) | 글리프가 옆으로 회전했음을 나타내는 값을 반환합니다(원점은 회전되지 않은 글리프의 상단 중앙으로 정의됩니다). |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setBidiLevel(int value)](#setBidiLevel-int-) | Unicode 알고리즘 양방향 중첩 수준을 지정하는 값을 설정합니다. |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다. |
+| [setFill(XpsBrush value)](#setFill-com.aspose.xps.XpsBrush-) | 렌더링된 글리프의 형태를 채우는 브러시를 설정합니다. |
+| [setFontRenderingEmSize(float value)](#setFontRenderingEmSize-float-) | 그리기 표면 단위로 표현된 폰트 크기를 부동 소수점 값으로 설정합니다(유효 좌표 공간 단위). |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | 하이퍼링크 대상 객체를 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 요소의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다. |
+| [setOriginX(float value)](#setOriginX-float-) | 실행에서 첫 번째 글리프의 x 좌표를 유효 좌표 공간 단위로 설정합니다. |
+| [setOriginY(float value)](#setOriginY-float-) | 실행에서 첫 번째 글리프의 y 좌표를 유효 좌표 공간 단위로 설정합니다. |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다. |
+| [setSideways(boolean value)](#setSideways-boolean-) | 글리프가 옆으로 회전했음을 나타내는 값을 설정합니다(원점은 회전되지 않은 글리프의 상단 중앙으로 정의됩니다). |
+| [setStyleSimulations(XpsStyleSimulations value)](#setStyleSimulations-com.aspose.xps.XpsStyleSimulations-) | 스타일 시뮬레이션을 지정하는 값을 설정합니다. |
+| [setUnicodeString(String value)](#setUnicodeString-java.lang.String-) | Glyphs 요소에 의해 렌더링된 텍스트 문자열을 설정합니다. |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsGlyphs deepClone()
+```
+
+
+이 글리프를 복제합니다.
+
+**Returns:**
+[XpsGlyphs](../../com.aspose.xps/xpsglyphs) - Clone of this glyphs.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getBidiLevel() {#getBidiLevel--}
+```
+public int getBidiLevel()
+```
+
+
+Unicode 알고리즘 양방향 중첩 수준을 지정하는 값을 반환합니다. 짝수 값은 왼쪽에서 오른쪽으로 레이아웃됨을 의미하고, 홀수 값은 오른쪽에서 왼쪽으로 레이아웃됨을 의미합니다. 오른쪽에서 왼쪽 레이아웃에서는 실행의 원점을 첫 번째 글리프의 오른쪽에 두며, 양의 전진 폭(왼쪽으로 이동을 나타냄)은 이후 글리프들을 이전 글리프의 왼쪽에 배치합니다.
+
+**Returns:**
+int - Unicode 알고리즘 양방향 중첩 수준을 지정하는 값.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다.
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getFill() {#getFill--}
+```
+public XpsBrush getFill()
+```
+
+
+렌더링된 글리프의 형태를 채우는 브러시를 반환합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush used to fill the shape of the rendered glyphs.
+### getFont() {#getFont--}
+```
+public XpsFont getFont()
+```
+
+
+요소 텍스트를 조판하는 데 사용되는 TrueType 폰트의 폰트 리소스를 반환합니다.
+
+**Returns:**
+[XpsFont](../../com.aspose.xps/xpsfont) - The font resource for the TrueType font used to typeset elements text.
+### getFontRenderingEmSize() {#getFontRenderingEmSize--}
+```
+public float getFontRenderingEmSize()
+```
+
+
+그리기 표면 단위로 표현된 폰트 크기를 부동 소수점 값으로 반환합니다(유효 좌표 공간 단위).
+
+**Returns:**
+float - 글꼴 크기.
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+하이퍼링크 대상 객체를 반환합니다.
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 요소의 균일한 투명성을 정의하는 값.
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getOriginX() {#getOriginX--}
+```
+public float getOriginX()
+```
+
+
+실행에서 첫 번째 글리프의 x 좌표를 유효 좌표 공간 단위로 반환합니다.
+
+**Returns:**
+float - 실행에서 첫 번째 글리프의 x 좌표, 유효 좌표 공간 단위.
+### getOriginY() {#getOriginY--}
+```
+public float getOriginY()
+```
+
+
+실행에서 첫 번째 글리프의 y 좌표를 유효 좌표 공간 단위로 반환합니다.
+
+**Returns:**
+float - 실행에서 첫 번째 글리프의 y 좌표, 유효 좌표 공간 단위.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### getStyleSimulations() {#getStyleSimulations--}
+```
+public XpsStyleSimulations getStyleSimulations()
+```
+
+
+스타일 시뮬레이션을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsStyleSimulations](../../com.aspose.xps/xpsstylesimulations) - The value specifying a style simulation.
+### getUnicodeString() {#getUnicodeString--}
+```
+public String getUnicodeString()
+```
+
+
+Glyphs 요소에 의해 렌더링된 텍스트 문자열을 반환합니다. 텍스트는 Unicode 코드 포인트로 지정됩니다.
+
+**Returns:**
+java.lang.String - Glyphs 요소에 의해 렌더링된 텍스트 문자열.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isSideways() {#isSideways--}
+```
+public boolean isSideways()
+```
+
+
+글리프가 옆으로 회전했음을 나타내는 값을 반환합니다(원점은 회전되지 않은 글리프의 상단 중앙으로 정의됩니다).
+
+**Returns:**
+boolean - 글리프가 옆으로 회전했음을 나타내는 값.
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setBidiLevel(int value) {#setBidiLevel-int-}
+```
+public void setBidiLevel(int value)
+```
+
+
+Unicode 알고리즘 양방향 중첩 수준을 지정하는 값을 설정합니다. 짝수 값은 왼쪽에서 오른쪽 레이아웃을 의미하고, 홀수 값은 오른쪽에서 왼쪽 레이아웃을 의미합니다. 오른쪽에서 왼쪽 레이아웃은 실행 시작점을 첫 번째 글리프의 오른쪽에 두며, 양의 전진 폭(왼쪽으로 이동을 나타냄)은 이후 글리프들을 이전 글리프의 왼쪽에 배치합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | int | Unicode 알고리즘 양방향 중첩 수준을 지정하는 값. |
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 요소의 렌더링 영역을 제한하는 경로 기하학. |
+
+### setFill(XpsBrush value) {#setFill-com.aspose.xps.XpsBrush-}
+```
+public void setFill(XpsBrush value)
+```
+
+
+렌더링된 글리프의 형태를 채우는 브러시를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 렌더링된 글리프의 형태를 채우는 데 사용되는 브러시. |
+
+### setFontRenderingEmSize(float value) {#setFontRenderingEmSize-float-}
+```
+public void setFontRenderingEmSize(float value)
+```
+
+
+그리기 표면 단위로 표현된 폰트 크기를 부동 소수점 값으로 설정합니다(유효 좌표 공간 단위).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 글꼴 크기. |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+하이퍼링크 대상 객체를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | 하이퍼링크 대상 객체. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 요소의 균일한 투명성을 정의하는 값. |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 마스크를 지정하는 브러시. |
+
+### setOriginX(float value) {#setOriginX-float-}
+```
+public void setOriginX(float value)
+```
+
+
+실행에서 첫 번째 글리프의 x 좌표를 유효 좌표 공간 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 실행에서 첫 번째 글리프의 x 좌표, 유효 좌표 공간 단위. |
+
+### setOriginY(float value) {#setOriginY-float-}
+```
+public void setOriginY(float value)
+```
+
+
+실행에서 첫 번째 글리프의 y 좌표를 유효 좌표 공간 단위로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 실행에서 첫 번째 글리프의 y 좌표, 유효 좌표 공간 단위. |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 아핀 변환 행렬. |
+
+### setSideways(boolean value) {#setSideways-boolean-}
+```
+public void setSideways(boolean value)
+```
+
+
+글리프가 옆으로 회전했음을 나타내는 값을 설정합니다(원점은 회전되지 않은 글리프의 상단 중앙으로 정의됩니다).
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 글리프가 옆으로 회전했음을 나타내는 값. |
+
+### setStyleSimulations(XpsStyleSimulations value) {#setStyleSimulations-com.aspose.xps.XpsStyleSimulations-}
+```
+public void setStyleSimulations(XpsStyleSimulations value)
+```
+
+
+스타일 시뮬레이션을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsStyleSimulations](../../com.aspose.xps/xpsstylesimulations) | 스타일 시뮬레이션을 지정하는 값. |
+
+### setUnicodeString(String value) {#setUnicodeString-java.lang.String-}
+```
+public void setUnicodeString(String value)
+```
+
+
+Glyphs 요소에 의해 렌더링된 텍스트 문자열을 설정합니다. 텍스트는 Unicode 코드 포인트로 지정됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | Glyphs 요소에 의해 렌더링된 텍스트 문자열. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsgradientbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpsgradientbrush/_index.md
@@ -1,0 +1,249 @@
+---
+title: "XpsGradientBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "LinerGradientBrush 및 RadialGradientBrush 요소의 공통 기능을 캡슐화하는 클래스."
+type: docs
+weight: 26
+url: /ko/java/com.aspose.xps/xpsgradientbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush)
+```
+public abstract class XpsGradientBrush extends XpsTransformableBrush
+```
+
+LinerGradientBrush 및 RadialGradientBrush 요소의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColorInterpolationMode()](#getColorInterpolationMode--) | 색상 보간을 위한 감마 함수 값을 반환합니다. |
+| [getGradientStops()](#getGradientStops--) | 그라디언트를 구성하는 그라디언트 스톱 목록을 반환합니다. |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getSpreadMethod()](#getSpreadMethod--) | 주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorInterpolationMode(XpsColorInterpolationMode value)](#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-) | 색상 보간을 위한 감마 함수 값을 설정합니다. |
+| [setGradientStops(List<XpsGradientStop> value)](#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--) | 그라디언트를 구성하는 그라디언트 스톱 목록을 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setSpreadMethod(XpsSpreadMethod value)](#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-) | 주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColorInterpolationMode() {#getColorInterpolationMode--}
+```
+public XpsColorInterpolationMode getColorInterpolationMode()
+```
+
+
+색상 보간을 위한 감마 함수 값을 반환합니다. 지정된 경우 감마 조정은 알파 구성 요소에 적용되지 않아야 합니다.
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) - Value specifying the gamma function for color interpolation.
+### getGradientStops() {#getGradientStops--}
+```
+public List<XpsGradientStop> getGradientStops()
+```
+
+
+그라디언트를 구성하는 그라디언트 스톱 목록을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsGradientStop> - 그라디언트를 구성하는 그라디언트 스톱 목록.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getSpreadMethod() {#getSpreadMethod--}
+```
+public XpsSpreadMethod getSpreadMethod()
+```
+
+
+주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 반환합니다.
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) - Value describing how the brush should fill the content area outside of the primary, initial gradient area.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorInterpolationMode(XpsColorInterpolationMode value) {#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-}
+```
+public void setColorInterpolationMode(XpsColorInterpolationMode value)
+```
+
+
+색 보간을 위한 감마 함수를 지정하는 값을 설정합니다. 지정된 경우 감마 조정은 알파 구성 요소에 적용되지 않아야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) | 색 보간을 위한 감마 함수를 지정하는 값. |
+
+### setGradientStops(List<XpsGradientStop> value) {#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--}
+```
+public void setGradientStops(List<XpsGradientStop> value)
+```
+
+
+그라디언트를 구성하는 그라디언트 스톱 목록을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트를 구성하는 그라디언트 스톱 목록. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setSpreadMethod(XpsSpreadMethod value) {#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-}
+```
+public void setSpreadMethod(XpsSpreadMethod value)
+```
+
+
+주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) | 브러시가 기본 초기 그라디언트 영역 외부의 콘텐츠 영역을 채우는 방법을 설명하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsgradientstop/_index.md
+++ b/korean/java/com.aspose.xps/xpsgradientstop/_index.md
@@ -1,0 +1,157 @@
+---
+title: "XpsGradientStop"
+second_title: "Aspose.Page용 Java API 참조"
+description: "GradientStop 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 27
+url: /ko/java/com.aspose.xps/xpsgradientstop/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public final class XpsGradientStop extends XpsObject
+```
+
+GradientStop 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 LinearGradientBrush와 RadialGradientBrush 요소 모두에서 사용되어 그라디언트를 렌더링하기 위한 색상 진행 위치와 범위를 정의합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 그라디언트 스톱을 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | 그라디언트 스톱 색상을 반환합니다. |
+| [getOffset()](#getOffset--) | 그라디언트 오프셋을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsGradientStop deepClone()
+```
+
+
+이 그라디언트 스톱을 복제합니다.
+
+**Returns:**
+[XpsGradientStop](../../com.aspose.xps/xpsgradientstop) - Clone of this gradient stop.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public XpsColor getColor()
+```
+
+
+그라디언트 스톱 색상을 반환합니다.
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - The gradient stop color.
+### getOffset() {#getOffset--}
+```
+public float getOffset()
+```
+
+
+그라디언트 오프셋을 반환합니다. 오프셋은 그라디언트 진행 중 색상이 지정되는 지점을 나타냅니다. 진행 중 오프셋 사이의 색상은 보간됩니다.
+
+**Returns:**
+float - 그라디언트 오프셋.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpshyperlinkelement/_index.md
+++ b/korean/java/com.aspose.xps/xpshyperlinkelement/_index.md
@@ -1,0 +1,187 @@
+---
+title: "XpsHyperlinkElement"
+second_title: "Aspose.Page용 Java API 참조"
+description: "하이퍼링크가 될 수 있는 XPS 요소의 공통 기능을 캡슐화합니다."
+type: docs
+weight: 28
+url: /ko/java/com.aspose.xps/xpshyperlinkelement/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement)
+```
+public abstract class XpsHyperlinkElement extends XpsElement
+```
+
+하이퍼링크가 될 수 있는 XPS 요소의 공통 기능을 캡슐화합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | 하이퍼링크 대상 객체를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | 하이퍼링크 대상 객체를 설정합니다. |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+하이퍼링크 대상 객체를 반환합니다.
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+하이퍼링크 대상 객체를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | 하이퍼링크 대상 객체. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpshyperlinktarget/_index.md
+++ b/korean/java/com.aspose.xps/xpshyperlinktarget/_index.md
@@ -1,0 +1,135 @@
+---
+title: "XpsHyperlinkTarget"
+second_title: "Aspose.Page용 Java API 참조"
+description: "하이퍼링크 대상의 기본 클래스."
+type: docs
+weight: 29
+url: /ko/java/com.aspose.xps/xpshyperlinktarget/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class XpsHyperlinkTarget
+```
+
+하이퍼링크 대상의 기본 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsHyperlinkTarget()](#XpsHyperlinkTarget--) |  |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsHyperlinkTarget() {#XpsHyperlinkTarget--}
+```
+public XpsHyperlinkTarget()
+```
+
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsiccbasedcolor/_index.md
+++ b/korean/java/com.aspose.xps/xpsiccbasedcolor/_index.md
@@ -1,0 +1,146 @@
+---
+title: "XpsIccBasedColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ICC 기반 색상을 캡슐화합니다."
+type: docs
+weight: 30
+url: /ko/java/com.aspose.xps/xpsiccbasedcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsColor](../../com.aspose.xps/xpscolor)
+```
+public final class XpsIccBasedColor extends XpsColor
+```
+
+ICC 기반 색상을 캡슐화합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getIccProfile()](#getIccProfile--) | 색상이 기반하는 ICC 프로파일 리소스를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toColor()](#toColor--) | .NET 네이티브 표현의 ICC 기반 색상을 가져오기 위한 편리한 메서드. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getIccProfile() {#getIccProfile--}
+```
+public XpsIccProfile getIccProfile()
+```
+
+
+색상이 기반하는 ICC 프로파일 리소스를 반환합니다.
+
+**Returns:**
+[XpsIccProfile](../../com.aspose.xps/xpsiccprofile) - The ICC profile resource the color based on.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toColor() {#toColor--}
+```
+public Color toColor()
+```
+
+
+.NET 네이티브 표현의 ICC 기반 색상을 가져오기 위한 편리한 메서드.
+
+**Returns:**
+java.awt.Color - System.Drawing.ColorSystem.Drawing.Color 구조체.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsiccprofile/_index.md
+++ b/korean/java/com.aspose.xps/xpsiccprofile/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsIccProfile"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ICC 프로파일 리소스를 캡슐화하는 클래스."
+type: docs
+weight: 31
+url: /ko/java/com.aspose.xps/xpsiccprofile/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsFileResource](../../com.aspose.xps/xpsfileresource)
+```
+public final class XpsIccProfile extends XpsFileResource
+```
+
+ICC 프로파일 리소스를 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsimage/_index.md
+++ b/korean/java/com.aspose.xps/xpsimage/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsImage"
+second_title: "Aspose.Page용 Java API 참조"
+description: "이미지 리소스를 캡슐화하는 클래스."
+type: docs
+weight: 32
+url: /ko/java/com.aspose.xps/xpsimage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsFileResource](../../com.aspose.xps/xpsfileresource)
+```
+public final class XpsImage extends XpsFileResource
+```
+
+이미지 리소스를 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsimagebrush/_index.md
+++ b/korean/java/com.aspose.xps/xpsimagebrush/_index.md
@@ -1,0 +1,282 @@
+---
+title: "XpsImageBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ImageBrush 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 33
+url: /ko/java/com.aspose.xps/xpsimagebrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsTilingBrush](../../com.aspose.xps/xpstilingbrush)
+```
+public final class XpsImageBrush extends XpsTilingBrush
+```
+
+ImageBrush 속성 요소 기능을 캡슐화하는 클래스. 이 요소는 이미지를 사용하여 영역을 채우는 데 사용됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 이미지 브러시를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getImage()](#getImage--) | 브러시에서 사용되는 이미지 리소스를 반환합니다. |
+| [getImageSource()](#getImageSource--) | 이미지 리소스의 URI를 반환합니다. |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getTileMode()](#getTileMode--) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [getViewbox()](#getViewbox--) | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 반환합니다. |
+| [getViewport()](#getViewport--) | 첫 번째 브러시 타일의 위치와 크기를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setTileMode(XpsTileMode value)](#setTileMode-com.aspose.xps.XpsTileMode-) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [setViewbox(Rectangle2D value)](#setViewbox-java.awt.geom.Rectangle2D-) | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 설정합니다. |
+| [setViewport(Rectangle2D value)](#setViewport-java.awt.geom.Rectangle2D-) | 첫 번째 브러시 타일의 위치와 크기를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsImageBrush deepClone()
+```
+
+
+이 이미지 브러시를 복제합니다.
+
+**Returns:**
+[XpsImageBrush](../../com.aspose.xps/xpsimagebrush) - Clone of this image brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getImage() {#getImage--}
+```
+public XpsImage getImage()
+```
+
+
+브러시에서 사용되는 이미지 리소스를 반환합니다.
+
+**Returns:**
+[XpsImage](../../com.aspose.xps/xpsimage) - Image resource used to for the brush.
+### getImageSource() {#getImageSource--}
+```
+public String getImageSource()
+```
+
+
+이미지 리소스의 URI를 반환합니다.
+
+**Returns:**
+java.lang.String - 이미지 리소스의 URI.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getTileMode() {#getTileMode--}
+```
+public XpsTileMode getTileMode()
+```
+
+
+채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode) - Value specifying how tiling is performed in the filled geometry.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### getViewbox() {#getViewbox--}
+```
+public Rectangle2D getViewbox()
+```
+
+
+뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 반환합니다.
+
+**Returns:**
+java.awt.geom.Rectangle2D - 뷰포트에 매핑될 브러시 소스 콘텐츠 영역.
+### getViewport() {#getViewport--}
+```
+public Rectangle2D getViewport()
+```
+
+
+첫 번째 브러시 타일의 위치와 크기를 반환합니다. 이후 타일은 타일 모드에 지정된 대로 이 타일을 기준으로 배치됩니다.
+
+**Returns:**
+java.awt.geom.Rectangle2D - 첫 번째 브러시 타일의 위치와 크기.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setTileMode(XpsTileMode value) {#setTileMode-com.aspose.xps.XpsTileMode-}
+```
+public void setTileMode(XpsTileMode value)
+```
+
+
+채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsTileMode](../../com.aspose.xps/xpstilemode) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### setViewbox(Rectangle2D value) {#setViewbox-java.awt.geom.Rectangle2D-}
+```
+public void setViewbox(Rectangle2D value)
+```
+
+
+뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Rectangle2D | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역. |
+
+### setViewport(Rectangle2D value) {#setViewport-java.awt.geom.Rectangle2D-}
+```
+public void setViewport(Rectangle2D value)
+```
+
+
+첫 번째 브러시 타일의 위치와 크기를 설정합니다. 이후 타일은 타일 모드에 지정된 대로 이 타일을 기준으로 배치됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Rectangle2D | 첫 번째 브러시 타일의 위치와 크기. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpslineargradientbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpslineargradientbrush/_index.md
@@ -1,0 +1,310 @@
+---
+title: "XpsLinearGradientBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "LinearGradientBrush 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 34
+url: /ko/java/com.aspose.xps/xpslineargradientbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsGradientBrush](../../com.aspose.xps/xpsgradientbrush)
+```
+public final class XpsLinearGradientBrush extends XpsGradientBrush
+```
+
+LinearGradientBrush 속성 요소 기능을 캡슐화하는 클래스. 이 요소는 벡터를 따라 선형 그라디언트 브러시를 지정하는 데 사용됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 선형 그라디언트 브러시를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColorInterpolationMode()](#getColorInterpolationMode--) | 색상 보간을 위한 감마 함수 값을 반환합니다. |
+| [getEndPoint()](#getEndPoint--) | 선형 그라디언트의 끝점을 반환합니다. |
+| [getGradientStops()](#getGradientStops--) | 그라디언트를 구성하는 그라디언트 스톱 목록을 반환합니다. |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getSpreadMethod()](#getSpreadMethod--) | 주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 반환합니다. |
+| [getStartPoint()](#getStartPoint--) | 선형 그라디언트의 시작점을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColorInterpolationMode(XpsColorInterpolationMode value)](#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-) | 색상 보간을 위한 감마 함수 값을 설정합니다. |
+| [setEndPoint(Point2D value)](#setEndPoint-java.awt.geom.Point2D-) | 선형 그라디언트의 끝점을 반환/설정합니다. |
+| [setGradientStops(List<XpsGradientStop> value)](#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--) | 그라디언트를 구성하는 그라디언트 스톱 목록을 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setSpreadMethod(XpsSpreadMethod value)](#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-) | 주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 설정합니다. |
+| [setStartPoint(Point2D value)](#setStartPoint-java.awt.geom.Point2D-) | 선형 그라디언트의 시작점을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsLinearGradientBrush deepClone()
+```
+
+
+이 선형 그라디언트 브러시를 복제합니다.
+
+**Returns:**
+[XpsLinearGradientBrush](../../com.aspose.xps/xpslineargradientbrush) - Clone of this linear gradient brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColorInterpolationMode() {#getColorInterpolationMode--}
+```
+public XpsColorInterpolationMode getColorInterpolationMode()
+```
+
+
+색상 보간을 위한 감마 함수 값을 반환합니다. 지정된 경우 감마 조정은 알파 구성 요소에 적용되지 않아야 합니다.
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) - Value specifying the gamma function for color interpolation.
+### getEndPoint() {#getEndPoint--}
+```
+public Point2D getEndPoint()
+```
+
+
+선형 그라디언트의 끝점을 반환합니다.
+
+**Returns:**
+java.awt.geom.Point2D - 선형 그라디언트의 끝점.
+### getGradientStops() {#getGradientStops--}
+```
+public List<XpsGradientStop> getGradientStops()
+```
+
+
+그라디언트를 구성하는 그라디언트 스톱 목록을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsGradientStop> - 그라디언트를 구성하는 그라디언트 스톱 목록.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getSpreadMethod() {#getSpreadMethod--}
+```
+public XpsSpreadMethod getSpreadMethod()
+```
+
+
+주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 반환합니다.
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) - Value describing how the brush should fill the content area outside of the primary, initial gradient area.
+### getStartPoint() {#getStartPoint--}
+```
+public Point2D getStartPoint()
+```
+
+
+선형 그라디언트의 시작점을 반환합니다.
+
+**Returns:**
+java.awt.geom.Point2D - 선형 그라디언트의 시작점.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColorInterpolationMode(XpsColorInterpolationMode value) {#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-}
+```
+public void setColorInterpolationMode(XpsColorInterpolationMode value)
+```
+
+
+색 보간을 위한 감마 함수를 지정하는 값을 설정합니다. 지정된 경우 감마 조정은 알파 구성 요소에 적용되지 않아야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) | 색 보간을 위한 감마 함수를 지정하는 값. |
+
+### setEndPoint(Point2D value) {#setEndPoint-java.awt.geom.Point2D-}
+```
+public void setEndPoint(Point2D value)
+```
+
+
+선형 그라디언트의 끝점을 반환/설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Point2D | 선형 그라디언트의 끝점입니다. |
+
+### setGradientStops(List<XpsGradientStop> value) {#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--}
+```
+public void setGradientStops(List<XpsGradientStop> value)
+```
+
+
+그라디언트를 구성하는 그라디언트 스톱 목록을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트를 구성하는 그라디언트 스톱 목록. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setSpreadMethod(XpsSpreadMethod value) {#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-}
+```
+public void setSpreadMethod(XpsSpreadMethod value)
+```
+
+
+주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) | 브러시가 기본 초기 그라디언트 영역 외부의 콘텐츠 영역을 채우는 방법을 설명하는 값. |
+
+### setStartPoint(Point2D value) {#setStartPoint-java.awt.geom.Point2D-}
+```
+public void setStartPoint(Point2D value)
+```
+
+
+선형 그라디언트의 시작점을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Point2D | 선형 그라디언트의 시작점입니다. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpslinecap/_index.md
+++ b/korean/java/com.aspose.xps/xpslinecap/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsLineCap"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Path 요소의 StrokeStartLineCap 및 StrokeEndLineCap 속성에 대한 유효한 값."
+type: docs
+weight: 61
+url: /ko/java/com.aspose.xps/xpslinecap/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsLineCap extends Enum<XpsLineCap>
+```
+
+Path 요소의 StrokeStartLineCap 및 StrokeEndLineCap 속성에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Flat](#Flat) | 플랫 라인 캡. |
+| [Round](#Round) | 라운드 라인 캡. |
+| [Square](#Square) | 스퀘어 라인 캡. |
+| [Triangle](#Triangle) | 트라이앵글 라인 캡. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Flat {#Flat}
+```
+public static final XpsLineCap Flat
+```
+
+
+플랫 라인 캡.
+
+### Round {#Round}
+```
+public static final XpsLineCap Round
+```
+
+
+라운드 라인 캡.
+
+### Square {#Square}
+```
+public static final XpsLineCap Square
+```
+
+
+스퀘어 라인 캡.
+
+### Triangle {#Triangle}
+```
+public static final XpsLineCap Triangle
+```
+
+
+트라이앵글 라인 캡.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsLineCap valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsLineCap](../../com.aspose.xps/xpslinecap)
+### values() {#values--}
+```
+public static XpsLineCap[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsLineCap[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpslinejoin/_index.md
+++ b/korean/java/com.aspose.xps/xpslinejoin/_index.md
@@ -1,0 +1,259 @@
+---
+title: "XpsLineJoin"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Path 요소의 StrokeLineJoin 속성에 대한 유효한 값들."
+type: docs
+weight: 62
+url: /ko/java/com.aspose.xps/xpslinejoin/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsLineJoin extends Enum<XpsLineJoin>
+```
+
+Path 요소의 StrokeLineJoin 속성에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Bevel](#Bevel) | 베벨 라인 조인. |
+| [Miter](#Miter) | 마이터 라인 조인. |
+| [Round](#Round) | 라운드 라인 조인. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Bevel {#Bevel}
+```
+public static final XpsLineJoin Bevel
+```
+
+
+베벨 라인 조인.
+
+### Miter {#Miter}
+```
+public static final XpsLineJoin Miter
+```
+
+
+마이터 라인 조인.
+
+### Round {#Round}
+```
+public static final XpsLineJoin Round
+```
+
+
+라운드 라인 조인.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsLineJoin valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsLineJoin](../../com.aspose.xps/xpslinejoin)
+### values() {#values--}
+```
+public static XpsLineJoin[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsLineJoin[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsloadoptions/_index.md
+++ b/korean/java/com.aspose.xps/xpsloadoptions/_index.md
@@ -1,0 +1,137 @@
+---
+title: "XpsLoadOptions"
+second_title: "Aspose.Page용 Java API 참조"
+description: "XPS 문서 로드 옵션."
+type: docs
+weight: 35
+url: /ko/java/com.aspose.xps/xpsloadoptions/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.LoadOptions](../../com.aspose.xps/loadoptions)
+```
+public class XpsLoadOptions extends LoadOptions
+```
+
+XPS 문서 로드 옵션.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsLoadOptions()](#XpsLoadOptions--) | 옵션의 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsLoadOptions() {#XpsLoadOptions--}
+```
+public XpsLoadOptions()
+```
+
+
+옵션의 새 인스턴스를 생성합니다.
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsmatrix/_index.md
+++ b/korean/java/com.aspose.xps/xpsmatrix/_index.md
@@ -1,0 +1,502 @@
+---
+title: "XpsMatrix"
+second_title: "Aspose.Page용 Java API 참조"
+description: "MatrixTransform 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 36
+url: /ko/java/com.aspose.xps/xpsmatrix/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public final class XpsMatrix extends XpsObject
+```
+
+MatrixTransform 속성 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 요소들의 좌표 시스템을 조작하기 위해 사용되는 임의의 아핀 행렬 변환을 정의합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 변환 행렬을 복제합니다. |
+| [equals(XpsMatrix a, XpsMatrix b)](#equals-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-) | 실제 구현. |
+| [equals(Object obj)](#equals-java.lang.Object-) | 지정된 객체가 이 인스턴스와 같은지 여부를 판단합니다. |
+| [getClass()](#getClass--) |  |
+| [getM11()](#getM11--) | M11 요소를 가져옵니다. |
+| [getM12()](#getM12--) | M12 요소를 가져옵니다. |
+| [getM21()](#getM21--) | M21 요소를 가져옵니다. |
+| [getM22()](#getM22--) | M22 요소를 가져옵니다. |
+| [getM31()](#getM31--) | M31 요소를 가져옵니다. |
+| [getM32()](#getM32--) | M32 요소를 가져옵니다. |
+| [hashCode()](#hashCode--) | 이 인스턴스에 대한 해시 코드를 반환합니다. |
+| [isIdentity()](#isIdentity--) | 이 인스턴스가 단위 행렬인지 여부를 나타내는 값을 가져옵니다. |
+| [multiply(XpsMatrix matrix)](#multiply-com.aspose.xps.XpsMatrix-) | 이 행렬에 기본(Prepend) 순서로 지정된  matrix  행렬을 곱합니다. |
+| [multiply(XpsMatrix matrix, XpsMatrix.MatrixOrder matrixOrder)](#multiply-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix.MatrixOrder-) | 이 행렬에  matrixOrder  로 지정된 순서로 지정된  matrix  행렬을 곱합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [op_Equality(XpsMatrix a, XpsMatrix b)](#op-Equality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-) | 연산자 == 를 구현합니다. |
+| [op_Inequality(XpsMatrix a, XpsMatrix b)](#op-Inequality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-) | 연산자 ! 를 구현합니다. |
+| [reset()](#reset--) | 이 Matrix를 단위 행렬로 재설정합니다. |
+| [rotate(float angle)](#rotate-float-) | 이 Matrix에 기본(Prepend) 순서로  angle  만큼 시계 방향 회전을 적용합니다. |
+| [rotate(float angle, XpsMatrix.MatrixOrder matrixOrder)](#rotate-float-com.aspose.xps.XpsMatrix.MatrixOrder-) | 이 Matrix에  matrixOrder  로 지정된 순서로  angle  만큼 시계 방향 회전을 적용합니다. |
+| [rotateAround(float angle, Point2D pivot)](#rotateAround-float-java.awt.geom.Point2D-) | 이 Matrix에 기본(Prepend) 순서로  pivot  를 중심으로  angle  만큼 시계 방향 회전을 적용합니다. |
+| [rotateAround(float angle, Point2D pivot, XpsMatrix.MatrixOrder matrixOrder)](#rotateAround-float-java.awt.geom.Point2D-com.aspose.xps.XpsMatrix.MatrixOrder-) | 이 Matrix에  matrixOrder  로 지정된 순서로  pivot  를 중심으로  angle  만큼 시계 방향 회전을 적용합니다. |
+| [scale(float scaleX, float scaleY)](#scale-float-float-) | 이 Matrix에 기본(Prepend) 순서로 지정된 스케일 벡터(scaleX 및 scaleY)를 적용합니다. |
+| [scale(float scaleX, float scaleY, XpsMatrix.MatrixOrder matrixOrder)](#scale-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-) | 이 Matrix에  matrixOrder  로 지정된 순서로 지정된 스케일 벡터(scaleX 및 scaleY)를 적용합니다. |
+| [skew(double skewX, double skewY)](#skew-double-double-) | 지정된 스키 변환을 이 Matrix에 적용합니다. |
+| [toString()](#toString--) | 이  XpsMatrix  인스턴스의 문자열 표현을 반환합니다. |
+| [transform(Rectangle2D rect)](#transform-java.awt.geom.Rectangle2D-) | 이 Matrix가 나타내는 어파인 변환을 지정된 사각형에 적용합니다. |
+| [transformPoint(Point2D point)](#transformPoint-java.awt.geom.Point2D-) | 이 Matrix가 나타내는 어파인 변환을 지정된 점에 적용합니다. |
+| [transformPoints(Point2D[] points)](#transformPoints-java.awt.geom.Point2D---) | 이 Matrix가 나타내는 어파인 변환을 지정된 점 배열에 적용합니다. |
+| [transformPoints(Point2D[] points, int startIndex, int numberOfPoints)](#transformPoints-java.awt.geom.Point2D---int-int-) | 이 Matrix가 나타내는 어파인 변환을 지정된 점 배열의 일부에 적용합니다. |
+| [translate(float offsetX, float offsetY)](#translate-float-float-) | 지정된 변환 벡터를 이 Matrix에 적용합니다. |
+| [translate(float offsetX, float offsetY, XpsMatrix.MatrixOrder matrixOrder)](#translate-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-) | 지정된 변환 벡터를  matrixOrder  로 지정된 순서에 따라 이 Matrix에 적용합니다. |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsMatrix deepClone()
+```
+
+
+이 변환 행렬을 복제합니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - Clone of this transformation matrix.
+### equals(XpsMatrix a, XpsMatrix b) {#equals-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-}
+```
+public static boolean equals(XpsMatrix a, XpsMatrix b)
+```
+
+
+실제 구현.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 첫 번째 행렬입니다. |
+| b | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 두 번째 행렬입니다. |
+
+**Returns:**
+boolean - 행렬이 같으면 [true]
+### equals(Object obj) {#equals-java.lang.Object-}
+```
+public boolean equals(Object obj)
+```
+
+
+지정된 객체가 이 인스턴스와 같은지 여부를 판단합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | java.lang.Object | 이 인스턴스와 비교할 객체. |
+
+**Returns:**
+boolean - 지정된 객체가 이 인스턴스와 같으면 true; 그렇지 않으면 false. obj 매개변수가 null인 경우.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getM11() {#getM11--}
+```
+public float getM11()
+```
+
+
+M11 요소를 가져옵니다.
+
+**Returns:**
+float - M11 요소.
+### getM12() {#getM12--}
+```
+public float getM12()
+```
+
+
+M12 요소를 가져옵니다.
+
+**Returns:**
+float - M12 요소.
+### getM21() {#getM21--}
+```
+public float getM21()
+```
+
+
+M21 요소를 가져옵니다.
+
+**Returns:**
+float - M21 요소.
+### getM22() {#getM22--}
+```
+public float getM22()
+```
+
+
+M22 요소를 가져옵니다.
+
+**Returns:**
+float - M22 요소.
+### getM31() {#getM31--}
+```
+public float getM31()
+```
+
+
+M31 요소를 가져옵니다.
+
+**Returns:**
+float - M31 요소.
+### getM32() {#getM32--}
+```
+public float getM32()
+```
+
+
+M32 요소를 가져옵니다.
+
+**Returns:**
+float - M32 요소.
+### hashCode() {#hashCode--}
+```
+public int hashCode()
+```
+
+
+이 인스턴스에 대한 해시 코드를 반환합니다.
+
+**Returns:**
+int - 이 인스턴스에 대한 해시 코드로, 해시 알고리즘 및 해시 테이블과 같은 데이터 구조에서 사용하기에 적합합니다.
+### isIdentity() {#isIdentity--}
+```
+public boolean isIdentity()
+```
+
+
+이 인스턴스가 단위 행렬인지 여부를 나타내는 값을 가져옵니다.
+
+값: 이 인스턴스가 단위 행렬이면 True; 그렇지 않으면 false.
+
+**Returns:**
+boolean - 이 인스턴스가 단위 행렬인지 여부를 나타내는 값.
+### multiply(XpsMatrix matrix) {#multiply-com.aspose.xps.XpsMatrix-}
+```
+public void multiply(XpsMatrix matrix)
+```
+
+
+이 행렬에 기본(Prepend) 순서로 지정된  matrix  행렬을 곱합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| matrix | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 행렬. |
+
+### multiply(XpsMatrix matrix, XpsMatrix.MatrixOrder matrixOrder) {#multiply-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void multiply(XpsMatrix matrix, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+이 행렬에  matrixOrder  로 지정된 순서로 지정된  matrix  행렬을 곱합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| matrix | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 행렬. |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 순서. |
+
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### op_Equality(XpsMatrix a, XpsMatrix b) {#op-Equality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-}
+```
+public static boolean op_Equality(XpsMatrix a, XpsMatrix b)
+```
+
+
+연산자 == 를 구현합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 첫 번째 행렬입니다. |
+| b | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 두 번째 행렬입니다. |
+
+**Returns:**
+boolean - 연산자의 결과.
+### op_Inequality(XpsMatrix a, XpsMatrix b) {#op-Inequality-com.aspose.xps.XpsMatrix-com.aspose.xps.XpsMatrix-}
+```
+public static boolean op_Inequality(XpsMatrix a, XpsMatrix b)
+```
+
+
+연산자 != 를 구현합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| a | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 첫 번째 행렬입니다. |
+| b | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 두 번째 행렬입니다. |
+
+**Returns:**
+boolean - 연산자의 결과.
+### reset() {#reset--}
+```
+public void reset()
+```
+
+
+이 Matrix를 단위 행렬로 재설정합니다.
+
+### rotate(float angle) {#rotate-float-}
+```
+public void rotate(float angle)
+```
+
+
+이 Matrix에 기본(Prepend) 순서로  angle  만큼 시계 방향 회전을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | float | 각도. |
+
+### rotate(float angle, XpsMatrix.MatrixOrder matrixOrder) {#rotate-float-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void rotate(float angle, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+이 Matrix에  matrixOrder  로 지정된 순서로  angle  만큼 시계 방향 회전을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | float | 각도. |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 순서. |
+
+### rotateAround(float angle, Point2D pivot) {#rotateAround-float-java.awt.geom.Point2D-}
+```
+public void rotateAround(float angle, Point2D pivot)
+```
+
+
+이 Matrix에 기본(Prepend) 순서로  pivot  를 중심으로  angle  만큼 시계 방향 회전을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | float | 각도. |
+| 피벗 | java.awt.geom.Point2D | 피벗 포인트. |
+
+### rotateAround(float angle, Point2D pivot, XpsMatrix.MatrixOrder matrixOrder) {#rotateAround-float-java.awt.geom.Point2D-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void rotateAround(float angle, Point2D pivot, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+이 Matrix에  matrixOrder  로 지정된 순서로  pivot  를 중심으로  angle  만큼 시계 방향 회전을 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| angle | float | 각도. |
+| 피벗 | java.awt.geom.Point2D | 피벗 포인트. |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 순서. |
+
+### scale(float scaleX, float scaleY) {#scale-float-float-}
+```
+public void scale(float scaleX, float scaleY)
+```
+
+
+이 Matrix에 기본(Prepend) 순서로 지정된 스케일 벡터(scaleX 및 scaleY)를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleX | float | x 축 스케일. |
+| scaleY | float | y 축 스케일. |
+
+### scale(float scaleX, float scaleY, XpsMatrix.MatrixOrder matrixOrder) {#scale-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void scale(float scaleX, float scaleY, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+이 Matrix에  matrixOrder  로 지정된 순서로 지정된 스케일 벡터(scaleX 및 scaleY)를 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| scaleX | float | X 축 스케일. |
+| scaleY | float | Y 축 스케일. |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 순서. |
+
+### skew(double skewX, double skewY) {#skew-double-double-}
+```
+public void skew(double skewX, double skewY)
+```
+
+
+지정된 스키 변환을 이 Matrix에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| skewX | double | 왜곡 x. |
+| skewY | double | 왜곡 y. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+이  XpsMatrix  인스턴스의 문자열 표현을 반환합니다.
+
+**Returns:**
+java.lang.String - 문자열 표현
+### transform(Rectangle2D rect) {#transform-java.awt.geom.Rectangle2D-}
+```
+public Rectangle2D transform(Rectangle2D rect)
+```
+
+
+이 Matrix가 나타내는 어파인 변환을 지정된 사각형에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| rect | java.awt.geom.Rectangle2D | 사각형. |
+
+**Returns:**
+java.awt.geom.Rectangle2D - 변환된 사각형
+### transformPoint(Point2D point) {#transformPoint-java.awt.geom.Point2D-}
+```
+public Point2D transformPoint(Point2D point)
+```
+
+
+이 Matrix가 나타내는 어파인 변환을 지정된 점에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 포인트 | java.awt.geom.Point2D | 점. |
+
+**Returns:**
+java.awt.geom.Point2D - 변환된 점
+### transformPoints(Point2D[] points) {#transformPoints-java.awt.geom.Point2D---}
+```
+public void transformPoints(Point2D[] points)
+```
+
+
+이 Matrix가 나타내는 어파인 변환을 지정된 점 배열에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 점들. |
+
+### transformPoints(Point2D[] points, int startIndex, int numberOfPoints) {#transformPoints-java.awt.geom.Point2D---int-int-}
+```
+public void transformPoints(Point2D[] points, int startIndex, int numberOfPoints)
+```
+
+
+이 Matrix가 나타내는 어파인 변환을 지정된 점 배열의 일부에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| points | java.awt.geom.Point2D[] | 점들. |
+| startIndex | int | 시작 인덱스. |
+| numberOfPoints | int | 포인트 수. |
+
+### translate(float offsetX, float offsetY) {#translate-float-float-}
+```
+public void translate(float offsetX, float offsetY)
+```
+
+
+지정된 변환 벡터를 이 Matrix에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| offsetX | float | 오프셋 X. |
+| offsetY | float | 오프셋 Y. |
+
+### translate(float offsetX, float offsetY, XpsMatrix.MatrixOrder matrixOrder) {#translate-float-float-com.aspose.xps.XpsMatrix.MatrixOrder-}
+```
+public void translate(float offsetX, float offsetY, XpsMatrix.MatrixOrder matrixOrder)
+```
+
+
+지정된 변환 벡터를  matrixOrder  로 지정된 순서에 따라 이 Matrix에 적용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| offsetX | float | 오프셋 X. |
+| offsetY | float | 오프셋 Y. |
+| matrixOrder | [MatrixOrder](../../com.aspose.xps/matrixorder) | 순서. |
+
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsobject/_index.md
+++ b/korean/java/com.aspose.xps/xpsobject/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsObject"
+second_title: "Aspose.Page용 Java API 참조"
+description: "공통 XPS 모델 객체 기능을 캡슐화하는 클래스."
+type: docs
+weight: 37
+url: /ko/java/com.aspose.xps/xpsobject/
+---
+**Inheritance:**
+java.lang.Object
+```
+public abstract class XpsObject
+```
+
+공통 XPS 모델 객체 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspage/_index.md
+++ b/korean/java/com.aspose.xps/xpspage/_index.md
@@ -1,0 +1,248 @@
+---
+title: "XpsPage"
+second_title: "Aspose.Page용 Java API 참조"
+description: "FixedPage 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 38
+url: /ko/java/com.aspose.xps/xpspage/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement)
+```
+public final class XpsPage extends XpsElement
+```
+
+FixedPage 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 페이지의 내용을 포함하며 FixedPage 파트의 루트 요소입니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 페이지를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getHeight()](#getHeight--) | 페이지의 높이를 반환합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [getWidth()](#getWidth--) | 페이지의 너비를 반환합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [getXmlLang()](#getXmlLang--) | 현재 요소 및 모든 자식 또는 하위 요소에 사용되는 기본 언어를 지정하는 값을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setHeight(float value)](#setHeight-float-) | 페이지의 높이를 설정합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [setWidth(float value)](#setWidth-float-) | 페이지의 너비를 설정합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다. |
+| [setXmlLang(String value)](#setXmlLang-java.lang.String-) | 현재 요소 및 모든 자식 또는 하위 요소에 사용되는 기본 언어를 지정하는 값을 설정합니다. |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPage deepClone()
+```
+
+
+이 페이지를 복제합니다.
+
+**Returns:**
+[XpsPage](../../com.aspose.xps/xpspage) - Clone of this page.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getHeight() {#getHeight--}
+```
+public float getHeight()
+```
+
+
+페이지의 높이를 반환합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Returns:**
+float - 페이지의 높이.
+### getWidth() {#getWidth--}
+```
+public float getWidth()
+```
+
+
+페이지의 너비를 반환합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Returns:**
+float - 페이지의 너비.
+### getXmlLang() {#getXmlLang--}
+```
+public String getXmlLang()
+```
+
+
+현재 요소 및 모든 자식 또는 하위 요소에 사용되는 기본 언어를 지정하는 값을 반환합니다.
+
+**Returns:**
+java.lang.String - 기본 언어를 지정하는 값.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setHeight(float value) {#setHeight-float-}
+```
+public void setHeight(float value)
+```
+
+
+페이지의 높이를 설정합니다. 높이는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 페이지의 높이. |
+
+### setWidth(float value) {#setWidth-float-}
+```
+public void setWidth(float value)
+```
+
+
+페이지의 너비를 설정합니다. 너비는 유효 좌표 공간 단위의 실수값으로 표현됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 페이지의 너비. |
+
+### setXmlLang(String value) {#setXmlLang-java.lang.String-}
+```
+public void setXmlLang(String value)
+```
+
+
+현재 요소 및 모든 자식 또는 하위 요소에 사용되는 기본 언어를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.lang.String | 기본 언어를 지정하는 값. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspagelinktarget/_index.md
+++ b/korean/java/com.aspose.xps/xpspagelinktarget/_index.md
@@ -1,0 +1,153 @@
+---
+title: "XpsPageLinkTarget"
+second_title: "Aspose.Page용 Java API 참조"
+description: "페이지 하이퍼링크 대상을 캡슐화하는 클래스."
+type: docs
+weight: 39
+url: /ko/java/com.aspose.xps/xpspagelinktarget/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget)
+```
+public final class XpsPageLinkTarget extends XpsHyperlinkTarget
+```
+
+페이지 하이퍼링크 대상을 캡슐화하는 클래스.
+## 생성자
+
+| 생성자 | 설명 |
+| --- | --- |
+| [XpsPageLinkTarget(int targetPageNumber)](#XpsPageLinkTarget-int-) | 새 인스턴스를 생성합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getTargetPageNumber()](#getTargetPageNumber--) | 부모 XPS 요소가 참조하는 페이지 번호를 가져옵니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### XpsPageLinkTarget(int targetPageNumber) {#XpsPageLinkTarget-int-}
+```
+public XpsPageLinkTarget(int targetPageNumber)
+```
+
+
+새 인스턴스를 생성합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| targetPageNumber | int | 전체 XPS 문서(고정 문서 시퀀스) 내의 절대 페이지 번호. |
+
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getTargetPageNumber() {#getTargetPageNumber--}
+```
+public int getTargetPageNumber()
+```
+
+
+부모 XPS 요소가 참조하는 페이지 번호를 가져옵니다.
+
+**Returns:**
+int - 부모 XPS 요소가 참조하는 페이지 번호.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspath/_index.md
+++ b/korean/java/com.aspose.xps/xpspath/_index.md
@@ -1,0 +1,573 @@
+---
+title: "XpsPath"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Path 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 40
+url: /ko/java/com.aspose.xps/xpspath/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsElement](../../com.aspose.xps/xpselement), [com.aspose.xps.XpsHyperlinkElement](../../com.aspose.xps/xpshyperlinkelement), [com.aspose.xps.XpsContentElement](../../com.aspose.xps/xpscontentelement)
+```
+public final class XpsPath extends XpsContentElement
+```
+
+Path 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 고정 페이지에 벡터 그래픽 및 이미지를 추가하는 유일한 방법입니다. 페이지에 렌더링될 단일 벡터 그래픽을 정의합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 경로를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 요소의 자식에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getClip()](#getClip--) | 요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다. |
+| [getData()](#getData--) | 경로의 기하학을 반환합니다. |
+| [getFill()](#getFill--) | 경로의 Data 속성으로 지정된 기하학을 그리는 데 사용되는 브러시를 반환합니다. |
+| [getHyperlinkTarget()](#getHyperlinkTarget--) | 하이퍼링크 대상 객체를 반환합니다. |
+| [getOpacity()](#getOpacity--) | 요소의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getOpacityMask()](#getOpacityMask--) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다. |
+| [getRenderTransform()](#getRenderTransform--) | 요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다. |
+| [getStroke()](#getStroke--) | 스트로크를 그리는 데 사용되는 브러시를 반환합니다. |
+| [getStrokeDashArray()](#getStrokeDashArray--) | 외곽선 스트로크의 대시 및 간격 길이를 지정하는 배열을 반환합니다. |
+| [getStrokeDashCap()](#getStrokeDashCap--) | 각 대시의 끝이 그려지는 방식을 지정하는 값을 반환합니다. |
+| [getStrokeDashOffset()](#getStrokeDashOffset--) | 대시 배열 패턴을 반복하기 위한 시작점을 반환합니다. |
+| [getStrokeEndLineCap()](#getStrokeEndLineCap--) | 스트로크에서 마지막 대시의 끝 모양을 정의하는 값을 반환합니다. |
+| [getStrokeLineJoin()](#getStrokeLineJoin--) | 스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 반환합니다. |
+| [getStrokeMiterLimit()](#getStrokeMiterLimit--) | 최대 마이터 길이와 스트로크 두께 절반 사이의 비율을 반환합니다. |
+| [getStrokeStartLineCap()](#getStrokeStartLineCap--) | 스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 반환합니다. |
+| [getStrokeThickness()](#getStrokeThickness--) | 스트로크의 두께를 반환합니다. 단위는 실제 좌표 공간이며(경로의 렌더 변환을 포함합니다). |
+| [hashCode()](#hashCode--) |  |
+| [iterator()](#iterator--) | Iterable 인터페이스의 구현. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setClip(XpsPathGeometry value)](#setClip-com.aspose.xps.XpsPathGeometry-) | 요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다. |
+| [setData(XpsPathGeometry value)](#setData-com.aspose.xps.XpsPathGeometry-) | 경로의 기하학을 설정합니다. |
+| [setFill(XpsBrush value)](#setFill-com.aspose.xps.XpsBrush-) | 경로의 Data 속성으로 지정된 기하학을 그리는 데 사용되는 브러시를 설정합니다. |
+| [setHyperlinkTarget(XpsHyperlinkTarget value)](#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-) | 하이퍼링크 대상 객체를 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 요소의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setOpacityMask(XpsBrush value)](#setOpacityMask-com.aspose.xps.XpsBrush-) | Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다. |
+| [setRenderTransform(XpsMatrix value)](#setRenderTransform-com.aspose.xps.XpsMatrix-) | 요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다. |
+| [setStroke(XpsBrush value)](#setStroke-com.aspose.xps.XpsBrush-) | 스트로크를 그리는 데 사용되는 브러시를 설정합니다. |
+| [setStrokeDashArray(float[] value)](#setStrokeDashArray-float---) | 외곽선 스트로크의 대시 및 간격 길이를 지정하는 배열을 설정합니다. |
+| [setStrokeDashCap(XpsDashCap value)](#setStrokeDashCap-com.aspose.xps.XpsDashCap-) | 각 대시의 끝이 그려지는 방식을 지정하는 값을 설정합니다. |
+| [setStrokeDashOffset(float value)](#setStrokeDashOffset-float-) | 대시 배열 패턴을 반복하기 위한 시작점을 설정합니다. |
+| [setStrokeEndLineCap(XpsLineCap value)](#setStrokeEndLineCap-com.aspose.xps.XpsLineCap-) | 스트로크에서 마지막 대시의 끝 모양을 정의하는 값을 설정합니다. |
+| [setStrokeLineJoin(XpsLineJoin value)](#setStrokeLineJoin-com.aspose.xps.XpsLineJoin-) | 스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 설정합니다. |
+| [setStrokeMiterLimit(float value)](#setStrokeMiterLimit-float-) | 최대 마이터 길이와 스트로크 두께 절반 사이의 비율을 설정합니다. |
+| [setStrokeStartLineCap(XpsLineCap value)](#setStrokeStartLineCap-com.aspose.xps.XpsLineCap-) | 스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 설정합니다. |
+| [setStrokeThickness(float value)](#setStrokeThickness-float-) | 스트로크의 두께를 설정합니다. 단위는 실제 좌표 공간이며(경로의 렌더 변환을 포함합니다). |
+| [size()](#size--) | 하위 요소의 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPath deepClone()
+```
+
+
+이 경로를 복제합니다.
+
+**Returns:**
+[XpsPath](../../com.aspose.xps/xpspath) - Clone this path.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public XpsContentElement get(int i)
+```
+
+
+인덱스 i 로 요소의 자식에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 하위 요소의 인덱스. |
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - Child element at  i  position.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getClip() {#getClip--}
+```
+public XpsPathGeometry getClip()
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 반환합니다.
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The path geometry limiting the rendered region of the element.
+### getData() {#getData--}
+```
+public XpsPathGeometry getData()
+```
+
+
+경로의 기하학을 반환합니다.
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - The geometry of the path.
+### getFill() {#getFill--}
+```
+public XpsBrush getFill()
+```
+
+
+경로의 Data 속성으로 지정된 기하학을 그리는 데 사용되는 브러시를 반환합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush used to paint the geometry specified
+### getHyperlinkTarget() {#getHyperlinkTarget--}
+```
+public XpsHyperlinkTarget getHyperlinkTarget()
+```
+
+
+하이퍼링크 대상 객체를 반환합니다.
+
+**Returns:**
+[XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) - Hyperlink target object.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 요소의 균일한 투명성을 정의하는 값.
+### getOpacityMask() {#getOpacityMask--}
+```
+public XpsBrush getOpacityMask()
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 반환하지만, 요소의 서로 다른 영역에 대해 서로 다른 알파 값을 허용합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush specifying a mask.
+### getRenderTransform() {#getRenderTransform--}
+```
+public XpsMatrix getRenderTransform()
+```
+
+
+요소와 모든 자식 요소(있는 경우)의 모든 속성에 대한 새로운 좌표계를 설정하는 아핀 변환 행렬을 반환합니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### getStroke() {#getStroke--}
+```
+public XpsBrush getStroke()
+```
+
+
+스트로크를 그리는 데 사용되는 브러시를 반환합니다.
+
+**Returns:**
+[XpsBrush](../../com.aspose.xps/xpsbrush) - The brush used to draw the stroke.
+### getStrokeDashArray() {#getStrokeDashArray--}
+```
+public float[] getStrokeDashArray()
+```
+
+
+외곽선 스트로크의 대시 및 간격 길이를 지정하는 배열을 반환합니다.
+
+**Returns:**
+float[] - 외곽선 스트로크의 대시 및 간격 길이를 지정하는 배열.
+### getStrokeDashCap() {#getStrokeDashCap--}
+```
+public XpsDashCap getStrokeDashCap()
+```
+
+
+각 대시의 끝이 그려지는 방식을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsDashCap](../../com.aspose.xps/xpsdashcap) - The value specifying how the ends of each dash are drawn.
+### getStrokeDashOffset() {#getStrokeDashOffset--}
+```
+public float getStrokeDashOffset()
+```
+
+
+대시 배열 패턴을 반복하기 위한 시작점을 반환합니다. 이 값을 생략하면 대시 배열이 스트로크의 원점에 맞춰집니다.
+
+**Returns:**
+float - 대시 배열 패턴을 반복하는 시작점.
+### getStrokeEndLineCap() {#getStrokeEndLineCap--}
+```
+public XpsLineCap getStrokeEndLineCap()
+```
+
+
+스트로크에서 마지막 대시의 끝 모양을 정의하는 값을 반환합니다.
+
+**Returns:**
+[XpsLineCap](../../com.aspose.xps/xpslinecap) - The value defining the shape of the end of the last dash in a stroke.
+### getStrokeLineJoin() {#getStrokeLineJoin--}
+```
+public XpsLineJoin getStrokeLineJoin()
+```
+
+
+스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 반환합니다.
+
+**Returns:**
+[XpsLineJoin](../../com.aspose.xps/xpslinejoin) - The value defining the shape of the beginning of the first dash in a stroke.
+### getStrokeMiterLimit() {#getStrokeMiterLimit--}
+```
+public float getStrokeMiterLimit()
+```
+
+
+최대 마이터 길이와 스트로크 두께의 절반 사이의 비율을 반환합니다. 이 값은  StrokeLineJoin  속성이  Miter 를 지정한 경우에만 의미가 있습니다.
+
+**Returns:**
+float - 최대 마이터 길이와 스트로크 두께의 절반 사이의 비율.
+### getStrokeStartLineCap() {#getStrokeStartLineCap--}
+```
+public XpsLineCap getStrokeStartLineCap()
+```
+
+
+스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 반환합니다.
+
+**Returns:**
+[XpsLineCap](../../com.aspose.xps/xpslinecap) - The value defining the shape of the beginning of the first dash in a stroke.
+### getStrokeThickness() {#getStrokeThickness--}
+```
+public float getStrokeThickness()
+```
+
+
+스트로크의 두께를 반환합니다. 단위는 실제 좌표 공간(경로의 렌더 변환 포함)입니다. 스트로크는 Path 요소\\u2019s Data 속성으로 지정된 기하학 경계 위에 그려집니다. StrokeThickness의 절반은 Data 속성으로 지정된 기하학 외부로, 나머지 절반은 내부로 확장됩니다.
+
+**Returns:**
+float - 스트로크의 두께.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### iterator() {#iterator--}
+```
+public Iterator<XpsContentElement> iterator()
+```
+
+
+Iterable 인터페이스의 구현.
+
+**Returns:**
+java.util.Iterator<com.aspose.xps.XpsContentElement> - 목록에 대한 열거자를 반환합니다.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setClip(XpsPathGeometry value) {#setClip-com.aspose.xps.XpsPathGeometry-}
+```
+public void setClip(XpsPathGeometry value)
+```
+
+
+요소의 렌더링 영역을 제한하는 경로 기하학을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 요소의 렌더링 영역을 제한하는 경로 기하학. |
+
+### setData(XpsPathGeometry value) {#setData-com.aspose.xps.XpsPathGeometry-}
+```
+public void setData(XpsPathGeometry value)
+```
+
+
+경로의 기하학을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) | 경로의 기하학. |
+
+### setFill(XpsBrush value) {#setFill-com.aspose.xps.XpsBrush-}
+```
+public void setFill(XpsBrush value)
+```
+
+
+경로의 Data 속성으로 지정된 기하학을 그리는 데 사용되는 브러시를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 지정된 기하학을 그리는 데 사용되는 브러시 |
+
+### setHyperlinkTarget(XpsHyperlinkTarget value) {#setHyperlinkTarget-com.aspose.xps.XpsHyperlinkTarget-}
+```
+public void setHyperlinkTarget(XpsHyperlinkTarget value)
+```
+
+
+하이퍼링크 대상 객체를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsHyperlinkTarget](../../com.aspose.xps/xpshyperlinktarget) | 하이퍼링크 대상 객체. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+요소의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 요소의 균일한 투명성을 정의하는 값. |
+
+### setOpacityMask(XpsBrush value) {#setOpacityMask-com.aspose.xps.XpsBrush-}
+```
+public void setOpacityMask(XpsBrush value)
+```
+
+
+Opacity 속성과 동일한 방식으로 요소에 적용되는 알파 값 마스크를 지정하는 브러시를 설정하지만, 요소의 서로 다른 영역에 대해 다른 알파 값을 허용합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 마스크를 지정하는 브러시. |
+
+### setRenderTransform(XpsMatrix value) {#setRenderTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setRenderTransform(XpsMatrix value)
+```
+
+
+요소 및 모든 하위 요소(있는 경우)의 모든 속성에 대한 새로운 좌표 프레임을 설정하는 아핀 변환 행렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 아핀 변환 행렬. |
+
+### setStroke(XpsBrush value) {#setStroke-com.aspose.xps.XpsBrush-}
+```
+public void setStroke(XpsBrush value)
+```
+
+
+스트로크를 그리는 데 사용되는 브러시를 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsBrush](../../com.aspose.xps/xpsbrush) | 스트로크를 그리는 데 사용되는 브러시. |
+
+### setStrokeDashArray(float[] value) {#setStrokeDashArray-float---}
+```
+public void setStrokeDashArray(float[] value)
+```
+
+
+외곽선 스트로크의 대시 및 간격 길이를 지정하는 배열을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float[] | 외곽선 스트로크의 대시와 간격 길이를 지정하는 배열. |
+
+### setStrokeDashCap(XpsDashCap value) {#setStrokeDashCap-com.aspose.xps.XpsDashCap-}
+```
+public void setStrokeDashCap(XpsDashCap value)
+```
+
+
+각 대시의 끝이 그려지는 방식을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsDashCap](../../com.aspose.xps/xpsdashcap) | 각 대시의 끝이 그려지는 방식을 지정하는 값. |
+
+### setStrokeDashOffset(float value) {#setStrokeDashOffset-float-}
+```
+public void setStrokeDashOffset(float value)
+```
+
+
+대시 배열 패턴을 반복하는 시작점을 설정합니다. 이 값을 생략하면 대시 배열이 스트로크의 원점에 맞춰집니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 대시 배열 패턴을 반복하는 시작점. |
+
+### setStrokeEndLineCap(XpsLineCap value) {#setStrokeEndLineCap-com.aspose.xps.XpsLineCap-}
+```
+public void setStrokeEndLineCap(XpsLineCap value)
+```
+
+
+스트로크에서 마지막 대시의 끝 모양을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsLineCap](../../com.aspose.xps/xpslinecap) | 스트로크에서 마지막 대시의 끝 모양을 정의하는 값. |
+
+### setStrokeLineJoin(XpsLineJoin value) {#setStrokeLineJoin-com.aspose.xps.XpsLineJoin-}
+```
+public void setStrokeLineJoin(XpsLineJoin value)
+```
+
+
+스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsLineJoin](../../com.aspose.xps/xpslinejoin) | 스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값. |
+
+### setStrokeMiterLimit(float value) {#setStrokeMiterLimit-float-}
+```
+public void setStrokeMiterLimit(float value)
+```
+
+
+최대 마이터 길이와 스트로크 두께의 절반 사이의 비율을 설정합니다. 이 값은  StrokeLineJoin  속성이  Mither 를 지정한 경우에만 의미가 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 최대 마이터 길이와 스트로크 두께의 절반 사이의 비율. |
+
+### setStrokeStartLineCap(XpsLineCap value) {#setStrokeStartLineCap-com.aspose.xps.XpsLineCap-}
+```
+public void setStrokeStartLineCap(XpsLineCap value)
+```
+
+
+스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsLineCap](../../com.aspose.xps/xpslinecap) | 스트로크에서 첫 번째 대시의 시작 모양을 정의하는 값. |
+
+### setStrokeThickness(float value) {#setStrokeThickness-float-}
+```
+public void setStrokeThickness(float value)
+```
+
+
+스트로크의 두께를 설정합니다. 단위는 실제 좌표 공간(경로의 렌더 변환 포함)입니다. 스트로크는 Path 요소\\u2019s Data 속성으로 지정된 기하학 경계 위에 그려집니다. StrokeThickness의 절반은 Data 속성으로 지정된 기하학 외부로, 나머지 절반은 내부로 확장됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 스트로크의 두께. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+하위 요소의 수를 반환합니다.
+
+**Returns:**
+int - 하위 요소의 수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspathfigure/_index.md
+++ b/korean/java/com.aspose.xps/xpspathfigure/_index.md
@@ -1,0 +1,313 @@
+---
+title: "XpsPathFigure"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PathFigure 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 41
+url: /ko/java/com.aspose.xps/xpspathfigure/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), com.aspose.xps.XpsArray
+```
+public class XpsPathFigure extends XpsArray<XpsPathSegment>
+```
+
+PathFigure 요소 기능을 캡슐화하는 클래스. 이 요소는 하나 이상의 선 또는 곡선 세그먼트 집합으로 구성됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(T obj)](#add-T-) | 배열에 새 객체를 추가합니다. |
+| [deepClone()](#deepClone--) | 이 PathFigure를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 배열 요소에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getSegments()](#getSegments--) | 자식 경로 세그먼트 목록을 반환합니다. |
+| [getStartPoint()](#getStartPoint--) | PathFigure의 첫 번째 세그먼트 시작점을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [insert(int index, T obj)](#insert-int-T-) | 지정된 위치에 새 객체를 배열에 삽입합니다. |
+| [isClosed()](#isClosed--) | PathFigure가 닫혔는지 여부를 나타내는 값을 반환합니다. |
+| [isFilled()](#isFilled--) | PathFigure가 포함된 경로 기하학의 면적을 계산하는 데 사용되는지 여부를 나타내는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(T obj)](#remove-T-) | 배열에서 객체를 제거합니다. |
+| [removeAt(int index)](#removeAt-int-) | 지정된 위치에서 배열의 객체를 제거합니다. |
+| [setClosed(boolean value)](#setClosed-boolean-) | PathFigure가 닫혔는지 여부를 나타내는 값을 설정합니다. |
+| [setFilled(boolean value)](#setFilled-boolean-) | PathFigure가 포함된 경로 기하학의 면적을 계산하는 데 사용되는지 여부를 나타내는 값을 설정합니다. |
+| [setStartPoint(Point2D value)](#setStartPoint-java.awt.geom.Point2D-) | PathFigure의 첫 번째 세그먼트 시작점을 설정합니다. |
+| [size()](#size--) | 요소 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(T obj) {#add-T-}
+```
+public T add(T obj)
+```
+
+
+배열에 새 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T | 추가할 객체. |
+
+**Returns:**
+T - 추가된 객체.
+### deepClone() {#deepClone--}
+```
+public XpsPathFigure deepClone()
+```
+
+
+이 PathFigure를 복제합니다.
+
+**Returns:**
+[XpsPathFigure](../../com.aspose.xps/xpspathfigure) - Clone of this path figure.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public T get(int i)
+```
+
+
+인덱스 i 로 배열 요소에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 요소의 인덱스. |
+
+**Returns:**
+T - i 위치에 있는 요소.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getSegments() {#getSegments--}
+```
+public List<XpsPathSegment> getSegments()
+```
+
+
+자식 경로 세그먼트 목록을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsPathSegment> - 자식 경로 세그먼트 목록.
+### getStartPoint() {#getStartPoint--}
+```
+public Point2D getStartPoint()
+```
+
+
+PathFigure의 첫 번째 세그먼트 시작점을 반환합니다.
+
+**Returns:**
+java.awt.geom.Point2D - PathFigure의 첫 번째 세그먼트 시작점.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insert(int index, T obj) {#insert-int-T-}
+```
+public T insert(int index, T obj)
+```
+
+
+지정된 위치에 새 객체를 배열에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 객체를 삽입할 위치. |
+| obj | T | 삽입할 객체. |
+
+**Returns:**
+T - 삽입된 객체.
+### isClosed() {#isClosed--}
+```
+public boolean isClosed()
+```
+
+
+PathFigure가 닫혔는지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - 경로 도형이 닫혀 있는지를 나타내는 값.
+### isFilled() {#isFilled--}
+```
+public boolean isFilled()
+```
+
+
+PathFigure가 포함된 경로 기하학의 면적을 계산하는 데 사용되는지 여부를 나타내는 값을 반환합니다.
+
+**Returns:**
+boolean - 경로 도형이 포함된 경로 기하학의 면적을 계산하는 데 사용되는지를 나타내는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(T obj) {#remove-T-}
+```
+public T remove(T obj)
+```
+
+
+배열에서 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T | 제거할 객체. |
+
+**Returns:**
+T - 제거된 객체.
+### removeAt(int index) {#removeAt-int-}
+```
+public T removeAt(int index)
+```
+
+
+지정된 위치에서 배열의 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 객체를 제거할 위치. |
+
+**Returns:**
+T - 제거된 객체.
+### setClosed(boolean value) {#setClosed-boolean-}
+```
+public void setClosed(boolean value)
+```
+
+
+PathFigure가 닫혔는지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 경로 도형이 닫혀 있는지를 나타내는 값. |
+
+### setFilled(boolean value) {#setFilled-boolean-}
+```
+public void setFilled(boolean value)
+```
+
+
+PathFigure가 포함된 경로 기하학의 면적을 계산하는 데 사용되는지 여부를 나타내는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 경로 도형이 포함된 경로 기하학의 면적을 계산하는 데 사용되는지를 나타내는 값. |
+
+### setStartPoint(Point2D value) {#setStartPoint-java.awt.geom.Point2D-}
+```
+public void setStartPoint(Point2D value)
+```
+
+
+PathFigure의 첫 번째 세그먼트 시작점을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Point2D | 경로 도형의 첫 번째 세그먼트 시작점. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+요소 수를 반환합니다.
+
+**Returns:**
+int - 요소의 개수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspathgeometry/_index.md
+++ b/korean/java/com.aspose.xps/xpspathgeometry/_index.md
@@ -1,0 +1,356 @@
+---
+title: "XpsPathGeometry"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PathGeometry 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 42
+url: /ko/java/com.aspose.xps/xpspathgeometry/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), com.aspose.xps.XpsArray
+
+**All Implemented Interfaces:**
+com.aspose.xps.ITransformableProperty
+```
+public final class XpsPathGeometry extends XpsArray<XpsPathFigure> implements ITransformableProperty
+```
+
+PathGeometry 속성 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 Figures 속성으로 지정하거나 자식 PathFigure 요소로 지정된 경로 피겨 집합을 포함합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [add(T obj)](#add-T-) | 배열에 새 객체를 추가합니다. |
+| [addSegment(XpsPathSegment segment)](#addSegment-com.aspose.xps.XpsPathSegment-) | 마지막 pah 피겨의 자식 세그먼트 목록에 경로 세그먼트를 추가합니다. |
+| [deepClone()](#deepClone--) | 이 경로 기하학을 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [get(int i)](#get-int-) | 인덱스 i 로 배열 요소에 접근할 수 있습니다. |
+| [getClass()](#getClass--) |  |
+| [getFillRule()](#getFillRule--) | 기하학적 도형의 교차 영역이 결합되어 영역을 형성하는 방식을 지정하는 값을 반환합니다. |
+| [getPathFigures()](#getPathFigures--) | 자식 경로 피겨 목록을 반환합니다. |
+| [getTransform()](#getTransform--) | 채우기, 클리핑 또는 스트로크에 사용되기 전에 경로 기하학의 모든 자식 및 하위 요소에 적용되는 로컬 행렬 변환을 설정하는 어파인 변환 행렬을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [insert(int index, T obj)](#insert-int-T-) | 지정된 위치에 새 객체를 배열에 삽입합니다. |
+| [insertSegment(int index, XpsPathSegment segment)](#insertSegment-int-com.aspose.xps.XpsPathSegment-) | 마지막 경로 피겨의 자식 세그먼트 목록에 인덱스 위치에 경로 세그먼트를 삽입합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [remove(T obj)](#remove-T-) | 배열에서 객체를 제거합니다. |
+| [removeAt(int index)](#removeAt-int-) | 지정된 위치에서 배열의 객체를 제거합니다. |
+| [removeSegment(XpsPathSegment segment)](#removeSegment-com.aspose.xps.XpsPathSegment-) | 마지막 경로 피겨의 자식 세그먼트 목록에서 경로 세그먼트를 제거합니다. |
+| [removeSegmentAt(int index)](#removeSegmentAt-int-) | 마지막 경로 피겨의 자식 세그먼트 목록에서 인덱스 위치에 있는 경로 세그먼트를 제거합니다. |
+| [setFillRule(XpsFillRule value)](#setFillRule-com.aspose.xps.XpsFillRule-) | 기하학적 도형의 교차 영역이 결합되어 영역을 형성하는 방식을 지정하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 채우기, 클리핑 또는 스트로크에 사용되기 전에 경로 기하학의 모든 자식 및 하위 요소에 적용되는 로컬 행렬 변환을 설정하는 어파인 변환 행렬을 설정합니다. |
+| [size()](#size--) | 요소 수를 반환합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### add(T obj) {#add-T-}
+```
+public T add(T obj)
+```
+
+
+배열에 새 객체를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T | 추가할 객체. |
+
+**Returns:**
+T - 추가된 객체.
+### addSegment(XpsPathSegment segment) {#addSegment-com.aspose.xps.XpsPathSegment-}
+```
+public XpsPathSegment addSegment(XpsPathSegment segment)
+```
+
+
+마지막 pah 피겨의 자식 세그먼트 목록에 경로 세그먼트를 추가합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| segment | [XpsPathSegment](../../com.aspose.xps/xpspathsegment) | 추가될 경로 세그먼트. |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Added path segment.
+### deepClone() {#deepClone--}
+```
+public XpsPathGeometry deepClone()
+```
+
+
+이 경로 기하학을 복제합니다.
+
+**Returns:**
+[XpsPathGeometry](../../com.aspose.xps/xpspathgeometry) - Clone of this path geometry.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### get(int i) {#get-int-}
+```
+public T get(int i)
+```
+
+
+인덱스 i 로 배열 요소에 접근할 수 있습니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| i | int | 요소의 인덱스. |
+
+**Returns:**
+T - i 위치에 있는 요소.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getFillRule() {#getFillRule--}
+```
+public XpsFillRule getFillRule()
+```
+
+
+기하학적 도형의 교차 영역이 결합되어 영역을 형성하는 방식을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsFillRule](../../com.aspose.xps/xpsfillrule) - The value specifying how the intersecting areas of geometric shapes are combined to form a region.
+### getPathFigures() {#getPathFigures--}
+```
+public List<XpsPathFigure> getPathFigures()
+```
+
+
+자식 경로 피겨 목록을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsPathFigure> - 자식 경로 피겨 목록.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+채우기, 클리핑 또는 스트로크에 사용되기 전에 경로 기하학의 모든 자식 및 하위 요소에 적용되는 로컬 행렬 변환을 설정하는 어파인 변환 행렬을 반환합니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The affine transformation matrix.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### insert(int index, T obj) {#insert-int-T-}
+```
+public T insert(int index, T obj)
+```
+
+
+지정된 위치에 새 객체를 배열에 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 객체를 삽입할 위치. |
+| obj | T | 삽입할 객체. |
+
+**Returns:**
+T - 삽입된 객체.
+### insertSegment(int index, XpsPathSegment segment) {#insertSegment-int-com.aspose.xps.XpsPathSegment-}
+```
+public XpsPathSegment insertSegment(int index, XpsPathSegment segment)
+```
+
+
+마지막 경로 피겨의 자식 세그먼트 목록에 인덱스 위치에 경로 세그먼트를 삽입합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 세그먼트를 삽입해야 하는 위치. |
+| segment | [XpsPathSegment](../../com.aspose.xps/xpspathsegment) | 삽입될 경로 세그먼트. |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Inserted path segment.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### remove(T obj) {#remove-T-}
+```
+public T remove(T obj)
+```
+
+
+배열에서 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| obj | T | 제거할 객체. |
+
+**Returns:**
+T - 제거된 객체.
+### removeAt(int index) {#removeAt-int-}
+```
+public T removeAt(int index)
+```
+
+
+지정된 위치에서 배열의 객체를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 객체를 제거할 위치. |
+
+**Returns:**
+T - 제거된 객체.
+### removeSegment(XpsPathSegment segment) {#removeSegment-com.aspose.xps.XpsPathSegment-}
+```
+public XpsPathSegment removeSegment(XpsPathSegment segment)
+```
+
+
+마지막 경로 피겨의 자식 세그먼트 목록에서 경로 세그먼트를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| segment | [XpsPathSegment](../../com.aspose.xps/xpspathsegment) | 제거될 경로 세그먼트. |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Removed path segment.
+### removeSegmentAt(int index) {#removeSegmentAt-int-}
+```
+public XpsPathSegment removeSegmentAt(int index)
+```
+
+
+마지막 경로 피겨의 자식 세그먼트 목록에서 인덱스 위치에 있는 경로 세그먼트를 제거합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 인덱스 | int | 경로 세그먼트를 제거해야 하는 위치. |
+
+**Returns:**
+[XpsPathSegment](../../com.aspose.xps/xpspathsegment) - Removed path segment.
+### setFillRule(XpsFillRule value) {#setFillRule-com.aspose.xps.XpsFillRule-}
+```
+public void setFillRule(XpsFillRule value)
+```
+
+
+기하학적 도형의 교차 영역이 결합되어 영역을 형성하는 방식을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsFillRule](../../com.aspose.xps/xpsfillrule) | 기하학적 도형의 교차 영역이 결합되어 영역을 형성하는 방식을 지정하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+채우기, 클리핑 또는 스트로크에 사용되기 전에 경로 기하학의 모든 자식 및 하위 요소에 적용되는 로컬 행렬 변환을 설정하는 어파인 변환 행렬을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 아핀 변환 행렬. |
+
+### size() {#size--}
+```
+public int size()
+```
+
+
+요소 수를 반환합니다.
+
+**Returns:**
+int - 요소의 개수.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspathpolysegment/_index.md
+++ b/korean/java/com.aspose.xps/xpspathpolysegment/_index.md
@@ -1,0 +1,149 @@
+---
+title: "XpsPathPolySegment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PolyLineSegment, PolyBzierSegment 및 PolyQuadraticBzierSegment 요소의 공통 기능을 캡슐화하는 클래스."
+type: docs
+weight: 43
+url: /ko/java/com.aspose.xps/xpspathpolysegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment)
+```
+public abstract class XpsPathPolySegment extends XpsPathSegment
+```
+
+PolyLineSegment, PolyBezierSegment 및 PolyQuadraticBezierSegment 요소의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspathsegment/_index.md
+++ b/korean/java/com.aspose.xps/xpspathsegment/_index.md
@@ -1,0 +1,149 @@
+---
+title: "XpsPathSegment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "모든 경로 세그먼트 요소의 공통 기능을 캡슐화하는 클래스."
+type: docs
+weight: 44
+url: /ko/java/com.aspose.xps/xpspathsegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public abstract class XpsPathSegment extends XpsObject
+```
+
+모든 경로 세그먼트 요소의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspolybeziersegment/_index.md
+++ b/korean/java/com.aspose.xps/xpspolybeziersegment/_index.md
@@ -1,0 +1,160 @@
+---
+title: "XpsPolyBezierSegment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PolyBezierSegment 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 45
+url: /ko/java/com.aspose.xps/xpspolybeziersegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment), [com.aspose.xps.XpsPathPolySegment](../../com.aspose.xps/xpspathpolysegment)
+```
+public class XpsPolyBezierSegment extends XpsPathPolySegment
+```
+
+PolyBezierSegment 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 일련의 3차 베지어 곡선을 설명합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 3차 베지어 곡선 집합을 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPolyBezierSegment deepClone()
+```
+
+
+이 3차 베지어 곡선 집합을 복제합니다.
+
+**Returns:**
+[XpsPolyBezierSegment](../../com.aspose.xps/xpspolybeziersegment) - Clone of this set of cubic B?zier curves.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspolylinesegment/_index.md
+++ b/korean/java/com.aspose.xps/xpspolylinesegment/_index.md
@@ -1,0 +1,160 @@
+---
+title: "XpsPolyLineSegment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PolyLineSegment 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 46
+url: /ko/java/com.aspose.xps/xpspolylinesegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment), [com.aspose.xps.XpsPathPolySegment](../../com.aspose.xps/xpspathpolysegment)
+```
+public class XpsPolyLineSegment extends XpsPathPolySegment
+```
+
+PolyLineSegment 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 임의 개수의 개별 정점을 포함하는 다각형 그리기를 설명합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 다각형을 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPolyLineSegment deepClone()
+```
+
+
+이 다각형을 복제합니다.
+
+**Returns:**
+[XpsPolyLineSegment](../../com.aspose.xps/xpspolylinesegment) - Clone of this polygon.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpspolyquadraticbeziersegment/_index.md
+++ b/korean/java/com.aspose.xps/xpspolyquadraticbeziersegment/_index.md
@@ -1,0 +1,160 @@
+---
+title: "XpsPolyQuadraticBezierSegment"
+second_title: "Aspose.Page용 Java API 참조"
+description: "PolyQuadraticBezierSegment 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 47
+url: /ko/java/com.aspose.xps/xpspolyquadraticbeziersegment/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsPathSegment](../../com.aspose.xps/xpspathsegment), [com.aspose.xps.XpsPathPolySegment](../../com.aspose.xps/xpspathpolysegment)
+```
+public class XpsPolyQuadraticBezierSegment extends XpsPathPolySegment
+```
+
+PolyQuadraticBezierSegment 요소 기능을 캡슐화하는 클래스. 이 요소는 지정된 제어점을 사용하여 경로 도형의 이전 점에서 일련의 정점들을 통해 일련의 2차 베지어 곡선을 설명합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 2차 베지어 곡선 집합을 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [isStroked()](#isStroked--) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다. |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setStroked(boolean value)](#setStroked-boolean-) | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsPolyQuadraticBezierSegment deepClone()
+```
+
+
+이 2차 베지어 곡선 집합을 복제합니다.
+
+**Returns:**
+[XpsPolyQuadraticBezierSegment](../../com.aspose.xps/xpspolyquadraticbeziersegment) - Clone of this set of quadratic B?zier curves.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### isStroked() {#isStroked--}
+```
+public boolean isStroked()
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 반환합니다.
+
+**Returns:**
+boolean - 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값.
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setStroked(boolean value) {#setStroked-boolean-}
+```
+public void setStroked(boolean value)
+```
+
+
+이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | boolean | 이 경로 세그먼트에 대한 스트로크가 그려지는지 여부를 지정하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsradialgradientbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpsradialgradientbrush/_index.md
@@ -1,0 +1,360 @@
+---
+title: "XpsRadialGradientBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "RadialGradientBrush 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 48
+url: /ko/java/com.aspose.xps/xpsradialgradientbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsGradientBrush](../../com.aspose.xps/xpsgradientbrush)
+```
+public final class XpsRadialGradientBrush extends XpsGradientBrush
+```
+
+RadialGradientBrush 속성 요소 기능을 캡슐화하는 클래스. 이 요소는 방사형 그라디언트 브러시를 지정하는 데 사용됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 방사형 그라디언트 브러시를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getCenter()](#getCenter--) | 방사형 그라디언트의 중심점(즉, 타원의 중심)을 반환합니다. |
+| [getClass()](#getClass--) |  |
+| [getColorInterpolationMode()](#getColorInterpolationMode--) | 색상 보간을 위한 감마 함수 값을 반환합니다. |
+| [getGradientOrigin()](#getGradientOrigin--) | 방사형 그라디언트의 원점을 반환합니다. |
+| [getGradientStops()](#getGradientStops--) | 그라디언트를 구성하는 그라디언트 스톱 목록을 반환합니다. |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getRadiusX()](#getRadiusX--) | 방사형 그라디언트를 정의하는 타원의 x 차원 반경을 반환합니다. |
+| [getRadiusY()](#getRadiusY--) | 방사형 그라디언트를 정의하는 타원의 y 차원 반경을 반환합니다. |
+| [getSpreadMethod()](#getSpreadMethod--) | 주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setCenter(Point2D value)](#setCenter-java.awt.geom.Point2D-) | 방사형 그라디언트의 중심점(즉, 타원의 중심)을 설정합니다. |
+| [setColorInterpolationMode(XpsColorInterpolationMode value)](#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-) | 색상 보간을 위한 감마 함수 값을 설정합니다. |
+| [setGradientOrigin(Point2D value)](#setGradientOrigin-java.awt.geom.Point2D-) | 방사형 그라디언트의 원점을 설정합니다. |
+| [setGradientStops(List<XpsGradientStop> value)](#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--) | 그라디언트를 구성하는 그라디언트 스톱 목록을 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setRadiusX(float value)](#setRadiusX-float-) | 방사형 그라디언트를 정의하는 타원의 x 차원 반경을 설정합니다. |
+| [setRadiusY(float value)](#setRadiusY-float-) | 방사형 그라디언트를 정의하는 타원의 y 차원 반경을 설정합니다. |
+| [setSpreadMethod(XpsSpreadMethod value)](#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-) | 주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsRadialGradientBrush deepClone()
+```
+
+
+이 방사형 그라디언트 브러시를 복제합니다.
+
+**Returns:**
+[XpsRadialGradientBrush](../../com.aspose.xps/xpsradialgradientbrush) - Clone of this radial gradient brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getCenter() {#getCenter--}
+```
+public Point2D getCenter()
+```
+
+
+방사형 그라디언트의 중심점(즉, 타원의 중심)을 반환합니다.
+
+**Returns:**
+java.awt.geom.Point2D - 방사형 그라디언트의 중심점.
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColorInterpolationMode() {#getColorInterpolationMode--}
+```
+public XpsColorInterpolationMode getColorInterpolationMode()
+```
+
+
+색상 보간을 위한 감마 함수 값을 반환합니다. 지정된 경우 감마 조정은 알파 구성 요소에 적용되지 않아야 합니다.
+
+**Returns:**
+[XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) - Value specifying the gamma function for color interpolation.
+### getGradientOrigin() {#getGradientOrigin--}
+```
+public Point2D getGradientOrigin()
+```
+
+
+방사형 그라디언트의 원점을 반환합니다.
+
+**Returns:**
+java.awt.geom.Point2D - 방사형 그라디언트의 원점.
+### getGradientStops() {#getGradientStops--}
+```
+public List<XpsGradientStop> getGradientStops()
+```
+
+
+그라디언트를 구성하는 그라디언트 스톱 목록을 반환합니다.
+
+**Returns:**
+java.util.List<com.aspose.xps.XpsGradientStop> - 그라디언트를 구성하는 그라디언트 스톱 목록.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getRadiusX() {#getRadiusX--}
+```
+public float getRadiusX()
+```
+
+
+방사형 그라디언트를 정의하는 타원의 x 차원 반경을 반환합니다.
+
+**Returns:**
+float - 방사형 그라디언트를 정의하는 타원의 x 차원 반경.
+### getRadiusY() {#getRadiusY--}
+```
+public float getRadiusY()
+```
+
+
+방사형 그라디언트를 정의하는 타원의 y 차원 반경을 반환합니다.
+
+**Returns:**
+float - 방사형 그라디언트를 정의하는 타원의 y 차원 반경.
+### getSpreadMethod() {#getSpreadMethod--}
+```
+public XpsSpreadMethod getSpreadMethod()
+```
+
+
+주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 반환합니다.
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) - Value describing how the brush should fill the content area outside of the primary, initial gradient area.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setCenter(Point2D value) {#setCenter-java.awt.geom.Point2D-}
+```
+public void setCenter(Point2D value)
+```
+
+
+방사형 그라디언트의 중심점(즉, 타원의 중심)을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Point2D | 방사형 그라디언트의 중심점. |
+
+### setColorInterpolationMode(XpsColorInterpolationMode value) {#setColorInterpolationMode-com.aspose.xps.XpsColorInterpolationMode-}
+```
+public void setColorInterpolationMode(XpsColorInterpolationMode value)
+```
+
+
+색 보간을 위한 감마 함수를 지정하는 값을 설정합니다. 지정된 경우 감마 조정은 알파 구성 요소에 적용되지 않아야 합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsColorInterpolationMode](../../com.aspose.xps/xpscolorinterpolationmode) | 색 보간을 위한 감마 함수를 지정하는 값. |
+
+### setGradientOrigin(Point2D value) {#setGradientOrigin-java.awt.geom.Point2D-}
+```
+public void setGradientOrigin(Point2D value)
+```
+
+
+방사형 그라디언트의 원점을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Point2D | 방사형 그라디언트의 원점. |
+
+### setGradientStops(List<XpsGradientStop> value) {#setGradientStops-java.util.List-com.aspose.xps.XpsGradientStop--}
+```
+public void setGradientStops(List<XpsGradientStop> value)
+```
+
+
+그라디언트를 구성하는 그라디언트 스톱 목록을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.util.List<com.aspose.xps.XpsGradientStop> | 그라디언트를 구성하는 그라디언트 스톱 목록. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setRadiusX(float value) {#setRadiusX-float-}
+```
+public void setRadiusX(float value)
+```
+
+
+방사형 그라디언트를 정의하는 타원의 x 차원 반경을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 방사형 그라디언트를 정의하는 타원의 x 차원 반경. |
+
+### setRadiusY(float value) {#setRadiusY-float-}
+```
+public void setRadiusY(float value)
+```
+
+
+방사형 그라디언트를 정의하는 타원의 y 차원 반경을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 방사형 그라디언트를 정의하는 타원의 y 차원 반경. |
+
+### setSpreadMethod(XpsSpreadMethod value) {#setSpreadMethod-com.aspose.xps.XpsSpreadMethod-}
+```
+public void setSpreadMethod(XpsSpreadMethod value)
+```
+
+
+주요 초기 그라디언트 영역 외부의 콘텐츠 영역을 브러시가 어떻게 채워야 하는지를 설명하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod) | 브러시가 기본 초기 그라디언트 영역 외부의 콘텐츠 영역을 채우는 방법을 설명하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsrgbcolor/_index.md
+++ b/korean/java/com.aspose.xps/xpsrgbcolor/_index.md
@@ -1,0 +1,135 @@
+---
+title: "XpsRgbColor"
+second_title: "Aspose.Page용 Java API 참조"
+description: "sRGB 또는 scRGB와 같은 모든 색 공간의 RGB 색상을 캡슐화합니다."
+type: docs
+weight: 49
+url: /ko/java/com.aspose.xps/xpsrgbcolor/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsColor](../../com.aspose.xps/xpscolor)
+```
+public final class XpsRgbColor extends XpsColor
+```
+
+RGB 색상(모든 색 공간, sRGB 또는 scRGB)을 캡슐화합니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toColor()](#toColor--) | .NET 기본 RGB 색상 표현을 가져오는 편리한 메서드. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toColor() {#toColor--}
+```
+public Color toColor()
+```
+
+
+.NET 기본 RGB 색상 표현을 가져오는 편리한 메서드.
+
+**Returns:**
+java.awt.Color - System.Drawing.ColorSystem.Drawing.Color 구조체.
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpssolidcolorbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpssolidcolorbrush/_index.md
@@ -1,0 +1,185 @@
+---
+title: "XpsSolidColorBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "SolidColorBrush 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 50
+url: /ko/java/com.aspose.xps/xpssolidcolorbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush)
+```
+public final class XpsSolidColorBrush extends XpsBrush
+```
+
+SolidColorBrush 속성 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 정의된 기하학적 영역을 단색으로 채우는 데 사용됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 단색 브러시를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getColor()](#getColor--) | 채워진 요소의 색상을 반환합니다. |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setColor(XpsColor value)](#setColor-com.aspose.xps.XpsColor-) | 채워진 요소의 색상을 설정합니다. |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsSolidColorBrush deepClone()
+```
+
+
+이 단색 브러시를 복제합니다.
+
+**Returns:**
+[XpsSolidColorBrush](../../com.aspose.xps/xpssolidcolorbrush) - Clone of this solid color brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getColor() {#getColor--}
+```
+public XpsColor getColor()
+```
+
+
+채워진 요소의 색상을 반환합니다.
+
+**Returns:**
+[XpsColor](../../com.aspose.xps/xpscolor) - The color for filled elements.
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setColor(XpsColor value) {#setColor-com.aspose.xps.XpsColor-}
+```
+public void setColor(XpsColor value)
+```
+
+
+채워진 요소의 색상을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsColor](../../com.aspose.xps/xpscolor) | 채워진 요소의 색상. |
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsspreadmethod/_index.md
+++ b/korean/java/com.aspose.xps/xpsspreadmethod/_index.md
@@ -1,0 +1,259 @@
+---
+title: "XpsSpreadMethod"
+second_title: "Aspose.Page용 Java API 참조"
+description: "그라디언트 브러시의 SpreadMethod 속성에 대한 유효한 값들."
+type: docs
+weight: 63
+url: /ko/java/com.aspose.xps/xpsspreadmethod/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsSpreadMethod extends Enum<XpsSpreadMethod>
+```
+
+그라디언트 브러시의 SpreadMethod 속성에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Pad](#Pad) | 이 방법에서는 첫 번째 색상과 마지막 색상을 사용하여 시작과 끝의 남은 채우기 영역을 채웁니다. |
+| [Reflect](#Reflect) | 이 방법에서는 그라디언트 스톱을 역순으로 반복 재생하여 채우기 영역을 덮습니다. |
+| [Repeat](#Repeat) | 이 방법에서는 그라디언트 스톱을 순서대로 반복하여 채우기 영역이 완전히 채워질 때까지 진행합니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Pad {#Pad}
+```
+public static final XpsSpreadMethod Pad
+```
+
+
+이 방법에서는 첫 번째 색상과 마지막 색상을 사용하여 시작과 끝의 남은 채우기 영역을 채웁니다.
+
+### Reflect {#Reflect}
+```
+public static final XpsSpreadMethod Reflect
+```
+
+
+이 방법에서는 그라디언트 스톱을 역순으로 반복 재생하여 채우기 영역을 덮습니다.
+
+### Repeat {#Repeat}
+```
+public static final XpsSpreadMethod Repeat
+```
+
+
+이 방법에서는 그라디언트 스톱을 순서대로 반복하여 채우기 영역이 완전히 채워질 때까지 진행합니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsSpreadMethod valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsSpreadMethod](../../com.aspose.xps/xpsspreadmethod)
+### values() {#values--}
+```
+public static XpsSpreadMethod[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsSpreadMethod[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsstylesimulations/_index.md
+++ b/korean/java/com.aspose.xps/xpsstylesimulations/_index.md
@@ -1,0 +1,268 @@
+---
+title: "XpsStyleSimulations"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Glyphs 요소의 StyleSimulations 속성에 대한 유효한 값."
+type: docs
+weight: 64
+url: /ko/java/com.aspose.xps/xpsstylesimulations/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsStyleSimulations extends Enum<XpsStyleSimulations>
+```
+
+Glyphs 요소의 StyleSimulations 속성에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [BoldItalicSimulation](#BoldItalicSimulation) | 굵은 이탤릭 시뮬레이션 |
+| [BoldSimulation](#BoldSimulation) | 굵은 시뮬레이션 |
+| [ItalicSimulation](#ItalicSimulation) | 기울임 시뮬레이션 |
+| [None](#None) | 스타일 시뮬레이션 없음 |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### BoldItalicSimulation {#BoldItalicSimulation}
+```
+public static final XpsStyleSimulations BoldItalicSimulation
+```
+
+
+굵은 이탤릭 시뮬레이션
+
+### BoldSimulation {#BoldSimulation}
+```
+public static final XpsStyleSimulations BoldSimulation
+```
+
+
+굵은 시뮬레이션
+
+### ItalicSimulation {#ItalicSimulation}
+```
+public static final XpsStyleSimulations ItalicSimulation
+```
+
+
+기울임 시뮬레이션
+
+### None {#None}
+```
+public static final XpsStyleSimulations None
+```
+
+
+스타일 시뮬레이션 없음
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsStyleSimulations valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsStyleSimulations](../../com.aspose.xps/xpsstylesimulations)
+### values() {#values--}
+```
+public static XpsStyleSimulations[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsStyleSimulations[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpssweepdirection/_index.md
+++ b/korean/java/com.aspose.xps/xpssweepdirection/_index.md
@@ -1,0 +1,250 @@
+---
+title: "XpsSweepDirection"
+second_title: "Aspose.Page용 Java API 참조"
+description: "ArcSegment 요소의 SweepDirection 속성에 대한 유효한 값."
+type: docs
+weight: 65
+url: /ko/java/com.aspose.xps/xpssweepdirection/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsSweepDirection extends Enum<XpsSweepDirection>
+```
+
+ArcSegment 요소의 SweepDirection 속성에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [Clockwise](#Clockwise) | 시계 방향. |
+| [Counterclockwise](#Counterclockwise) | 반시계 방향. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### Clockwise {#Clockwise}
+```
+public static final XpsSweepDirection Clockwise
+```
+
+
+시계 방향.
+
+### Counterclockwise {#Counterclockwise}
+```
+public static final XpsSweepDirection Counterclockwise
+```
+
+
+반시계 방향.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsSweepDirection valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsSweepDirection](../../com.aspose.xps/xpssweepdirection)
+### values() {#values--}
+```
+public static XpsSweepDirection[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsSweepDirection[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpstilemode/_index.md
+++ b/korean/java/com.aspose.xps/xpstilemode/_index.md
@@ -1,0 +1,277 @@
+---
+title: "XpsTileMode"
+second_title: "Aspose.Page용 Java API 참조"
+description: "타일링 브러시의 TileMode 속성에 대한 유효한 값들."
+type: docs
+weight: 66
+url: /ko/java/com.aspose.xps/xpstilemode/
+---
+**Inheritance:**
+java.lang.Object, java.lang.Enum
+```
+public enum XpsTileMode extends Enum<XpsTileMode>
+```
+
+타일링 브러시의 TileMode 속성에 대한 유효한 값입니다.
+## 필드
+
+| 필드 | 설명 |
+| --- | --- |
+| [FlipX](#FlipX) | 타일 배열은 Tile 타일 모드와 유사하지만, 교대로 배치된 열의 타일은 수평으로 뒤집힙니다. |
+| [FlipXY](#FlipXY) | 타일 배열은 Tile 타일 모드와 유사하지만, 교대로 배치된 열의 타일은 수평으로, 교대로 배치된 행의 타일은 수직으로 뒤집힙니다. |
+| [FlipY](#FlipY) | 타일 배열은 Tile 타일 모드와 유사하지만, 교대로 배치된 행의 타일은 수직으로 뒤집힙니다. |
+| [None](#None) | 이 모드에서는 단일 기본 타일만 그려집니다. |
+| [Tile](#Tile) | 이 모드에서는 기본 타일을 그린 후, 각 타일의 오른쪽 가장자리가 다음 타일의 왼쪽 가장자리에 맞닿고, 각 타일의 아래쪽 가장자리가 다음 타일의 위쪽 가장자리에 맞닿도록 기본 타일을 반복하여 나머지 영역을 채웁니다. |
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [<T>valueOf(Class<T> arg0, String arg1)](#-T-valueOf-java.lang.Class-T--java.lang.String-) |  |
+| [compareTo(E arg0)](#compareTo-E-) |  |
+| [describeConstable()](#describeConstable--) |  |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getDeclaringClass()](#getDeclaringClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [name()](#name--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [ordinal()](#ordinal--) |  |
+| [toString()](#toString--) |  |
+| [valueOf(String name)](#valueOf-java.lang.String-) |  |
+| [values()](#values--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### FlipX {#FlipX}
+```
+public static final XpsTileMode FlipX
+```
+
+
+타일 배열은 Tile 타일 모드와 유사하지만, 교대로 배치된 열의 타일은 수평으로 뒤집힙니다. 기본 타일은 뷰포트에 지정된 대로 배치됩니다. 이 타일의 왼쪽 및 오른쪽 열에 있는 타일은 수평으로 뒤집힙니다.
+
+### FlipXY {#FlipXY}
+```
+public static final XpsTileMode FlipXY
+```
+
+
+타일 배열은 Tile 타일 모드와 유사하지만, 교대로 배치된 열의 타일은 수평으로, 교대로 배치된 행의 타일은 수직으로 뒤집힙니다. 기본 타일은 뷰포트에 지정된 대로 배치됩니다.
+
+### FlipY {#FlipY}
+```
+public static final XpsTileMode FlipY
+```
+
+
+타일 배열은 Tile 타일 모드와 유사하지만, 교대로 배치된 행의 타일은 수직으로 뒤집힙니다. 기본 타일은 뷰포트에 지정된 대로 배치됩니다. 위와 아래 행은 수직으로 뒤집힙니다.
+
+### None {#None}
+```
+public static final XpsTileMode None
+```
+
+
+이 모드에서는 단일 기본 타일만 그려지고, 나머지 영역은 투명하게 남겨집니다.
+
+### Tile {#Tile}
+```
+public static final XpsTileMode Tile
+```
+
+
+이 모드에서는 기본 타일을 그린 후, 각 타일의 오른쪽 가장자리가 다음 타일의 왼쪽 가장자리에 맞닿고, 각 타일의 아래쪽 가장자리가 다음 타일의 위쪽 가장자리에 맞닿도록 기본 타일을 반복하여 나머지 영역을 채웁니다.
+
+### <T>valueOf(Class<T> arg0, String arg1) {#-T-valueOf-java.lang.Class-T--java.lang.String-}
+```
+public static T <T>valueOf(Class<T> arg0, String arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Class<T> |  |
+| arg1 | java.lang.String |  |
+
+**Returns:**
+T
+### compareTo(E arg0) {#compareTo-E-}
+```
+public final int compareTo(E arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | E |  |
+
+**Returns:**
+int
+### describeConstable() {#describeConstable--}
+```
+public final Optional<Enum.EnumDesc<E>> describeConstable()
+```
+
+
+
+
+**Returns:**
+java.util.Optional<java.lang.Enum.EnumDesc<E>>
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public final boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getDeclaringClass() {#getDeclaringClass--}
+```
+public final Class<E> getDeclaringClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<E>
+### hashCode() {#hashCode--}
+```
+public final int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### name() {#name--}
+```
+public final String name()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### ordinal() {#ordinal--}
+```
+public final int ordinal()
+```
+
+
+
+
+**Returns:**
+int
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### valueOf(String name) {#valueOf-java.lang.String-}
+```
+public static XpsTileMode valueOf(String name)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 이름 | java.lang.String |  |
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode)
+### values() {#values--}
+```
+public static XpsTileMode[] values()
+```
+
+
+
+
+**Returns:**
+com.aspose.xps.XpsTileMode[]
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpstilingbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpstilingbrush/_index.md
@@ -1,0 +1,249 @@
+---
+title: "XpsTilingBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "타일 브러시 요소인 VisualBrush와 ImageBrush의 공통 기능을 캡슐화하는 클래스입니다."
+type: docs
+weight: 51
+url: /ko/java/com.aspose.xps/xpstilingbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush)
+```
+public abstract class XpsTilingBrush extends XpsTransformableBrush
+```
+
+타일링 브러시 요소(VisualBrush 및 ImageBrush)의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getTileMode()](#getTileMode--) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [getViewbox()](#getViewbox--) | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 반환합니다. |
+| [getViewport()](#getViewport--) | 첫 번째 브러시 타일의 위치와 크기를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setTileMode(XpsTileMode value)](#setTileMode-com.aspose.xps.XpsTileMode-) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [setViewbox(Rectangle2D value)](#setViewbox-java.awt.geom.Rectangle2D-) | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 설정합니다. |
+| [setViewport(Rectangle2D value)](#setViewport-java.awt.geom.Rectangle2D-) | 첫 번째 브러시 타일의 위치와 크기를 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getTileMode() {#getTileMode--}
+```
+public XpsTileMode getTileMode()
+```
+
+
+채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode) - Value specifying how tiling is performed in the filled geometry.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### getViewbox() {#getViewbox--}
+```
+public Rectangle2D getViewbox()
+```
+
+
+뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 반환합니다.
+
+**Returns:**
+java.awt.geom.Rectangle2D - 뷰포트에 매핑될 브러시 소스 콘텐츠 영역.
+### getViewport() {#getViewport--}
+```
+public Rectangle2D getViewport()
+```
+
+
+첫 번째 브러시 타일의 위치와 크기를 반환합니다. 이후 타일은 타일 모드에 지정된 대로 이 타일을 기준으로 배치됩니다.
+
+**Returns:**
+java.awt.geom.Rectangle2D - 첫 번째 브러시 타일의 위치와 크기.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setTileMode(XpsTileMode value) {#setTileMode-com.aspose.xps.XpsTileMode-}
+```
+public void setTileMode(XpsTileMode value)
+```
+
+
+채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsTileMode](../../com.aspose.xps/xpstilemode) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### setViewbox(Rectangle2D value) {#setViewbox-java.awt.geom.Rectangle2D-}
+```
+public void setViewbox(Rectangle2D value)
+```
+
+
+뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Rectangle2D | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역. |
+
+### setViewport(Rectangle2D value) {#setViewport-java.awt.geom.Rectangle2D-}
+```
+public void setViewport(Rectangle2D value)
+```
+
+
+첫 번째 브러시 타일의 위치와 크기를 설정합니다. 이후 타일은 타일 모드에 지정된 대로 이 타일을 기준으로 배치됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Rectangle2D | 첫 번째 브러시 타일의 위치와 크기. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpstransformablebrush/_index.md
+++ b/korean/java/com.aspose.xps/xpstransformablebrush/_index.md
@@ -1,0 +1,177 @@
+---
+title: "XpsTransformableBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "SolidColorBrush를 제외한 변형 가능한 브러시 요소의 공통 기능을 캡슐화하는 클래스."
+type: docs
+weight: 52
+url: /ko/java/com.aspose.xps/xpstransformablebrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush)
+
+**All Implemented Interfaces:**
+com.aspose.xps.ITransformableProperty
+```
+public abstract class XpsTransformableBrush extends XpsBrush implements ITransformableProperty
+```
+
+변환 가능한 브러시 요소(모두 SolidColorBrush 제외)의 공통 기능을 캡슐화하는 클래스.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsvisual/_index.md
+++ b/korean/java/com.aspose.xps/xpsvisual/_index.md
@@ -1,0 +1,124 @@
+---
+title: "XpsVisual"
+second_title: "Aspose.Page용 Java API 참조"
+description: "Visual 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 53
+url: /ko/java/com.aspose.xps/xpsvisual/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject)
+```
+public final class XpsVisual extends XpsObject
+```
+
+Visual 요소 기능을 캡슐화하는 클래스. 이 속성 요소는 단일 Visual 브러시 타일의 내용을 정의하는 마크업을 포함합니다. 이 타일은 Visual 브러시가 적용되는 기하학적 영역을 채우는 데 사용할 수 있습니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+

--- a/korean/java/com.aspose.xps/xpsvisualbrush/_index.md
+++ b/korean/java/com.aspose.xps/xpsvisualbrush/_index.md
@@ -1,0 +1,285 @@
+---
+title: "XpsVisualBrush"
+second_title: "Aspose.Page용 Java API 참조"
+description: "VisualBrush 속성 요소 기능을 캡슐화하는 클래스."
+type: docs
+weight: 54
+url: /ko/java/com.aspose.xps/xpsvisualbrush/
+---
+**Inheritance:**
+java.lang.Object, [com.aspose.xps.XpsObject](../../com.aspose.xps/xpsobject), [com.aspose.xps.XpsBrush](../../com.aspose.xps/xpsbrush), [com.aspose.xps.XpsTransformableBrush](../../com.aspose.xps/xpstransformablebrush), [com.aspose.xps.XpsTilingBrush](../../com.aspose.xps/xpstilingbrush)
+```
+public final class XpsVisualBrush extends XpsTilingBrush
+```
+
+VisualBrush 속성 요소 기능을 캡슐화하는 클래스입니다. 이 요소는 그림으로 영역을 채우는 데 사용됩니다.
+## 메서드
+
+| 메서드 | 설명 |
+| --- | --- |
+| [deepClone()](#deepClone--) | 이 비주얼 브러시를 복제합니다. |
+| [equals(Object arg0)](#equals-java.lang.Object-) |  |
+| [getClass()](#getClass--) |  |
+| [getOpacity()](#getOpacity--) | 브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다. |
+| [getTileMode()](#getTileMode--) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 반환합니다. |
+| [getTransform()](#getTransform--) | 브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. |
+| [getViewbox()](#getViewbox--) | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 반환합니다. |
+| [getViewport()](#getViewport--) | 첫 번째 브러시 타일의 위치와 크기를 반환합니다. |
+| [getVisual()](#getVisual--) | brush\\u2019s 소스 콘텐츠를 그리는 데 사용되는 Path, Glyphs 또는 Canvas 요소를 반환합니다. |
+| [hashCode()](#hashCode--) |  |
+| [notify()](#notify--) |  |
+| [notifyAll()](#notifyAll--) |  |
+| [setOpacity(float value)](#setOpacity-float-) | 브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다. |
+| [setTileMode(XpsTileMode value)](#setTileMode-com.aspose.xps.XpsTileMode-) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 설정합니다. |
+| [setTransform(XpsMatrix value)](#setTransform-com.aspose.xps.XpsMatrix-) | 브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. |
+| [setViewbox(Rectangle2D value)](#setViewbox-java.awt.geom.Rectangle2D-) | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 설정합니다. |
+| [setViewport(Rectangle2D value)](#setViewport-java.awt.geom.Rectangle2D-) | 첫 번째 브러시 타일의 위치와 크기를 설정합니다. |
+| [setVisual(XpsContentElement visual)](#setVisual-com.aspose.xps.XpsContentElement-) | visual을 visual brush의 Visual 요소로 설정합니다. |
+| [toString()](#toString--) |  |
+| [wait()](#wait--) |  |
+| [wait(long arg0)](#wait-long-) |  |
+| [wait(long arg0, int arg1)](#wait-long-int-) |  |
+### deepClone() {#deepClone--}
+```
+public XpsVisualBrush deepClone()
+```
+
+
+이 비주얼 브러시를 복제합니다.
+
+**Returns:**
+[XpsVisualBrush](../../com.aspose.xps/xpsvisualbrush) - Clone of this visual brush.
+### equals(Object arg0) {#equals-java.lang.Object-}
+```
+public boolean equals(Object arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | java.lang.Object |  |
+
+**Returns:**
+boolean
+### getClass() {#getClass--}
+```
+public final native Class<?> getClass()
+```
+
+
+
+
+**Returns:**
+java.lang.Class<?>
+### getOpacity() {#getOpacity--}
+```
+public float getOpacity()
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 반환합니다.
+
+**Returns:**
+float - 브러시 채우기의 균일한 투명성을 정의하는 값.
+### getTileMode() {#getTileMode--}
+```
+public XpsTileMode getTileMode()
+```
+
+
+채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 반환합니다.
+
+**Returns:**
+[XpsTileMode](../../com.aspose.xps/xpstilemode) - Value specifying how tiling is performed in the filled geometry.
+### getTransform() {#getTransform--}
+```
+public XpsMatrix getTransform()
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 반환합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Returns:**
+[XpsMatrix](../../com.aspose.xps/xpsmatrix) - The matrix transformation applied to the coordinate space of the brush.
+### getViewbox() {#getViewbox--}
+```
+public Rectangle2D getViewbox()
+```
+
+
+뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 반환합니다.
+
+**Returns:**
+java.awt.geom.Rectangle2D - 뷰포트에 매핑될 브러시 소스 콘텐츠 영역.
+### getViewport() {#getViewport--}
+```
+public Rectangle2D getViewport()
+```
+
+
+첫 번째 브러시 타일의 위치와 크기를 반환합니다. 이후 타일은 타일 모드에 지정된 대로 이 타일을 기준으로 배치됩니다.
+
+**Returns:**
+java.awt.geom.Rectangle2D - 첫 번째 브러시 타일의 위치와 크기.
+### getVisual() {#getVisual--}
+```
+public XpsContentElement getVisual()
+```
+
+
+brush\\u2019s 소스 콘텐츠를 그리는 데 사용되는 Path, Glyphs 또는 Canvas 요소를 반환합니다.
+
+**Returns:**
+[XpsContentElement](../../com.aspose.xps/xpscontentelement) - A Path, Glyphs, or Canvas element used to draw the brush\\u2019s source content.
+### hashCode() {#hashCode--}
+```
+public native int hashCode()
+```
+
+
+
+
+**Returns:**
+int
+### notify() {#notify--}
+```
+public final native void notify()
+```
+
+
+
+
+### notifyAll() {#notifyAll--}
+```
+public final native void notifyAll()
+```
+
+
+
+
+### setOpacity(float value) {#setOpacity-float-}
+```
+public void setOpacity(float value)
+```
+
+
+브러시 채우기의 균일한 투명성을 정의하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | float | 브러시 채우기의 균일한 투명성을 정의하는 값. |
+
+### setTileMode(XpsTileMode value) {#setTileMode-com.aspose.xps.XpsTileMode-}
+```
+public void setTileMode(XpsTileMode value)
+```
+
+
+채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsTileMode](../../com.aspose.xps/xpstilemode) | 채워진 기하학에서 타일링이 수행되는 방식을 지정하는 값. |
+
+### setTransform(XpsMatrix value) {#setTransform-com.aspose.xps.XpsMatrix-}
+```
+public void setTransform(XpsMatrix value)
+```
+
+
+브러시 좌표 공간에 적용된 행렬 변환을 설정합니다. Transform 속성은 현재 유효한 렌더 변환과 연결되어 브러시 로컬의 유효한 렌더 변환을 생성합니다. 브러시의 뷰포트는 로컬 유효 렌더 변환을 사용하여 변환됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| value | [XpsMatrix](../../com.aspose.xps/xpsmatrix) | 브러시 좌표 공간에 적용된 행렬 변환. |
+
+### setViewbox(Rectangle2D value) {#setViewbox-java.awt.geom.Rectangle2D-}
+```
+public void setViewbox(Rectangle2D value)
+```
+
+
+뷰포트에 매핑될 브러시 소스 콘텐츠 영역을 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Rectangle2D | 뷰포트에 매핑될 브러시 소스 콘텐츠 영역. |
+
+### setViewport(Rectangle2D value) {#setViewport-java.awt.geom.Rectangle2D-}
+```
+public void setViewport(Rectangle2D value)
+```
+
+
+첫 번째 브러시 타일의 위치와 크기를 설정합니다. 이후 타일은 타일 모드에 지정된 대로 이 타일을 기준으로 배치됩니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| 값 | java.awt.geom.Rectangle2D | 첫 번째 브러시 타일의 위치와 크기. |
+
+### setVisual(XpsContentElement visual) {#setVisual-com.aspose.xps.XpsContentElement-}
+```
+public void setVisual(XpsContentElement visual)
+```
+
+
+visual을 visual brush의 Visual 요소로 설정합니다.
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| visual | [XpsContentElement](../../com.aspose.xps/xpscontentelement) | 요소. |
+
+### toString() {#toString--}
+```
+public String toString()
+```
+
+
+
+
+**Returns:**
+java.lang.String
+### wait() {#wait--}
+```
+public final void wait()
+```
+
+
+
+
+### wait(long arg0) {#wait-long-}
+```
+public final native void wait(long arg0)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+
+### wait(long arg0, int arg1) {#wait-long-int-}
+```
+public final void wait(long arg0, int arg1)
+```
+
+
+
+
+**Parameters:**
+| 매개변수 | 유형 | 설명 |
+| --- | --- | --- |
+| arg0 | long |  |
+| arg1 | int |  |
+


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 392/392
- Errors: 0
- Source: `english/java`
- Output: `korean/java`

🤖 Generated by RDA