### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Greece

### DIFF
--- a/greece/javascript-cpp/convert/_index.md
+++ b/greece/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Συναρτήσεις μετατροπής"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις μετατροπής για εργασία με αρχεία Postscript/XPS."
+weight: 10
+type: docs
+url: /el/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Μετατροπή αρχείου Postscript σε εικόνα. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Μετατροπή αρχείου Postscript σε PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Μετατροπή αρχείου XPS σε εικόνα. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Μετατροπή αρχείου XPS σε PDF. |
+
+## Detailed Description
+
+Μετατροπή αρχείου postscript ή xps σε εικόνα ή αρχείο PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/greece/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το Postscript σε εικόνα"
+type: docs
+weight: 10
+url: /el/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Μετατρέπει το Postscript σε εικόνα.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| imageFormat | ImageFormat | Μορφή εικόνας για μετατροπή. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/greece/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/greece/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το Postscript σε PDF"
+type: docs
+weight: 10
+url: /el/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Μετατρέπει το Postscript σε PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/greece/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/greece/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το XPS σε εικόνα"
+type: docs
+weight: 10
+url: /el/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Μετατρέπει το Postscript σε εικόνα.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| imageFormat | ImageFormat | Μορφή εικόνας για μετατροπή. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/greece/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/greece/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το XPS σε PDF"
+type: docs
+weight: 10
+url: /el/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Μετατρέπει το XPS σε PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/greece/javascript-cpp/core/_index.md
+++ b/greece/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Βασικές συναρτήσεις"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Βασικές συναρτήσεις για εργασία με αρχεία Postscript/XPS."
+weight: 60
+type: docs
+url: /el/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Αποθηκεύστε το BLOB στη μνήμη FS για επεξεργασία. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Αποθηκεύστε το BLOB αναπαράστασης συμβολοσειράς στη μνήμη FS για επεξεργασία. |
+
+## Detailed Description
+
+Βασικές συναρτήσεις για εργασία με αρχεία Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/core/asposepageprepare/_index.md
+++ b/greece/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αποθηκεύστε το BLOB στη μνήμη FS για επεξεργασία."
+type: docs
+url: /el/javascript-cpp/core/asposepageprepare/
+---
+
+_Αποθηκεύστε το BLOB στη μνήμη FS για επεξεργασία._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+Αντικείμενο JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/greece/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/greece/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αποθηκεύστε το BLOB αναπαράστασης συμβολοσειράς στη μνήμη FS για επεξεργασία."
+type: docs
+url: /el/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Αποθηκεύστε την αναπαράσταση συμβολοσειράς BLOB στη μνήμη FS για επεξεργασία._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Παρατηρήσεις
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Παραδείγματα
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/greece/javascript-cpp/enumerations/_index.md
+++ b/greece/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Απαριθμήσεις"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για μετατροπή γραμματοσειρών σε μορφές TrueType."
+weight: 80
+type: docs
+url: /el/javascript-cpp/enumerations/
+---
+
+## Απαριθμήσεις
+
+| Απαρίθμηση | Περιγραφή |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Καθορίζει τη μορφή εικόνας. |
+| [Units](./units/) | Καθορίζει τον τύπο του μεγέθους. |

--- a/greece/javascript-cpp/enumerations/imageformat/_index.md
+++ b/greece/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Απαρίθμηση ImageFormat"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "ImageFormat απαρίθμηση. Καθορίζει μορφή εικόνας"
+type: docs
+weight: 100
+url: /el/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Καθορίζει τη μορφή εικόνας.
+
+```csharp
+public enum ImageFormat
+```
+
+### Τιμές
+
+| Όνομα | Τιμή | Περιγραφή |
+| ---  | ---   | --- |
+| Bmp | `0` | Μορφή εικόνας BMP. |
+| Jpeg | `1` | Μορφή εικόνας JPG. |
+| Gif | `2` | Μορφή εικόνας GIF. |
+| Tiff | `3` | Μορφή εικόνας TIFF. |
+

