### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to German

### DIFF
--- a/german/javascript-cpp/convert/_index.md
+++ b/german/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Konvertierungsfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertierungsfunktionen zum Arbeiten mit Postscript/XPS-Dateien."
+weight: 10
+type: docs
+url: /de/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Eine Postscript-Datei in ein Bild konvertieren. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Eine Postscript-Datei in PDF konvertieren. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Eine XPS-Datei in ein Bild konvertieren. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Eine XPS-Datei in PDF konvertieren. |
+
+## Detailed Description
+
+Postscript- oder XPS-Datei in ein Bild oder PDF konvertieren.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/german/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das Postscript in ein Bild"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Konvertiert das Postscript in ein Bild.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| imageFormat | ImageFormat | Bildformat, in das konvertiert werden soll. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/german/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/german/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das Postscript in PDF"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konvertiert das Postscript in PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/german/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/german/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das XPS in ein Bild"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Konvertiert das Postscript in ein Bild.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| imageFormat | ImageFormat | Bildformat, in das konvertiert werden soll. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/german/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/german/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das XPS in PDF"
+type: docs
+weight: 10
+url: /de/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konvertiert das XPS in PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/german/javascript-cpp/core/_index.md
+++ b/german/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Kernfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Kernfunktionen zum Arbeiten mit Postscript/XPS-Dateien."
+weight: 60
+type: docs
+url: /de/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Speichere das BLOB im Memory FS zur Verarbeitung. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Speichere das BLOB der Zeichenkettenrepräsentation im Memory FS zur Verarbeitung. |
+
+## Detailed Description
+
+Kernfunktionen zum Arbeiten mit Postscript/XPS-Dateien.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/core/asposepageprepare/_index.md
+++ b/german/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Speichere das BLOB im Memory FS zur Verarbeitung."
+type: docs
+url: /de/javascript-cpp/core/asposepageprepare/
+---
+
+_Speichere das BLOB im Memory FS zur Verarbeitung._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON-Objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/german/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/german/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Speichere das BLOB der Zeichenkettenrepräsentation im Memory FS zur Verarbeitung."
+type: docs
+url: /de/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Speichere die String-Repräsentation des BLOB im Memory FS zur Verarbeitung._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Hinweise
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Beispiele
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/german/javascript-cpp/enumerations/_index.md
+++ b/german/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Aufzählungen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Konvertieren von Schriftarten in TrueType-Formate."
+weight: 80
+type: docs
+url: /de/javascript-cpp/enumerations/
+---
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Gibt das Bildformat an. |
+| [Units](./units/) | Gibt den Typ der Größe an. |

--- a/german/javascript-cpp/enumerations/imageformat/_index.md
+++ b/german/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "ImageFormat-Enum. Gibt das Bildformat an"
+type: docs
+weight: 100
+url: /de/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Gibt das Bildformat an.
+
+```csharp
+public enum ImageFormat
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP-Bildformat. |
+| Jpeg | `1` | JPG-Bildformat. |
+| Gif | `2` | GIF-Bildformat. |
+| Tiff | `3` | TIFF-Bildformat. |
+

--- a/german/javascript-cpp/enumerations/units/_index.md
+++ b/german/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Units-Enum. Gibt den Typ der Größe an."
+type: docs
+weight: 100
+url: /de/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Gibt den Typ der Größe an.
+
+```js
+enum Units
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| ---        | ---   | --- |
+| Points | `0` | Punkte (1/72 Zoll). |
+| Inches | `1` | Zoll. |
+| Millimeters | `2` | Millimeter. |
+| Centimeters | `3` | Zentimeter. |
+| Percents | `4` | Prozentsatz der vorhandenen Größe. |

