### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Indonesian

### DIFF
--- a/indonesian/javascript-cpp/convert/_index.md
+++ b/indonesian/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Fungsi konversi"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi konversi untuk bekerja dengan file Postscript/XPS."
+weight: 10
+type: docs
+url: /id/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Konversi file Postscript ke gambar. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Konversi file Postscript ke PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Konversi file XPS ke gambar. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Konversi file XPS ke PDF. |
+
+## Detailed Description
+
+Konversi file postscript atau xps ke gambar atau file PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/indonesian/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi Postscript ke gambar"
+type: docs
+weight: 10
+url: /id/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Mengonversi Postscript ke gambar.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| imageFormat | ImageFormat | format gambar untuk dikonversi menjadi. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/indonesian/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/indonesian/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi Postscript ke PDF"
+type: docs
+weight: 10
+url: /id/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Mengonversi Postscript ke PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/indonesian/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/indonesian/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi XPS ke gambar"
+type: docs
+weight: 10
+url: /id/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Mengonversi Postscript ke gambar.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| imageFormat | ImageFormat | format gambar untuk dikonversi menjadi. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/indonesian/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/indonesian/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi XPS ke PDF"
+type: docs
+weight: 10
+url: /id/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Mengonversi XPS ke PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/indonesian/javascript-cpp/core/_index.md
+++ b/indonesian/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fungsi inti"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi inti untuk bekerja dengan file Postscript/XPS."
+weight: 60
+type: docs
+url: /id/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Simpan BLOB di Memory FS untuk diproses. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Simpan BLOB representasi string di Memory FS untuk diproses. |
+
+## Detailed Description
+
+Fungsi inti untuk bekerja dengan file Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/core/asposepageprepare/_index.md
+++ b/indonesian/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Simpan BLOB di Memory FS untuk diproses."
+type: docs
+url: /id/javascript-cpp/core/asposepageprepare/
+---
+
+_Simpan BLOB di Memory FS untuk diproses._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+objek JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/indonesian/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/indonesian/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Simpan BLOB representasi string di Memory FS untuk diproses."
+type: docs
+url: /id/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Simpan representasi string BLOB di Memory FS untuk diproses._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Catatan
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Contoh
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/indonesian/javascript-cpp/enumerations/_index.md
+++ b/indonesian/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Enumerasi"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk mengonversi font ke format TrueType."
+weight: 80
+type: docs
+url: /id/javascript-cpp/enumerations/
+---
+
+## Enumerasi
+
+| Enumerasi | Deskripsi |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Menentukan format gambar. |
+| [Units](./units/) | Menentukan tipe ukuran. |

--- a/indonesian/javascript-cpp/enumerations/imageformat/_index.md
+++ b/indonesian/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Enum ImageFormat. Menentukan format gambar"
+type: docs
+weight: 100
+url: /id/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Menentukan format gambar.
+
+```csharp
+public enum ImageFormat
+```
+
+### Nilai
+
+| Nama | Nilai | Deskripsi |
+| ---  | ---   | --- |
+| Bmp | `0` | Format gambar BMP. |
+| Jpeg | `1` | Format gambar JPG. |
+| Gif | `2` | Format gambar GIF. |
+| Tiff | `3` | Format gambar TIFF. |
+

--- a/indonesian/javascript-cpp/enumerations/units/_index.md
+++ b/indonesian/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Units enum. Menentukan jenis ukuran"
+type: docs
+weight: 100
+url: /id/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Menentukan tipe ukuran.
+
+```js
+enum Units
+```
+
+### Nilai
+
+| Nama | Nilai | Deskripsi |
+| ---        | ---   | --- |
+| Points | `0` | Poin (1/72 inci). |
+| Inches | `1` | Inci. |
+| Millimeters | `2` | Milimeter. |
+| Centimeters | `3` | Sentimeter. |
+| Percents | `4` | Persentase ukuran yang ada. |

