### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to French

### DIFF
--- a/french/javascript-cpp/convert/_index.md
+++ b/french/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Fonctions de conversion"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de conversion pour travailler avec des fichiers Postscript/XPS."
+weight: 10
+type: docs
+url: /fr/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Convertir un fichier Postscript en image. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Convertir un fichier Postscript en PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Convertir un fichier XPS en image. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Convertir un fichier XPS en PDF. |
+
+## Detailed Description
+
+Convertir un fichier postscript ou xps en image ou en fichier PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/french/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le Postscript en image"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Convertit le Postscript en image.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom de fichier. |
+| imageFormat | ImageFormat | format d'image dans lequel convertir. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/french/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/french/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le Postscript en PDF"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convertit le Postscript en PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom de fichier. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/french/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/french/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le XPS en image"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Convertit le Postscript en image.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom de fichier. |
+| imageFormat | ImageFormat | format d'image dans lequel convertir. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/french/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/french/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le XPS en PDF"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convertit le XPS en PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom de fichier. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/french/javascript-cpp/core/_index.md
+++ b/french/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fonctions de base"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de base pour travailler avec des fichiers Postscript/XPS."
+weight: 60
+type: docs
+url: /fr/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Enregistrer le BLOB dans le système de fichiers mémoire pour le traitement. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Enregistrer le BLOB de représentation sous forme de chaîne dans le système de fichiers mémoire pour le traitement. |
+
+## Detailed Description
+
+Fonctions de base pour travailler avec des fichiers Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/core/asposepageprepare/_index.md
+++ b/french/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Enregistrer le BLOB dans le système de fichiers mémoire pour le traitement."
+type: docs
+url: /fr/javascript-cpp/core/asposepageprepare/
+---
+
+_Enregistrer le BLOB dans le système de fichiers mémoire pour le traitement._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+Objet JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/french/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/french/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Enregistrer le BLOB de représentation sous forme de chaîne dans le système de fichiers mémoire pour le traitement."
+type: docs
+url: /fr/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Enregistrer la représentation sous forme de chaîne du BLOB dans le système de fichiers mémoire pour le traitement._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Remarques
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Exemples
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/french/javascript-cpp/enumerations/_index.md
+++ b/french/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Énumérations"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de conversion de polices vers les formats TrueType."
+weight: 80
+type: docs
+url: /fr/javascript-cpp/enumerations/
+---
+
+## Énumérations
+
+| Énumération | Description |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Spécifie le format d'image. |
+| [Units](./units/) | Spécifie le type de taille. |

--- a/french/javascript-cpp/enumerations/imageformat/_index.md
+++ b/french/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Enum ImageFormat. Spécifie le format d'image"
+type: docs
+weight: 100
+url: /fr/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Spécifie le format d'image.
+
+```csharp
+public enum ImageFormat
+```
+
+### Valeurs
+
+| Nom | Valeur | Description |
+| ---  | ---   | --- |
+| Bmp | `0` | Format d'image BMP. |
+| Jpeg | `1` | Format d'image JPG. |
+| Gif | `2` | Format d'image GIF. |
+| Tiff | `3` | Format d'image TIFF. |
+

--- a/french/javascript-cpp/enumerations/units/_index.md
+++ b/french/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Units enum. Spécifie le type de taille"
+type: docs
+weight: 100
+url: /fr/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Spécifie le type de taille.
+
+```js
+enum Units
+```
+
+### Valeurs
+
+| Nom | Valeur | Description |
+| ---        | ---   | --- |
+| Points | `0` | Points (1/72 de pouce). |
+| Inches | `1` | Pouces. |
+| Millimeters | `2` | Millimètres. |
+| Centimeters | `3` | Centimètres. |
+| Percents | `4` | Pourcentages de la taille existante. |

