### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Chinese

### DIFF
--- a/chinese/javascript-cpp/convert/_index.md
+++ b/chinese/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "转换函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 Postscript/XPS 文件的转换函数。"
+weight: 10
+type: docs
+url: /zh/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | 将 Postscript 文件转换为图像。 |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | 将 Postscript 文件转换为 PDF。 |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | 将 XPS 文件转换为图像。 |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | 将 XPS 文件转换为 PDF。 |
+
+## Detailed Description
+
+将 Postscript 或 XPS 文件转换为图像或 PDF 文件。
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/chinese/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 Postscript 转换为图像"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+将 Postscript 转换为图像。
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | string | 文件名。 |
+| imageFormat | ImageFormat | 要转换成的图像格式。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/chinese/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/chinese/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 Postscript 转换为 PDF"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+将 Postscript 转换为 PDF。
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | string | 文件名。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/chinese/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/chinese/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 XPS 转换为图像"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+将 Postscript 转换为图像。
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | string | 文件名。 |
+| imageFormat | ImageFormat | 要转换成的图像格式。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/chinese/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/chinese/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 XPS 转换为 PDF"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+将 XPS 转换为 PDF。
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 用于转换的源字体内容。 |
+| fileName | string | 文件名。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/chinese/javascript-cpp/core/_index.md
+++ b/chinese/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "核心函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 Postscript/XPS 文件的核心函数。"
+weight: 60
+type: docs
+url: /zh/javascript-cpp/core/
+---
+
+## Core Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | 将 BLOB 保存到内存文件系统以进行处理。 |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | 将字符串表示的 BLOB 保存到内存文件系统以进行处理。 |
+
+## Detailed Description
+
+用于处理 Postscript/XPS 文件的核心函数。
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/core/asposepageprepare/_index.md
+++ b/chinese/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 BLOB 保存到内存文件系统以进行处理。"
+type: docs
+url: /zh/javascript-cpp/core/asposepageprepare/
+---
+
+_在内存文件系统中保存 BLOB 以进行处理。_
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON 对象
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/chinese/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/chinese/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将字符串表示的 BLOB 保存到内存文件系统以进行处理。"
+type: docs
+url: /zh/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_在内存文件系统中保存字符串表示的 BLOB 以进行处理。_
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### 备注
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### 示例
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/chinese/javascript-cpp/enumerations/_index.md
+++ b/chinese/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "枚举"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于将字体转换为 TrueType 格式的函数。"
+weight: 80
+type: docs
+url: /zh/javascript-cpp/enumerations/
+---
+
+## 枚举
+
+| 枚举 | 描述 |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | 指定图像格式。 |
+| [Units](./units/) | 指定尺寸类型。 |