--- a/german/javascript-cpp/eps/_index.md
+++ b/german/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "EPS-Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit EPS-Dateien."
+weight: 41
+type: docs
+url: /de/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS-Datei zuschneiden. |
+| [AsposeResizeEPS](./resizeeps/) | EPS-Datei skalieren. |
+
+## Detailed Description
+
+Größe der EPS-Datei manipulieren.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/eps/cropeps/_index.md
+++ b/german/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "EPS zuschneiden"
+type: docs
+weight: 10
+url: /de/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Schneidet die EPS-Datei zu. Sie speichert die ursprüngliche EPS-Datei mit aktualisiertem vorhandenen %%BoundingBox oder erstellt einen neuen.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+| links | float | Gibt die linke Begrenzung des Zuschneidefelds an. |
+| oben | float | Gibt die obere Begrenzung des Zuschneidefelds an. |
+| rechts | float | Gibt die rechte Begrenzung des Zuschneidefelds an. |
+| unten | float | Gibt die untere Begrenzung des Zuschneidefelds an. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/german/javascript-cpp/eps/resizeeps/_index.md
+++ b/german/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "EPS skalieren"
+type: docs
+weight: 10
+url: /de/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Skaliert EPS-Datei. Sie speichert die ursprüngliche EPS-Datei mit aktualisiertem vorhandenen %%BoundingBox oder erstellt einen neuen.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+| width | float | Gibt die Breite des neuen Begrenzungsrahmens an. |
+| height | float | Gibt die Höhe des neuen Begrenzungsrahmens an. |
+| Einheit | Module.Units | Gibt den Typ der neuen Größe an. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/german/javascript-cpp/image/_index.md
+++ b/german/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Bildfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit Bilddateien."
+weight: 50
+type: docs
+url: /de/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Speichere Bilddatei als EPS. |
+
+## Detailed Description
+
+Speichere Bild in den gängigsten Formaten BMP, PNG, JPEG, GOF, TIFF als EPS-Datei.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/image/saveimageaseps/_index.md
+++ b/german/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "EPS skalieren"
+type: docs
+weight: 10
+url: /de/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Skaliert EPS-Datei. Sie speichert die ursprüngliche EPS-Datei mit aktualisiertem vorhandenen %%BoundingBox oder erstellt einen neuen.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+

--- a/german/javascript-cpp/merge/_index.md
+++ b/german/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Zusammenführungsfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Zusammenführungsfunktionen zur Arbeit mit Postscript/XPS-Dateien."
+weight: 20
+type: docs
+url: /de/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Füge Postscript-Dateien zu PDF zusammen. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | XPS-Dateien zu PDF zusammenführen. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | XPS-Dateien zu einer XPS-Datei zusammenführen. |
+
+## Detailed Description
+
+Mehrere Postscript- oder XPS-Dateien zu einer PDF-Datei oder mehrere XPS-Dateien zu einer XPS-Datei zusammenführen.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/german/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Füge die Postscript-Dateien zu PDF zusammen"
+type: docs
+weight: 10
+url: /de/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Füge die Postscript-Dateien zu PDF zusammen.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileNames | string | Die Namen der Dateien zum Zusammenführen. |
+| fileNameResult | string | Der Name der resultierenden PDF-Datei. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/german/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/german/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Füge die XPS-Dateien zu PDF zusammen"
+type: docs
+weight: 10
+url: /de/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Füge die XPS-Dateien zu PDF zusammen.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileNames | string | Die Namen der Dateien zum Zusammenführen. |
+| fileNameResult | string | Der Name der resultierenden PDF-Datei. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/german/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/german/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Füge die XPS-Dateien zu einem XPS zusammen"
+type: docs
+weight: 10
+url: /de/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Füge mehrere XPS-Dateien zu einer XPS-Datei zusammen.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileNames | string | Die Namen der Dateien zum Zusammenführen. |
+| fileNameResult | string | Der Name der resultierenden XPS-Datei. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/german/javascript-cpp/misc/_index.md
+++ b/german/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Verschiedene Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Sekundäre Funktionen zum Arbeiten mit Postscript/XPS-Dateien."
+weight: 90
+type: docs
+url: /de/javascript-cpp/misc/
+---
+## Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Hole Informationen über das Produkt. |
+| [DownloadFile](./downloadfile/) | Erstelle einen Link in HTML, um die Datei herunterzuladen. |
+| [DownloadFileAuto](./downloadfileauto/) | Erstelle einen Link in HTML, um die Datei herunterzuladen und den Download nach 2 Sekunden zu starten. |
+
+## Detailed Description
+
+Sekundäre Funktionen zum Arbeiten mit Postscript/XPS-Dateien.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/misc/downloadfile/_index.md
+++ b/german/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Erstelle einen Link in HTML, um die Datei herunterzuladen."
+type: docs
+url: /de/javascript-cpp/misc/downloadfile/
+---
+
+_Erstelle einen Link in HTML, um die Datei herunterzuladen._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/german/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/german/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Erstelle einen Link in HTML, um die Datei herunterzuladen und den Download nach 2 Sekunden zu starten."
+type: docs
+url: /de/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Erstelle einen Link in HTML, um die Datei herunterzuladen und den Download nach 2 Sekunden zu starten.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parameter
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Hinweise
+
+Funktioniert nicht im Web Worker.