--- a/french/javascript-cpp/eps/_index.md
+++ b/french/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Fonctions EPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers EPS."
+weight: 41
+type: docs
+url: /fr/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Recadrer le fichier EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Redimensionner le fichier EPS. |
+
+## Detailed Description
+
+Manipuler la taille du fichier EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/eps/cropeps/_index.md
+++ b/french/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Rogner EPS"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Recadre le fichier EPS. Il enregistre le fichier EPS initial avec le %%BoundingBox existant mis à jour ou un nouveau sera créé.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+| gauche | float | Spécifie la limite gauche de la boîte de recadrage. |
+| haut | float | Spécifie la limite supérieure de la boîte de recadrage. |
+| droite | float | Spécifie la limite droite de la boîte de recadrage. |
+| bas | float | Spécifie la limite inférieure de la boîte de recadrage. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/french/javascript-cpp/eps/resizeeps/_index.md
+++ b/french/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Redimensionner EPS"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Redimensionne le fichier EPS. Il enregistre le fichier EPS initial avec le %%BoundingBox existant mis à jour ou un nouveau sera créé.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+| largeur | float | Spécifie la largeur de la nouvelle boîte englobante. |
+| hauteur | float | Spécifie la hauteur de la nouvelle boîte englobante. |
+| unité | Module.Units | Spécifie le type de la nouvelle taille. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/french/javascript-cpp/image/_index.md
+++ b/french/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Fonctions d'image"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers image."
+weight: 50
+type: docs
+url: /fr/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Enregistrer le fichier image au format EPS. |
+
+## Detailed Description
+
+Enregistrer l'image des formats les plus populaires (BMP, PNG, JPEG, GOF, TIFF) au format EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/image/saveimageaseps/_index.md
+++ b/french/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Redimensionner EPS"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Redimensionne le fichier EPS. Il enregistre le fichier EPS initial avec le %%BoundingBox existant mis à jour ou un nouveau sera créé.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+

--- a/french/javascript-cpp/merge/_index.md
+++ b/french/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Fonctions de fusion"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de fusion pour travailler avec les fichiers Postscript/XPS."
+weight: 20
+type: docs
+url: /fr/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Fusionner des fichiers Postscript en PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Fusionner un fichier XPS en PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Fusionner un fichier XPS en fichier XPS. |
+
+## Detailed Description
+
+Fusionner plusieurs fichiers postscript ou xps en un seul fichier pdf ou plusieurs fichiers xps en un seul fichier xps.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/french/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fusionner les fichiers Postscript en PDF"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Fusionner les fichiers Postscript en PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileNames | string | Les noms des fichiers à fusionner. |
+| fileNameResult | string | Le nom du fichier PDF résultant. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/french/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/french/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fusionner les fichiers XPS en PDF"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Fusionner les fichiers XPS en PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileNames | string | Les noms des fichiers à fusionner. |
+| fileNameResult | string | Le nom du fichier PDF résultant. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/french/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/french/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fusionner les fichiers XPS en un seul XPS"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Fusionner plusieurs fichiers XPS en un seul fichier XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileNames | string | Les noms des fichiers à fusionner. |
+| fileNameResult | string | Le nom du fichier XPS résultant. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/french/javascript-cpp/misc/_index.md
+++ b/french/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fonctions diverses"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions secondaires pour travailler avec des fichiers Postscript/XPS."
+weight: 90
+type: docs
+url: /fr/javascript-cpp/misc/
+---
+## Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Obtenir des informations sur le produit. |
+| [DownloadFile](./downloadfile/) | Créer un lien en HTML pour télécharger le fichier. |
+| [DownloadFileAuto](./downloadfileauto/) | Créer un lien en HTML pour télécharger le fichier et démarrer le téléchargement après 2 secondes. |
+
+## Detailed Description
+
+Fonctions secondaires pour travailler avec des fichiers Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/misc/downloadfile/_index.md
+++ b/french/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Créer un lien en HTML pour télécharger le fichier."
+type: docs
+url: /fr/javascript-cpp/misc/downloadfile/
+---
+
+_Créer un lien en HTML pour télécharger le fichier._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/french/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/french/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Créer un lien en HTML pour télécharger le fichier et démarrer le téléchargement après 2 secondes."
+type: docs
+url: /fr/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Créer un lien en HTML pour télécharger le fichier et démarrer le téléchargement après 2 secondes.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Paramètres
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Remarques
+
+Ne fonctionne pas dans Web Worker.