--- a/greece/javascript-cpp/enumerations/units/_index.md
+++ b/greece/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Units enum. Καθορίζει τον τύπο του μεγέθους"
+type: docs
+weight: 100
+url: /el/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Καθορίζει τον τύπο του μεγέθους.
+
+```js
+enum Units
+```
+
+### Τιμές
+
+| Όνομα | Τιμή | Περιγραφή |
+| ---        | ---   | --- |
+| Points | `0` | Σημεία (1/72 ίντσας). |
+| Inches | `1` | Ίντσες. |
+| Millimeters | `2` | Χιλιοστά. |
+| Centimeters | `3` | Εκατοστά. |
+| Percents | `4` | Ποσοστά του υπάρχοντος μεγέθους. |

--- a/greece/javascript-cpp/eps/_index.md
+++ b/greece/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Συναρτήσεις EPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία EPS."
+weight: 41
+type: docs
+url: /el/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Περικοπή αρχείου EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Αλλαγή μεγέθους αρχείου EPS. |
+
+## Detailed Description
+
+Διαχείριση μεγέθους αρχείου EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/eps/cropeps/_index.md
+++ b/greece/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Περικοπή EPS"
+type: docs
+weight: 10
+url: /el/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Κόβει το αρχείο EPS. Αποθηκεύει το αρχικό αρχείο EPS με ενημερωμένο υπάρχον %%BoundingBox ή θα δημιουργηθεί νέο.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+| αριστερά | float | Καθορίζει το αριστερό όριο του πλαισίου περικοπής. |
+| επάνω | float | Καθορίζει το άνω όριο του πλαισίου περικοπής. |
+| δεξιά | float | Καθορίζει το δεξιό όριο του πλαισίου περικοπής. |
+| κάτω | float | Καθορίζει το κάτω όριο του πλαισίου περικοπής. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/greece/javascript-cpp/eps/resizeeps/_index.md
+++ b/greece/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αλλαγή μεγέθους EPS"
+type: docs
+weight: 10
+url: /el/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Αλλάζει το μέγεθος του αρχείου EPS. Αποθηκεύει το αρχικό αρχείο EPS με ενημερωμένο υπάρχον %%BoundingBox ή θα δημιουργηθεί νέο.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+| width | float | Καθορίζει το πλάτος του νέου πλαισίου περιορισμού. |
+| height | float | Καθορίζει το ύψος του νέου πλαισίου περιορισμού. |
+| μονάδα | Module.Units | Καθορίζει τον τύπο του νέου μεγέθους. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/greece/javascript-cpp/image/_index.md
+++ b/greece/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Συναρτήσεις εικόνας"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία εικόνας."
+weight: 50
+type: docs
+url: /el/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Αποθηκεύστε το αρχείο εικόνας ως EPS. |
+
+## Detailed Description
+
+Αποθηκεύστε εικόνα των πιο δημοφιλών μορφών (BMP, PNG, JPEG, GOF, TIFF) ως αρχείο EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/image/saveimageaseps/_index.md
+++ b/greece/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αλλαγή μεγέθους EPS"
+type: docs
+weight: 10
+url: /el/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Αλλάζει το μέγεθος του αρχείου EPS. Αποθηκεύει το αρχικό αρχείο EPS με ενημερωμένο υπάρχον %%BoundingBox ή θα δημιουργηθεί νέο.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+

