### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Arabic

### DIFF
--- a/arabic/javascript-cpp/convert/_index.md
+++ b/arabic/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "دوال التحويل"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال التحويل للعمل مع ملفات Postscript/XPS."
+weight: 10
+type: docs
+url: /ar/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | تحويل ملف Postscript إلى صورة. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | تحويل ملف Postscript إلى PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | تحويل ملف XPS إلى صورة. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | تحويل ملف XPS إلى PDF. |
+
+## Detailed Description
+
+تحويل ملف postscript أو xps إلى صورة أو ملف PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/arabic/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "يقوم بتحويل Postscript إلى صورة"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+يقوم بتحويل Postscript إلى صورة.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى الخط المصدر للتحويل. |
+| fileName | string | اسم الملف. |
+| imageFormat | ImageFormat | تنسيق الصورة للتحويل إليه. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/arabic/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/arabic/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "يحوّل الـ Postscript إلى PDF"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+يقوم بتحويل Postscript إلى PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى الخط المصدر للتحويل. |
+| fileName | string | اسم الملف. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/arabic/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/arabic/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "يقوم بتحويل XPS إلى صورة"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+يقوم بتحويل Postscript إلى صورة.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى الخط المصدر للتحويل. |
+| fileName | string | اسم الملف. |
+| imageFormat | ImageFormat | تنسيق الصورة للتحويل إليه. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/arabic/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/arabic/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "يقوم بتحويل XPS إلى PDF"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+يقوم بتحويل XPS إلى PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى الخط المصدر للتحويل. |
+| fileName | string | اسم الملف. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/arabic/javascript-cpp/core/_index.md
+++ b/arabic/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "الدوال الأساسية"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "الدوال الأساسية للعمل مع ملفات Postscript/XPS."
+weight: 60
+type: docs
+url: /ar/javascript-cpp/core/
+---
+
+## Core Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | حفظ الـ BLOB في نظام الملفات الذاكرة للمعالجة. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | حفظ تمثيل السلسلة للـ BLOB في نظام الملفات الذاكرة للمعالجة. |
+
+## Detailed Description
+
+الدوال الأساسية للعمل مع ملفات Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/core/asposepageprepare/_index.md
+++ b/arabic/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "حفظ الـ BLOB في نظام الملفات الذاكرة للمعالجة."
+type: docs
+url: /ar/javascript-cpp/core/asposepageprepare/
+---
+
+_احفظ الـ BLOB في نظام الملفات الذاكرة للمعالجة._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+كائن JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/arabic/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/arabic/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "حفظ تمثيل السلسلة للـ BLOB في نظام الملفات الذاكرة للمعالجة."
+type: docs
+url: /ar/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_احفظ تمثيل السلسلة للـ BLOB في نظام الملفات الذاكرة للمعالجة._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### ملاحظات
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### أمثلة
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/arabic/javascript-cpp/enumerations/_index.md
+++ b/arabic/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "التعدادات"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال لتحويل الخطوط إلى صيغ TrueType."
+weight: 80
+type: docs
+url: /ar/javascript-cpp/enumerations/
+---
+
+## التعدادات
+
+| تعداد | الوصف |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | يحدد صيغة الصورة. |
+| [Units](./units/) | يحدد نوع الحجم. |

--- a/arabic/javascript-cpp/enumerations/imageformat/_index.md
+++ b/arabic/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "تعداد ImageFormat"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "تعداد ImageFormat. يحدد تنسيق الصورة"
+type: docs
+weight: 100
+url: /ar/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+يحدد صيغة الصورة.
+
+```csharp
+public enum ImageFormat
+```
+
+### القيم
+
+| الاسم | القيمة | الوصف |
+| ---  | ---   | --- |
+| Bmp | `0` | تنسيق BMP للصور. |
+| Jpeg | `1` | تنسيق JPG للصور. |
+| Gif | `2` | تنسيق GIF للصور. |
+| Tiff | `3` | تنسيق TIFF للصور. |
+

--- a/arabic/javascript-cpp/enumerations/units/_index.md
+++ b/arabic/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "تعداد الوحدات"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "تعداد الوحدات. يحدد نوع الحجم"
+type: docs
+weight: 100
+url: /ar/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+يحدد نوع الحجم.
+
+```js
+enum Units
+```
+
+### القيم
+
+| الاسم | القيمة | الوصف |
+| ---        | ---   | --- |
+| Points | `0` | نقاط (1/72 من البوصة). |
+| Inches | `1` | بوصات. |
+| Millimeters | `2` | ملليمترات. |
+| Centimeters | `3` | سنتيمترات. |
+| Percents | `4` | نسب الحجم الموجود. |