--- a/german/javascript-cpp/misc/pageabout/_index.md
+++ b/german/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Hole Informationen über das Produkt."
+type: docs
+url: /de/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Hole Informationen über das Produkt.
+
+```js
+function AsposePageAbout()
+```
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+| errorCode | Fehlercode (0 kein Fehler) |
+| errorText | Fehlertext ("" kein Fehler) |
+| Produkt | Produktname |
+| Version | Produktversion |
+| islicensed | Produkt ist lizenziert |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/german/javascript-cpp/ps/_index.md
+++ b/german/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS-Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit PS-Dateien."
+weight: 40
+type: docs
+url: /de/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Grenzen der PS-Datei ermitteln. |
+| [AsposePSExtractText](./psextracttext/) | Text aus PS-Datei extrahieren. |
+
+## Detailed Description
+
+PS-Datei manipulieren.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/ps/psextracttext/_index.md
+++ b/german/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Text aus PS-Datei extrahieren"
+type: docs
+weight: 10
+url: /de/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Text aus PS-Datei extrahieren. Der Text kann nur extrahiert werden, wenn er mit einer Type‑42‑Schrift (TrueType) oder einer Type‑0‑Schrift mit Type‑42‑Schriften in ihrer Vektor‑Karte geschrieben wurde.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| Start | int | Gibt die Seite an, von der aus der Text extrahiert werden soll. Dieser Parameter ist nützlich für mehrseitige Dokumente. |
+| Ende | int | Gibt die Seite an, bis zu der der Text extrahiert werden soll. Dieser Parameter ist nützlich für mehrseitige Dokumente. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | Text | der extrahierte Text |
+
+### Beispiele
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Siehe auch
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/german/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/german/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Bounding-Box abrufen"
+type: docs
+weight: 10
+url: /de/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Liest die EPS-Datei und extrahiert die Bounding-Box des EPS-Bildes aus dem %%BoundingBox-Kommentar oder die Grenzen für die Standardseitengröße (0, 0, 595, 842), falls diese nicht vorhanden sind.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | bbox | die Bounding-Box des EPS-Bildes. |
+
+### Beispiele
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/german/javascript-cpp/xmp/_index.md
+++ b/german/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "XMP-Metadatenfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadatenfunktionen zum Arbeiten mit EPS-Dateien."
+weight: 30
+type: docs
+url: /de/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Hole XMP-Metadaten. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Fügt einen Wert in ein Array ein. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Fügt einen benannten Wert in eine Struktur ein. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registriert Namespace-URI und fügt Wert hinzu. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Füge Postscript-Dateien zu PDF zusammen. |
+
+## Detailed Description
+
+Postscript- oder XPS-Datei in ein Bild oder PDF konvertieren.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/german/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 10
+url: /de/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Liest PS/EPS-Datei und extrahiert XmpMetdata, falls diese bereits existiert.
+Wenn die EPS-Datei keine XMP-Metadaten enthält, erhalten wir neue, die mit Werten aus den PS-Metadatenkommentaren (%%Creator, %%CreateDate, %%Title usw.) gefüllt sind.
+Die EPS-Datei mit ausgefüllten XMP-Metadaten wird in fileNameResult gespeichert.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/german/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/german/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 20
+url: /de/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Fügt einen Wert in ein Array ein. Der Wert wird am Ende des Arrays hinzugefügt.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/german/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/german/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 30
+url: /de/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Fügt einen benannten Wert in eine Struktur ein.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/german/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/german/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 40
+url: /de/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registriert Namespace-URI und fügt Wert hinzu.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/german/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/german/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 40
+url: /de/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Fügt einen benannten Wert in eine Struktur ein.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Zieldatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/german/javascript-cpp/xps/_index.md
+++ b/german/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS-Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit XPS-Dateien."
+weight: 42
+type: docs
+url: /de/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Die Anzahl der Seiten im xps-Dokument ermitteln. |
+
+## Detailed Description
+
+Manipuliere die XPS-Datei.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/german/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Anzahl der Seiten in XPS-Datei ermitteln"
+type: docs
+weight: 10
+url: /de/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Die Anzahl der Seiten im xps-Dokument ermitteln.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Fehlercode (0 kein Fehler) |
+|  | errorText | Fehlertext ("" kein Fehler) |
+|  | pageCount | Anzahl der Seiten |
+
+### Beispiele
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **German** (`de`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `german/javascript-cpp`

🤖 Generated by RDA