--- a/chinese/javascript-cpp/enumerations/imageformat/_index.md
+++ b/chinese/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 ImageFormat"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "ImageFormat 枚举。指定图像格式"
+type: docs
+weight: 100
+url: /zh/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+指定图像格式。
+
+```csharp
+public enum ImageFormat
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP 图像格式。 |
+| Jpeg | `1` | JPG 图像格式。 |
+| Gif | `2` | GIF 图像格式。 |
+| Tiff | `3` | TIFF 图像格式。 |
+

--- a/chinese/javascript-cpp/enumerations/units/_index.md
+++ b/chinese/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "枚举 Units"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "Units 枚举。指定尺寸类型"
+type: docs
+weight: 100
+url: /zh/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+指定尺寸类型。
+
+```js
+enum Units
+```
+
+### 值
+
+| 名称 | 值 | 描述 |
+| ---        | ---   | --- |
+| Points | `0` | 点 (1/72 英寸)。 |
+| Inches | `1` | 英寸。 |
+| Millimeters | `2` | 毫米。 |
+| Centimeters | `3` | 厘米。 |
+| Percents | `4` | 现有大小的百分比。 |

--- a/chinese/javascript-cpp/eps/_index.md
+++ b/chinese/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "EPS 函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 EPS 文件的函数。"
+weight: 41
+type: docs
+url: /zh/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | 裁剪 EPS 文件。 |
+| [AsposeResizeEPS](./resizeeps/) | 调整 EPS 文件大小。 |
+
+## Detailed Description
+
+操作 EPS 文件的尺寸。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/eps/cropeps/_index.md
+++ b/chinese/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "裁剪 EPS"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+裁剪 EPS 文件。它保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或创建新的。
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+| 左 | float | 指定裁剪框的左边界。 |
+| 上 | float | 指定裁剪框的上边界。 |
+| 右 | float | 指定裁剪框的右边界。 |
+| 下 | float | 指定裁剪框的下边界。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/chinese/javascript-cpp/eps/resizeeps/_index.md
+++ b/chinese/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "调整 EPS 大小"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+调整 EPS 文件。它会保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或者创建新的。
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+| width | float | 指定新边界框的 width。 |
+| height | float | 指定新边界框的 height。 |
+| unit | Module.Units | 指定新尺寸的类型。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/chinese/javascript-cpp/image/_index.md
+++ b/chinese/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "图像函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理图像文件的函数。"
+weight: 50
+type: docs
+url: /zh/javascript-cpp/image/
+---
+
+## Image Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | 将图像文件保存为 EPS。 |
+
+## Detailed Description
+
+将最流行格式的图像（BMP、PNG、JPEG、GOF、TIFF）保存为 EPS 文件。
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/image/saveimageaseps/_index.md
+++ b/chinese/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "调整 EPS 大小"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+调整 EPS 文件。它会保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或者创建新的。
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+

--- a/chinese/javascript-cpp/merge/_index.md
+++ b/chinese/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "合并功能"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 Postscript/XPS 文件的合并功能。"
+weight: 20
+type: docs
+url: /zh/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | 将 Postscript 文件合并为 PDF。 |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | 合并 XPS 文件为 PDF。 |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | 合并 XPS 文件为 XPS 文件。 |
+
+## Detailed Description
+
+合并多个 Postscript 或 XPS 文件为一个 PDF 文件，或将多个 XPS 文件合并为一个 XPS 文件。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/chinese/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 Postscript 文件合并为 PDF"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+将 Postscript 文件合并为 PDF。
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileNames | string | 用于合并的文件名称。 |
+| fileNameResult | string | 结果 PDF 文件的名称。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/chinese/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/chinese/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 XPS 文件合并为 PDF"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+将 XPS 文件合并为 PDF。
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileNames | string | 用于合并的文件名称。 |
+| fileNameResult | string | 结果 PDF 文件的名称。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/chinese/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/chinese/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "将 XPS 文件合并为一个 XPS"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+将多个 XPS 文件合并为一个 XPS 文件。
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileNames | string | 用于合并的文件名称。 |
+| fileNameResult | string | 结果 XPS 文件的名称。 |
+| supressErrors | bool | 指定是否必须抑制错误。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/chinese/javascript-cpp/misc/_index.md
+++ b/chinese/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "杂项函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 Postscript/XPS 文件的次要函数。"
+weight: 90
+type: docs
+url: /zh/javascript-cpp/misc/
+---
+## Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | 获取关于产品的信息。 |
+| [DownloadFile](./downloadfile/) | 在 HTML 中创建链接以下载文件。 |
+| [DownloadFileAuto](./downloadfileauto/) | 在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。 |
+
+## Detailed Description
+
+用于处理 Postscript/XPS 文件的次要函数。
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/misc/downloadfile/_index.md
+++ b/chinese/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "在 HTML 中创建链接以下载文件。"
+type: docs
+url: /zh/javascript-cpp/misc/downloadfile/
+---
+
+_在 HTML 中创建一个链接以下载文件。_
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/chinese/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/chinese/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。"
+type: docs
+url: /zh/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+在 HTML 中创建链接以下载文件，并在 2 秒后开始下载。
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### 参数
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### 备注
+
+在 Web Worker 中无法工作。

--- a/chinese/javascript-cpp/misc/pageabout/_index.md
+++ b/chinese/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取关于产品的信息。"
+type: docs
+url: /zh/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+获取关于产品的信息。
+
+```js
+function AsposePageAbout()
+```
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+| errorCode | 错误代码（0 表示无错误） |
+| errorText | 错误文本（"" 表示无错误） |
+| 产品 | 产品名称 |
+| 版本 | 产品版本 |
+| islicensed | 产品已授权 |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/chinese/javascript-cpp/ps/_index.md
+++ b/chinese/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS 函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 PS 文件的函数。"
+weight: 40
+type: docs
+url: /zh/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | 获取 PS 文件的边界。 |
+| [AsposePSExtractText](./psextracttext/) | 从 PS 文件中提取文本。 |
+
+## Detailed Description
+
+操作 PS 文件。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/ps/psextracttext/_index.md
+++ b/chinese/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "从 PS 文件中提取文本"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+从 PS 文件中提取文本。仅当文本使用 Type 42（TrueType）字体或在其向量映射中包含 Type 42 字体的 Type 0 字体编写时，才可以提取。
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| 开始 | int | 指定开始提取文本的页码。此参数在多页文档中非常有用。 |
+| 结束 | int | 指定提取文本结束的页码。此参数在多页文档中非常有用。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | 文本 | 提取的文本 |
+
+### 示例
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### 另见
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/chinese/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/chinese/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取边界框"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+读取 EPS 文件并从 %%BoundingBox 注释中提取 EPS 图像的边界框；如果不存在，则使用默认页面大小 (0, 0, 595, 842) 的边界。
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | bbox | EPS 图像的边界框。 |
+
+### 示例
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### 另见
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/chinese/javascript-cpp/xmp/_index.md
+++ b/chinese/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "XMP 元数据函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 EPS 文件的 XMP 元数据函数。"
+weight: 30
+type: docs
+url: /zh/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| 名称 | 描述 |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | 获取 XMP 元数据。 |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | 向数组中添加值。 |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | 向结构体中添加具名值。 |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | 注册命名空间 URI 并添加值。 |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | 将 Postscript 文件合并为 PDF。 |
+
+## Detailed Description
+
+将 Postscript 或 XPS 文件转换为图像或 PDF 文件。
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/chinese/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取 XMP 元数据"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+读取 PS/EPS 文件并提取 XmpMetdata（如果已存在）。
+如果 EPS 文件不包含 XMP 元数据，我们将获取一个新元数据，并用 PS 元数据注释（%%Creator、%%CreateDate、%%Title 等）中的值填充。
+填充了 XMP 元数据的 EPS 文件将保存到 fileNameResult。
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | XMP | 元数据值数组 |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/chinese/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取 XMP 元数据"
+type: docs
+weight: 20
+url: /zh/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+向数组中添加值。该值将被添加到数组的末尾。
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | XMP | 元数据值数组 |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/chinese/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取 XMP 元数据"
+type: docs
+weight: 30
+url: /zh/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+向结构体中添加具名值。
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | XMP | 元数据值数组 |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/chinese/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取 XMP 元数据"
+type: docs
+weight: 40
+url: /zh/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+注册命名空间 URI 并添加值。
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | XMP | 元数据值数组 |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/chinese/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取 XMP 元数据"
+type: docs
+weight: 40
+url: /zh/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+向结构体中添加具名值。
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+| fileNameResult | string | 结果文件名。 |
+
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | XMP | 元数据值数组 |
+|  | fileNameResult | 结果文件名 |
+
+### 示例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 另见
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/chinese/javascript-cpp/xps/_index.md
+++ b/chinese/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS 函数"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "用于处理 XPS 文件的函数。"
+weight: 42
+type: docs
+url: /zh/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| 函数 | 描述 |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | 获取 xps 文档的页数。 |
+
+## Detailed Description
+
+操作 XPS 文件。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+或
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/chinese/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/chinese/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page 用于 JavaScript via C++"
+description: "获取 XPS 文件的页数"
+type: docs
+weight: 10
+url: /zh/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+获取 xps 文档的页数。
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| 参数 | 类型 | 描述 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 对象 | 源文件的内容。 |
+| fileName | string | 源文件名。 |
+
+### 返回值
+
+JSON 对象
+| 字段 | 描述 |
+| ----- | ----------- |
+|  | errorCode | 错误代码（0 表示无错误） |
+|  | errorText | 错误文本（"" 表示无错误） |
+|  | pageCount | 页数 |
+
+### 示例
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Chinese** (`zh`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `chinese/javascript-cpp`

🤖 Generated by RDA