--- a/greece/javascript-cpp/merge/_index.md
+++ b/greece/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Συναρτήσεις συγχώνευσης"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις συγχώνευσης για εργασία με αρχεία Postscript/XPS."
+weight: 20
+type: docs
+url: /el/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Συγχωνεύει αρχεία Postscript σε PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Συγχώνευση αρχείων XPS σε PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Συγχώνευση αρχείων XPS σε αρχείο XPS. |
+
+## Detailed Description
+
+Συγχώνευση πολλών αρχείων postscript ή xps σε ένα αρχείο pdf ή πολλών αρχείων xps σε ένα αρχείο xps.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/greece/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συγχώνευση των αρχείων Postscript σε PDF"
+type: docs
+weight: 10
+url: /el/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Συγχώνευση των αρχείων Postscript σε PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileNames | string | Τα ονόματα των αρχείων για συγχώνευση. |
+| fileNameResult | string | Το όνομα του τελικού αρχείου pdf. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/greece/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/greece/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συγχώνευση των αρχείων XPS σε PDF"
+type: docs
+weight: 10
+url: /el/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Συγχώνευση των αρχείων XPS σε PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileNames | string | Τα ονόματα των αρχείων για συγχώνευση. |
+| fileNameResult | string | Το όνομα του τελικού αρχείου pdf. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/greece/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/greece/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συγχώνευση των αρχείων XPS σε ένα XPS"
+type: docs
+weight: 10
+url: /el/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Συγχώνευση πολλών αρχείων XPS σε ένα αρχείο XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileNames | string | Τα ονόματα των αρχείων για συγχώνευση. |
+| fileNameResult | string | Το όνομα του τελικού αρχείου xps. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/greece/javascript-cpp/misc/_index.md
+++ b/greece/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Διάφορες συναρτήσεις"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Δευτερεύουσες συναρτήσεις για εργασία με αρχεία Postscript/XPS."
+weight: 90
+type: docs
+url: /el/javascript-cpp/misc/
+---
+## Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Αποκτήστε πληροφορίες για το προϊόν. |
+| [DownloadFile](./downloadfile/) | Δημιουργήστε έναν σύνδεσμο σε HTML για λήψη του αρχείου. |
+| [DownloadFileAuto](./downloadfileauto/) | Δημιουργήστε έναν σύνδεσμο σε HTML για λήψη του αρχείου και ξεκινήστε τη λήψη μετά από 2 δευτερόλεπτα. |
+
+## Detailed Description
+
+Δευτερεύουσες συναρτήσεις για εργασία με αρχεία Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/misc/downloadfile/_index.md
+++ b/greece/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Δημιουργήστε έναν σύνδεσμο σε HTML για λήψη του αρχείου."
+type: docs
+url: /el/javascript-cpp/misc/downloadfile/
+---
+
+_Δημιουργήστε έναν σύνδεσμο σε HTML για λήψη του αρχείου._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/greece/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/greece/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Δημιουργήστε έναν σύνδεσμο σε HTML για λήψη του αρχείου και ξεκινήστε τη λήψη μετά από 2 δευτερόλεπτα."
+type: docs
+url: /el/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Δημιουργήστε έναν σύνδεσμο σε HTML για λήψη του αρχείου και ξεκινήστε τη λήψη μετά από 2 δευτερόλεπτα.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Παράμετροι
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Παρατηρήσεις
+
+Δεν λειτουργεί σε Web Worker.