--- a/arabic/javascript-cpp/eps/_index.md
+++ b/arabic/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "دوال EPS"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال للعمل مع ملفات EPS."
+weight: 41
+type: docs
+url: /ar/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | قص ملف EPS. |
+| [AsposeResizeEPS](./resizeeps/) | تغيير حجم ملف EPS. |
+
+## Detailed Description
+
+تعديل حجم ملف EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/eps/cropeps/_index.md
+++ b/arabic/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "اقتصاص EPS"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+يقص ملف EPS. يحفظ ملف EPS الأصلي مع تحديث %%BoundingBox الموجود أو سيتم إنشاء واحد جديد.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+| يسار | float | يحدد الحد الأيسر لصندوق الاقتصاص. |
+| أعلى | float | يحدد الحد العلوي لصندوق الاقتصاص. |
+| يمين | float | يحدد الحد الأيمن لصندوق الاقتصاص. |
+| أسفل | float | يحدد الحد السفلي لصندوق الاقتصاص. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/arabic/javascript-cpp/eps/resizeeps/_index.md
+++ b/arabic/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "تغيير حجم EPS"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+يقوم بتغيير حجم ملف EPS. يحفظ ملف EPS الأصلي مع تحديث %%BoundingBox الموجود أو يتم إنشاء واحد جديد.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+| width | float | يحدد عرض صندوق الحدود الجديد. |
+| height | float | يحدد ارتفاع صندوق الحدود الجديد. |
+| unit | Module.Units | يحدد نوع الحجم الجديد. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/arabic/javascript-cpp/image/_index.md
+++ b/arabic/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "دوال الصورة"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال للعمل مع ملفات الصورة."
+weight: 50
+type: docs
+url: /ar/javascript-cpp/image/
+---
+
+## Image Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | حفظ ملف الصورة كـ EPS. |
+
+## Detailed Description
+
+حفظ صورة بأكثر الصيغ شيوعًا مثل BMP و PNG و JPEG و GOF و TIFF كملف EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/image/saveimageaseps/_index.md
+++ b/arabic/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "تغيير حجم EPS"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+يقوم بتغيير حجم ملف EPS. يحفظ ملف EPS الأصلي مع تحديث %%BoundingBox الموجود أو يتم إنشاء واحد جديد.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+

--- a/arabic/javascript-cpp/merge/_index.md
+++ b/arabic/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "دمج الدوال"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دمج الدوال للعمل مع ملفات Postscript/XPS."
+weight: 20
+type: docs
+url: /ar/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | دمج ملفات Postscript إلى PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | دمج ملفات XPS إلى PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | دمج ملفات XPS إلى ملف XPS. |
+
+## Detailed Description
+
+دمج عدة ملفات postscript أو xps إلى ملف pdf واحد أو عدة ملفات xps إلى ملف xps واحد.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/arabic/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دمج ملفات Postscript إلى PDF"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+دمج ملفات Postscript إلى PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileNames | string | أسماء الملفات للدمج. |
+| fileNameResult | string | اسم ملف PDF الناتج. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/arabic/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/arabic/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دمج ملفات XPS إلى PDF"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+دمج ملفات XPS إلى PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileNames | string | أسماء الملفات للدمج. |
+| fileNameResult | string | اسم ملف PDF الناتج. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/arabic/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/arabic/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دمج ملفات XPS إلى XPS واحد"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+دمج عدة ملفات XPS إلى ملف XPS واحد.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileNames | string | أسماء الملفات للدمج. |
+| fileNameResult | string | اسم ملف XPS الناتج. |
+| supressErrors | bool | يحدد ما إذا كان يجب كتم الأخطاء أم لا. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/arabic/javascript-cpp/misc/_index.md
+++ b/arabic/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "دوال متنوعة"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال ثانوية للعمل مع ملفات Postscript/XPS."
+weight: 90
+type: docs
+url: /ar/javascript-cpp/misc/
+---
+## Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | الحصول على معلومات حول المنتج. |
+| [DownloadFile](./downloadfile/) | إنشاء رابط في HTML لتنزيل الملف. |
+| [DownloadFileAuto](./downloadfileauto/) | إنشاء رابط في HTML لتنزيل الملف وبدء التحميل بعد ثانيتين. |
+
+## Detailed Description
+
+دوال ثانوية للعمل مع ملفات Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/misc/downloadfile/_index.md
+++ b/arabic/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "إنشاء رابط في HTML لتنزيل الملف."
+type: docs
+url: /ar/javascript-cpp/misc/downloadfile/
+---
+
+_إنشاء رابط في HTML لتنزيل الملف._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/arabic/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/arabic/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "إنشاء رابط في HTML لتنزيل الملف وبدء التحميل بعد ثانيتين."
+type: docs
+url: /ar/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+إنشاء رابط في HTML لتنزيل الملف وبدء التحميل بعد ثانيتين.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### المعلمات
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### ملاحظات
+
+لا يعمل في Web Worker.

