### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Italian

### DIFF
--- a/italian/javascript-cpp/convert/_index.md
+++ b/italian/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Funzioni di conversione"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di conversione per lavorare con file Postscript/XPS."
+weight: 10
+type: docs
+url: /it/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Converti un file Postscript in immagine. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Converti un file Postscript in PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Converti un file XPS in immagine. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Converti un file XPS in PDF. |
+
+## Detailed Description
+
+Converti file postscript o xps in immagine o file PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/italian/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte il Postscript in immagine"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Converte il Postscript in immagine.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font di origine per la conversione. |
+| fileName | string | Nome file. |
+| imageFormat | ImageFormat | formato immagine in cui convertire. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/italian/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/italian/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte il Postscript in PDF"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converte il Postscript in PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font di origine per la conversione. |
+| fileName | string | Nome file. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/italian/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/italian/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte l'XPS in immagine"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Converte il Postscript in immagine.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font di origine per la conversione. |
+| fileName | string | Nome file. |
+| imageFormat | ImageFormat | formato immagine in cui convertire. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/italian/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/italian/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte l'XPS in PDF"
+type: docs
+weight: 10
+url: /it/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converte l'XPS in PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font di origine per la conversione. |
+| fileName | string | Nome file. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/italian/javascript-cpp/core/_index.md
+++ b/italian/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funzioni di base"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di base per lavorare con file Postscript/XPS."
+weight: 60
+type: docs
+url: /it/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Salva il BLOB nel file system in memoria per l'elaborazione. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Salva il BLOB di rappresentazione stringa nel file system in memoria per l'elaborazione. |
+
+## Detailed Description
+
+Funzioni di base per lavorare con file Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/core/asposepageprepare/_index.md
+++ b/italian/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Salva il BLOB nel file system in memoria per l'elaborazione."
+type: docs
+url: /it/javascript-cpp/core/asposepageprepare/
+---
+
+_Salva il BLOB nel file system in memoria per l'elaborazione._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+oggetto JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/italian/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/italian/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Salva il BLOB di rappresentazione stringa nel file system in memoria per l'elaborazione."
+type: docs
+url: /it/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Salva la rappresentazione stringa del BLOB nel file system in memoria per l'elaborazione._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Osservazioni
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Esempi
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/italian/javascript-cpp/enumerations/_index.md
+++ b/italian/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Enumerazioni"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per la conversione dei font in formati TrueType."
+weight: 80
+type: docs
+url: /it/javascript-cpp/enumerations/
+---
+
+## Enumerazioni
+
+| Enumerazione | Descrizione |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Specifica il formato immagine. |
+| [Units](./units/) | Specifica il tipo di dimensione. |

--- a/italian/javascript-cpp/enumerations/imageformat/_index.md
+++ b/italian/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "ImageFormat enum. Specifica il formato immagine"
+type: docs
+weight: 100
+url: /it/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Specifica il formato immagine.
+
+```csharp
+public enum ImageFormat
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| ---  | ---   | --- |
+| Bmp | `0` | Formato immagine BMP. |
+| Jpeg | `1` | Formato immagine JPG. |
+| Gif | `2` | Formato immagine GIF. |
+| Tiff | `3` | Formato immagine TIFF. |
+

--- a/italian/javascript-cpp/enumerations/units/_index.md
+++ b/italian/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Units enum. Specifica il tipo di dimensione"
+type: docs
+weight: 100
+url: /it/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Specifica il tipo di dimensione.
+
+```js
+enum Units
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| ---        | ---   | --- |
+| Points | `0` | Punti (1/72 di pollice). |
+| Inches | `1` | Pollici. |
+| Millimeters | `2` | Millimetri. |
+| Centimeters | `3` | Centimetri. |
+| Percents | `4` | Percentuali della dimensione esistente. |