--- a/french/javascript-cpp/misc/pageabout/_index.md
+++ b/french/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir des informations sur le produit."
+type: docs
+url: /fr/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Obtenir des informations sur le produit.
+
+```js
+function AsposePageAbout()
+```
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+| errorCode | code d'erreur (0 aucune erreur) |
+| errorText | texte d'erreur (\"\" aucune erreur) |
+| produit | Nom du produit |
+| version | Version du produit |
+| islicensed | Le produit est licencié |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/french/javascript-cpp/ps/_index.md
+++ b/french/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Fonctions PS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers PS."
+weight: 40
+type: docs
+url: /fr/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Obtenir les limites du fichier PS. |
+| [AsposePSExtractText](./psextracttext/) | Extraire le texte du fichier PS. |
+
+## Detailed Description
+
+Manipuler le fichier PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/ps/psextracttext/_index.md
+++ b/french/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Extraire le texte du fichier PS"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extraire le texte du fichier PS. Le texte ne peut être extrait que s'il est écrit avec une police Type 42 (TrueType) ou une police Type 0 contenant des polices Type 42 dans sa carte vectorielle.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| début | int | Spécifie la page à partir de laquelle commencer l'extraction du texte. Ce paramètre est utile pour les documents multi-pages. |
+| fin | int | Spécifie la page jusqu'à laquelle terminer l'extraction du texte. Ce paramètre est utile pour les documents multi-pages. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | texte | le texte extrait |
+
+### Exemples
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Voir aussi
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/french/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/french/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir la boîte englobante"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Lit le fichier EPS et extrait la boîte englobante de l'image EPS à partir du commentaire %%BoundingBox ou les limites pour la taille de page par défaut (0, 0, 595, 842) si elle n'existe pas.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | bbox | la boîte englobante de l'image EPS. |
+
+### Exemples
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/french/javascript-cpp/xmp/_index.md
+++ b/french/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Fonctions de métadonnées XMP"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de métadonnées XMP pour travailler avec des fichiers EPS."
+weight: 30
+type: docs
+url: /fr/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Obtenir les métadonnées XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Ajoute une valeur dans un tableau. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Ajoute une valeur nommée dans une structure. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Enregistre l'URI de l'espace de noms et ajoute une valeur. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Fusionner des fichiers Postscript en PDF. |
+
+## Detailed Description
+
+Convertir un fichier postscript ou xps en image ou en fichier PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/french/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Lit le fichier PS/EPS et extrait les métadonnées XmpMetdata si elles existent déjà.
+Si le fichier EPS ne contient pas de métadonnées XMP, nous en créons de nouvelles remplies avec les valeurs des commentaires de métadonnées PS (%%Creator, %%CreateDate, %%Title etc).
+Le fichier EPS avec les métadonnées XMP remplies sera enregistré dans fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/french/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/french/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 20
+url: /fr/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Ajoute une valeur dans un tableau. La valeur sera ajoutée à la fin du tableau.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/french/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/french/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 30
+url: /fr/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Ajoute une valeur nommée dans une structure.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/french/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/french/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 40
+url: /fr/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Enregistre l'URI de l'espace de noms et ajoute une valeur.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/french/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/french/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 40
+url: /fr/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Ajoute une valeur nommée dans une structure.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultat. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/french/javascript-cpp/xps/_index.md
+++ b/french/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fonctions XPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers XPS."
+weight: 42
+type: docs
+url: /fr/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Fonction | Description |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Obtenir le nombre de pages du document xps. |
+
+## Detailed Description
+
+Manipuler le fichier XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/french/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir le nombre de pages dans le fichier XPS"
+type: docs
+weight: 10
+url: /fr/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Obtenir le nombre de pages du document xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | code d'erreur (0 aucune erreur) |
+|  | errorText | texte d'erreur (\"\" aucune erreur) |
+|  | pageCount | nombre de pages |
+
+### Exemples
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **French** (`fr`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `french/javascript-cpp`

🤖 Generated by RDA