--- a/arabic/javascript-cpp/misc/pageabout/_index.md
+++ b/arabic/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "الحصول على معلومات حول المنتج."
+type: docs
+url: /ar/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+الحصول على معلومات حول المنتج.
+
+```js
+function AsposePageAbout()
+```
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+| errorCode | خطأ الكود (0 لا خطأ) |
+| errorText | خطأ النص ("" لا خطأ) |
+| المنتج | اسم المنتج |
+| الإصدار | إصدار المنتج |
+| islicensed | المنتج مرخص |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/arabic/javascript-cpp/ps/_index.md
+++ b/arabic/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "دوال PS"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال للعمل مع ملفات PS."
+weight: 40
+type: docs
+url: /ar/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | الحصول على حدود ملف PS. |
+| [AsposePSExtractText](./psextracttext/) | استخراج النص من ملف PS. |
+
+## Detailed Description
+
+تعديل ملف PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/ps/psextracttext/_index.md
+++ b/arabic/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "استخراج النص من ملف PS"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+استخراج النص من ملف PS. يمكن استخراج النص فقط إذا كان مكتوبًا بخط Type 42 (TrueType) أو بخط Type 0 مع خطوط Type 42 في خريطة المتجهات الخاصة به.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| ابدأ | int | يحدد الصفحة التي يبدأ منها استخراج النص. هذا المعامل مفيد للمستندات متعددة الصفحات. |
+| نهاية | int | يحدد الصفحة التي ينتهي عندها استخراج النص. هذا المعامل مفيد للمستندات متعددة الصفحات. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | نص | النص المستخرج |
+
+### أمثلة
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### انظر أيضًا
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/arabic/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/arabic/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على صندوق الحدود"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+يقرأ ملف EPS ويستخرج صندوق الحدود لصورة EPS من تعليق %%BoundingBox أو الحدود لحجم الصفحة الافتراضي (0, 0, 595, 842) إذا لم يكن موجودًا.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | bbox | صندوق الحدود لصورة EPS. |
+
+### أمثلة
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### انظر أيضًا
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/arabic/javascript-cpp/xmp/_index.md
+++ b/arabic/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "دوال بيانات التعريف XMP"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال بيانات التعريف XMP للعمل مع ملفات EPS."
+weight: 30
+type: docs
+url: /ar/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| الاسم | الوصف |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | الحصول على بيانات التعريف XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | يضيف قيمة إلى مصفوفة. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | يضيف قيمة مسماة إلى بنية. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | يسجل URI مساحة الاسم ويضيف قيمة. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | دمج ملفات Postscript إلى PDF. |
+
+## Detailed Description
+
+تحويل ملف postscript أو xps إلى صورة أو ملف PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/arabic/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على بيانات XMP الوصفية"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+يقرأ ملف PS/EPS ويستخرج XmpMetdata إذا كان موجودًا بالفعل.
+إذا لم يحتوي ملف EPS على بيانات XMP الوصفية، نحصل على واحدة جديدة مملوءة بالقيم من تعليقات بيانات PS الوصفية (%%Creator، %%CreateDate، %%Title إلخ).
+سيتم حفظ ملف EPS مع بيانات XMP الوصفية المملوءة في fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | XMP | مصفوفة قيم البيانات الوصفية |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/arabic/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/arabic/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على بيانات XMP الوصفية"
+type: docs
+weight: 20
+url: /ar/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+يضيف قيمة إلى مصفوفة. ستُضاف القيمة في نهاية المصفوفة.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | XMP | مصفوفة قيم البيانات الوصفية |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/arabic/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/arabic/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على بيانات XMP الوصفية"
+type: docs
+weight: 30
+url: /ar/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+يضيف قيمة مسماة إلى بنية.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | XMP | مصفوفة قيم البيانات الوصفية |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/arabic/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/arabic/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على بيانات XMP الوصفية"
+type: docs
+weight: 40
+url: /ar/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+يسجل URI مساحة الاسم ويضيف قيمة.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | XMP | مصفوفة قيم البيانات الوصفية |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/arabic/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/arabic/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على بيانات XMP الوصفية"
+type: docs
+weight: 40
+url: /ar/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+يضيف قيمة مسماة إلى بنية.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+| fileNameResult | string | اسم ملف النتيجة. |
+
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | XMP | مصفوفة قيم البيانات الوصفية |
+|  | fileNameResult | اسم ملف النتيجة |
+
+### أمثلة
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### انظر أيضًا
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/arabic/javascript-cpp/xps/_index.md
+++ b/arabic/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "دوال XPS"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "دوال للعمل مع ملفات XPS."
+weight: 42
+type: docs
+url: /ar/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| دالة | الوصف |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | الحصول على عدد الصفحات في مستند xps. |
+
+## Detailed Description
+
+معالجة ملف XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+أو
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/arabic/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/arabic/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page للـ JavaScript عبر C++"
+description: "احصل على عدد الصفحات في ملف XPS"
+type: docs
+weight: 10
+url: /ar/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+الحصول على عدد الصفحات في مستند xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| معامل | نوع | الوصف |
+| --------- | ---- | ----------- |
+| fileBlob | كائن Blob | محتوى ملف المصدر. |
+| fileName | string | اسم ملف المصدر. |
+
+### قيمة الإرجاع
+
+كائن JSON
+| حقل | الوصف |
+| ----- | ----------- |
+|  | errorCode | خطأ الكود (0 لا خطأ) |
+|  | errorText | خطأ النص ("" لا خطأ) |
+|  | pageCount | عدد الصفحات |
+
+### أمثلة
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Arabic** (`ar`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `arabic/javascript-cpp`

🤖 Generated by RDA