--- a/italian/javascript-cpp/eps/_index.md
+++ b/italian/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Funzioni EPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file EPS."
+weight: 41
+type: docs
+url: /it/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Ritaglia file EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Ridimensiona file EPS. |
+
+## Detailed Description
+
+Modifica la dimensione del file EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/eps/cropeps/_index.md
+++ b/italian/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ritaglia EPS"
+type: docs
+weight: 10
+url: /it/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Ritaglia il file EPS. Salva il file EPS iniziale con il %%BoundingBox esistente aggiornato oppure ne verrà creato uno nuovo.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+| sinistra | float | Specifica il limite sinistro della casella di ritaglio. |
+| alto | float | Specifica il limite superiore della casella di ritaglio. |
+| destra | float | Specifica il limite destro della casella di ritaglio. |
+| inferiore | float | Specifica il limite inferiore della casella di ritaglio. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/italian/javascript-cpp/eps/resizeeps/_index.md
+++ b/italian/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ridimensiona EPS"
+type: docs
+weight: 10
+url: /it/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Ridimensiona il file EPS. Salva il file EPS originale con il %%BoundingBox esistente aggiornato o ne crea uno nuovo.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+| width | float | Specifica la larghezza del nuovo bounding box. |
+| height | float | Specifica l'altezza del nuovo bounding box. |
+| unit | Module.Units | Specifica il tipo della nuova dimensione. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/italian/javascript-cpp/image/_index.md
+++ b/italian/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funzioni immagine"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con i file immagine."
+weight: 50
+type: docs
+url: /it/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Salva il file immagine come EPS. |
+
+## Detailed Description
+
+Salva l'immagine dei formati più popolari (BMP, PNG, JPEG, GOF, TIFF) come file EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/image/saveimageaseps/_index.md
+++ b/italian/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ridimensiona EPS"
+type: docs
+weight: 10
+url: /it/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Ridimensiona il file EPS. Salva il file EPS originale con il %%BoundingBox esistente aggiornato o ne crea uno nuovo.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+

--- a/italian/javascript-cpp/merge/_index.md
+++ b/italian/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Funzioni di unione"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di unione per lavorare con file Postscript/XPS."
+weight: 20
+type: docs
+url: /it/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Unisci file Postscript in PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Unisci un file XPS in PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Unisci un file XPS in un file XPS. |
+
+## Detailed Description
+
+Unisci diversi file postscript o xps in un unico file pdf o diversi file xps in un unico file xps.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/italian/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Unisci i file Postscript in PDF"
+type: docs
+weight: 10
+url: /it/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Unisci i file Postscript in PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileNames | string | I nomi dei file da unire. |
+| fileNameResult | string | Il nome del file PDF risultante. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/italian/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/italian/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Unisci i file XPS in PDF"
+type: docs
+weight: 10
+url: /it/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Unisci i file XPS in PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileNames | string | I nomi dei file da unire. |
+| fileNameResult | string | Il nome del file PDF risultante. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/italian/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/italian/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Unisci i file XPS in un unico XPS"
+type: docs
+weight: 10
+url: /it/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Unisci diversi file XPS in un unico file XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileNames | string | I nomi dei file da unire. |
+| fileNameResult | string | Il nome del file XPS risultante. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/italian/javascript-cpp/misc/_index.md
+++ b/italian/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funzioni varie"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni secondarie per lavorare con file Postscript/XPS."
+weight: 90
+type: docs
+url: /it/javascript-cpp/misc/
+---
+## Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Ottieni informazioni sul prodotto. |
+| [DownloadFile](./downloadfile/) | Crea un collegamento in HTML per scaricare il file. |
+| [DownloadFileAuto](./downloadfileauto/) | Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi. |
+
+## Detailed Description
+
+Funzioni secondarie per lavorare con file Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/misc/downloadfile/_index.md
+++ b/italian/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Crea un collegamento in HTML per scaricare il file."
+type: docs
+url: /it/javascript-cpp/misc/downloadfile/
+---
+
+_Crea un collegamento in HTML per scaricare il file._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/italian/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/italian/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi."
+type: docs
+url: /it/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Crea un collegamento in HTML per scaricare il file e avvia il download dopo 2 secondi.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parametri
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Osservazioni
+
+Non funziona in Web Worker.