--- a/indonesian/javascript-cpp/eps/_index.md
+++ b/indonesian/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Fungsi EPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file EPS."
+weight: 41
+type: docs
+url: /id/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Potong file EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Ubah ukuran file EPS. |
+
+## Detailed Description
+
+Manipulasi ukuran file EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/eps/cropeps/_index.md
+++ b/indonesian/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Potong EPS"
+type: docs
+weight: 10
+url: /id/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Memotong file EPS. Ini menyimpan file EPS awal dengan %%BoundingBox yang ada diperbarui atau yang baru akan dibuat.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+| kiri | float | Menentukan batas kiri kotak pemotongan. |
+| atas | float | Menentukan batas atas kotak pemotongan. |
+| kanan | float | Menentukan batas kanan kotak pemotongan. |
+| bawah | float | Menentukan batas bawah kotak pemotongan. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/indonesian/javascript-cpp/eps/resizeeps/_index.md
+++ b/indonesian/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Ubah ukuran EPS"
+type: docs
+weight: 10
+url: /id/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Mengubah ukuran file EPS. Ini menyimpan file EPS awal dengan %%BoundingBox yang ada diperbarui atau membuat yang baru.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+| lebar | float | Menentukan lebar kotak pembatas baru. |
+| tinggi | float | Menentukan tinggi kotak pembatas baru. |
+| unit | Module.Units | Menentukan jenis ukuran baru. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/indonesian/javascript-cpp/image/_index.md
+++ b/indonesian/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Fungsi gambar"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file gambar."
+weight: 50
+type: docs
+url: /id/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Simpan file gambar sebagai EPS. |
+
+## Detailed Description
+
+Simpan gambar dari format paling populer seperti BMP, PNG, JPEG, GOF, TIFF sebagai file EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/image/saveimageaseps/_index.md
+++ b/indonesian/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Ubah ukuran EPS"
+type: docs
+weight: 10
+url: /id/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Mengubah ukuran file EPS. Ini menyimpan file EPS awal dengan %%BoundingBox yang ada diperbarui atau membuat yang baru.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+

--- a/indonesian/javascript-cpp/merge/_index.md
+++ b/indonesian/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Fungsi penggabungan"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi penggabungan untuk bekerja dengan file Postscript/XPS."
+weight: 20
+type: docs
+url: /id/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Gabungkan file Postscript menjadi PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Gabungkan file XPS ke PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Gabungkan file XPS ke file XPS. |
+
+## Detailed Description
+
+Gabungkan beberapa file postscript atau xps menjadi satu file pdf atau beberapa file xps menjadi satu file xps.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/indonesian/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Gabungkan file Postscript ke PDF"
+type: docs
+weight: 10
+url: /id/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Gabungkan file Postscript ke PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileNames | string | Nama-nama file untuk digabungkan. |
+| fileNameResult | string | Nama file PDF hasil. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/indonesian/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/indonesian/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Gabungkan file XPS ke PDF"
+type: docs
+weight: 10
+url: /id/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Gabungkan file XPS ke PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileNames | string | Nama-nama file untuk digabungkan. |
+| fileNameResult | string | Nama file PDF hasil. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/indonesian/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/indonesian/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Gabungkan file XPS menjadi satu XPS"
+type: docs
+weight: 10
+url: /id/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Gabungkan beberapa file XPS menjadi satu file XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileNames | string | Nama-nama file untuk digabungkan. |
+| fileNameResult | string | Nama file XPS hasil. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/indonesian/javascript-cpp/misc/_index.md
+++ b/indonesian/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fungsi lain-lain"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi sekunder untuk bekerja dengan file Postscript/XPS."
+weight: 90
+type: docs
+url: /id/javascript-cpp/misc/
+---
+## Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Dapatkan info tentang Produk. |
+| [DownloadFile](./downloadfile/) | Buat tautan di HTML untuk mengunduh file. |
+| [DownloadFileAuto](./downloadfileauto/) | Buat tautan di HTML untuk mengunduh file dan memulai unduhan setelah 2 detik. |
+
+## Detailed Description
+
+Fungsi sekunder untuk bekerja dengan file Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/misc/downloadfile/_index.md
+++ b/indonesian/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Buat tautan di HTML untuk mengunduh file."
+type: docs
+url: /id/javascript-cpp/misc/downloadfile/
+---
+
+_Buat tautan di HTML untuk mengunduh file._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/indonesian/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/indonesian/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Buat tautan di HTML untuk mengunduh file dan memulai unduhan setelah 2 detik."
+type: docs
+url: /id/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Buat tautan di HTML untuk mengunduh file dan memulai unduhan setelah 2 detik.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parameter
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Catatan
+
+Tidak berfungsi di Web Worker.