--- a/greece/javascript-cpp/misc/pageabout/_index.md
+++ b/greece/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αποκτήστε πληροφορίες για το προϊόν."
+type: docs
+url: /el/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Αποκτήστε πληροφορίες για το προϊόν.
+
+```js
+function AsposePageAbout()
+```
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+| errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+| errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+| προϊόν | Όνομα προϊόντος |
+| έκδοση | Έκδοση προϊόντος |
+| islicensed | Το προϊόν είναι αδειοδοτημένο |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/greece/javascript-cpp/ps/_index.md
+++ b/greece/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Συναρτήσεις PS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία PS."
+weight: 40
+type: docs
+url: /el/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Λήψη ορίων αρχείου PS. |
+| [AsposePSExtractText](./psextracttext/) | Εξαγωγή κειμένου από αρχείο PS. |
+
+## Detailed Description
+
+Διαχείριση αρχείου PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/ps/psextracttext/_index.md
+++ b/greece/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Εξαγωγή κειμένου από αρχείο PS"
+type: docs
+weight: 10
+url: /el/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Εξαγωγή κειμένου από αρχείο PS. Το κείμενο μπορεί να εξαχθεί μόνο εάν είναι γραμμένο με γραμματοσειρά Type 42 (TrueType) ή γραμματοσειρά Type 0 με γραμματοσειρές Type 42 στον Vector Map της.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| έναρξη | int | Καθορίζει τη σελίδα από την οποία θα ξεκινήσει η εξαγωγή κειμένου. Αυτή η παράμετρος είναι χρήσιμη για έγγραφα πολλαπλών σελίδων. |
+| τέλος | int | Καθορίζει τη σελίδα μέχρι την οποία θα ολοκληρωθεί η εξαγωγή κειμένου. Αυτή η παράμετρος είναι χρήσιμη για έγγραφα πολλαπλών σελίδων. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | κείμενο | το εξαγόμενο κείμενο |
+
+### Παραδείγματα
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Δείτε επίσης
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/greece/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/greece/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε το πλαίσιο οριοθέτησης"
+type: docs
+weight: 10
+url: /el/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Διαβάζει το αρχείο EPS και εξάγει το πλαίσιο οριοθέτησης της εικόνας EPS από το σχόλιο %%BoundingBox ή τα όρια για το προεπιλεγμένο μέγεθος σελίδας (0, 0, 595, 842) εάν δεν υπάρχει.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | bbox | το πλαίσιο οριοθέτησης της εικόνας EPS. |
+
+### Παραδείγματα
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/greece/javascript-cpp/xmp/_index.md
+++ b/greece/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Συναρτήσεις μεταδεδομένων XMP"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις μεταδεδομένων XMP για εργασία με αρχεία EPS."
+weight: 30
+type: docs
+url: /el/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Αποκτήστε τα μεταδεδομένα XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Προσθέτει τιμή σε έναν πίνακα. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Προσθέτει ονομαστική τιμή σε μια δομή. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Καταχωρεί το URI του χώρου ονομάτων και προσθέτει τιμή. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Συγχωνεύει αρχεία Postscript σε PDF. |
+
+## Detailed Description
+
+Μετατροπή αρχείου postscript ή xps σε εικόνα ή αρχείο PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/greece/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε μεταδεδομένα XMP"
+type: docs
+weight: 10
+url: /el/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Διαβάζει αρχείο PS/EPS και εξάγει XmpMetdata εάν υπάρχει ήδη.
+Εάν το αρχείο EPS δεν περιέχει μεταδεδομένα XMP, λαμβάνουμε ένα νέο γεμάτο με τιμές από τα σχόλια μεταδεδομένων PS (%%Creator, %%CreateDate, %%Title κλπ).
+Το αρχείο EPS με τα γεμισμένα μεταδεδομένα XMP θα αποθηκευτεί στο fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/greece/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/greece/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε μεταδεδομένα XMP"
+type: docs
+weight: 20
+url: /el/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Προσθέτει τιμή σε έναν πίνακα. Η τιμή θα προστεθεί στο τέλος του πίνακα.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/greece/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/greece/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε μεταδεδομένα XMP"
+type: docs
+weight: 30
+url: /el/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Προσθέτει ονομαστική τιμή σε μια δομή.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/greece/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/greece/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε μεταδεδομένα XMP"
+type: docs
+weight: 40
+url: /el/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Καταχωρεί το URI του χώρου ονομάτων και προσθέτει τιμή.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/greece/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/greece/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε μεταδεδομένα XMP"
+type: docs
+weight: 40
+url: /el/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Προσθέτει ονομαστική τιμή σε μια δομή.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/greece/javascript-cpp/xps/_index.md
+++ b/greece/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Συναρτήσεις XPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία XPS."
+weight: 42
+type: docs
+url: /el/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Συνάρτηση | Περιγραφή |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Λήψη του αριθμού των σελίδων στο xps-document. |
+
+## Detailed Description
+
+Διαχειριστείτε το αρχείο XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/greece/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε αριθμό σελίδων στο αρχείο XPS-file"
+type: docs
+weight: 10
+url: /el/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Λήψη του αριθμού των σελίδων στο xps-document.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+
+### Τιμή Επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | pageCount | αριθμός σελίδων |
+
+### Παραδείγματα
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Greece** (`el`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `greece/javascript-cpp`

🤖 Generated by RDA