--- a/italian/javascript-cpp/misc/pageabout/_index.md
+++ b/italian/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni informazioni sul prodotto."
+type: docs
+url: /it/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Ottieni informazioni sul prodotto.
+
+```js
+function AsposePageAbout()
+```
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+| errorCode | errore di codice (0 nessun errore) |
+| errorText | errore di testo (\"\" nessun errore) |
+| prodotto | Nome prodotto |
+| versione | Versione prodotto |
+| islicensed | Il prodotto è licenziato |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/italian/javascript-cpp/ps/_index.md
+++ b/italian/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Funzioni PS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file PS."
+weight: 40
+type: docs
+url: /it/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Ottieni i limiti del file PS. |
+| [AsposePSExtractText](./psextracttext/) | Estrai testo dal file PS. |
+
+## Detailed Description
+
+Modifica file PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/ps/psextracttext/_index.md
+++ b/italian/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Estrai il testo dal file PS"
+type: docs
+weight: 10
+url: /it/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Estrai il testo dal file PS. Il testo può essere estratto solo se è scritto con font Type 42 (TrueType) o font Type 0 con font Type 42 nella sua Mappa Vettoriale.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| inizio | int | Specifica la pagina da cui iniziare l'estrazione del testo. Questo parametro è utile per documenti multipagina. |
+| fine | int | Specifica la pagina fino a cui terminare l'estrazione del testo. Questo parametro è utile per documenti multipagina. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | testo | il testo estratto |
+
+### Esempi
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Vedi anche
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/italian/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/italian/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni il riquadro di delimitazione"
+type: docs
+weight: 10
+url: /it/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Legge il file EPS ed estrae il riquadro di delimitazione dell'immagine EPS dal commento %%BoundingBox o i limiti per la dimensione predefinita della pagina (0, 0, 595, 842) se non esiste.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | bbox | il riquadro di delimitazione dell'immagine EPS. |
+
+### Esempi
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/italian/javascript-cpp/xmp/_index.md
+++ b/italian/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Funzioni di metadati XMP"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di metadati XMP per lavorare con file EPS."
+weight: 30
+type: docs
+url: /it/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Ottieni i metadati XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Aggiunge un valore in un array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Aggiunge un valore nominato in una struttura. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registra l'URI dello spazio dei nomi e aggiunge il valore. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Unisci file Postscript in PDF. |
+
+## Detailed Description
+
+Converti file postscript o xps in immagine o file PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/italian/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 10
+url: /it/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Legge il file PS/EPS ed estrae XmpMetdata se esiste già.
+Se il file EPS non contiene metadati XMP, ne otteniamo uno nuovo riempito con i valori dei commenti dei metadati PS (%%Creator, %%CreateDate, %%Title ecc).
+Il file EPS con i metadati XMP compilati verrà salvato in fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/italian/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/italian/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 20
+url: /it/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Aggiunge un valore in un array. Il valore sarà aggiunto alla fine dell'array.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/italian/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/italian/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 30
+url: /it/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Aggiunge un valore nominato in una struttura.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/italian/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/italian/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 40
+url: /it/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registra l'URI dello spazio dei nomi e aggiunge il valore.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/italian/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/italian/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 40
+url: /it/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Aggiunge un valore nominato in una struttura.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/italian/javascript-cpp/xps/_index.md
+++ b/italian/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funzioni XPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file XPS."
+weight: 42
+type: docs
+url: /it/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Ottieni il numero di pagine nel documento xps. |
+
+## Detailed Description
+
+Manipola il file XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/italian/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni il numero di pagine nel file XPS"
+type: docs
+weight: 10
+url: /it/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Ottieni il numero di pagine nel documento xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo (\"\" nessun errore) |
+|  | pageCount | numero di pagine |
+
+### Esempi
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `italian/javascript-cpp`

🤖 Generated by RDA