--- a/indonesian/javascript-cpp/misc/pageabout/_index.md
+++ b/indonesian/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan info tentang Produk."
+type: docs
+url: /id/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Dapatkan info tentang Produk.
+
+```js
+function AsposePageAbout()
+```
+
+### Nilai kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+| errorCode | kode error (0 tidak ada error) |
+| errorText | teks error ("" tidak ada error) |
+| produk | Nama produk |
+| versi | Versi produk |
+| islicensed | Produk berlisensi |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/indonesian/javascript-cpp/ps/_index.md
+++ b/indonesian/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Fungsi PS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file PS."
+weight: 40
+type: docs
+url: /id/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Dapatkan batas file PS. |
+| [AsposePSExtractText](./psextracttext/) | Ekstrak teks dari file PS. |
+
+## Detailed Description
+
+Manipulasi file PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/ps/psextracttext/_index.md
+++ b/indonesian/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Ekstrak teks dari file PS"
+type: docs
+weight: 10
+url: /id/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Ekstrak teks dari file PS. Teks dapat diekstrak hanya jika ditulis dengan font Type 42 (TrueType) atau font Type 0 dengan font Type 42 dalam Vector Map-nya.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| mulai | int | Menentukan halaman dari mana untuk memulai mengekstrak teks. Parameter ini berguna untuk dokumen multi-halaman. |
+| akhir | int | Menentukan halaman sampai mana untuk menyelesaikan mengekstrak teks. Parameter ini berguna untuk dokumen multi-halaman. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | teks | teks yang diekstrak |
+
+### Contoh
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Lihat Juga
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/indonesian/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/indonesian/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan kotak pembatas"
+type: docs
+weight: 10
+url: /id/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Membaca file EPS dan mengekstrak kotak pembatas gambar EPS dari komentar %%BoundingBox atau batas untuk ukuran halaman default (0, 0, 595, 842) jika tidak ada.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | bbox | kotak pembatas gambar EPS. |
+
+### Contoh
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/indonesian/javascript-cpp/xmp/_index.md
+++ b/indonesian/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Fungsi metadata XMP"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi metadata XMP untuk bekerja dengan file EPS."
+weight: 30
+type: docs
+url: /id/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Dapatkan metadata XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Menambahkan nilai ke dalam array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Menambahkan nilai bernama ke dalam struktur. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Mendaftarkan URI namespace dan menambahkan nilai. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Gabungkan file Postscript menjadi PDF. |
+
+## Detailed Description
+
+Konversi file postscript atau xps ke gambar atau file PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/indonesian/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 10
+url: /id/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Membaca file PS/EPS dan mengekstrak XmpMetdata jika sudah ada.
+Jika file EPS tidak mengandung metadata XMP, kami mendapatkan yang baru yang diisi dengan nilai dari komentar metadata PS (%%Creator, %%CreateDate, %%Title, dll).
+File EPS dengan metadata XMP yang terisi akan disimpan dalam fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/indonesian/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/indonesian/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 20
+url: /id/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Menambahkan nilai ke dalam array. Nilai akan ditambahkan di akhir array.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/indonesian/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/indonesian/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 30
+url: /id/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Menambahkan nilai bernama ke dalam struktur.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/indonesian/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/indonesian/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 40
+url: /id/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Mendaftarkan URI namespace dan menambahkan nilai.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/indonesian/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/indonesian/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 40
+url: /id/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Menambahkan nilai bernama ke dalam struktur.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/indonesian/javascript-cpp/xps/_index.md
+++ b/indonesian/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fungsi XPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file XPS."
+weight: 42
+type: docs
+url: /id/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Fungsi | Deskripsi |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Dapatkan jumlah halaman dalam dokumen xps. |
+
+## Detailed Description
+
+Manipulasi file XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/indonesian/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan jumlah halaman dalam file XPS"
+type: docs
+weight: 10
+url: /id/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Dapatkan jumlah halaman dalam dokumen xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+
+### Nilai Kembali
+
+objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kode error (0 tidak ada error) |
+|  | errorText | teks error ("" tidak ada error) |
+|  | pageCount | jumlah halaman |
+
+### Contoh
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Indonesian** (`id`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `indonesian/javascript-cpp`

🤖 Generated by RDA