### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Japanese

### DIFF
--- a/japanese/javascript-cpp/convert/_index.md
+++ b/japanese/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "変換関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルを操作するための変換関数。"
+weight: 10
+type: docs
+url: /ja/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Postscript ファイルを画像に変換します。 |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Postscript ファイルを PDF に変換します。 |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | XPS ファイルを画像に変換します。 |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | XPS ファイルを PDF に変換します。 |
+
+## Detailed Description
+
+Postscript または XPS ファイルを画像または PDF ファイルに変換します。
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/japanese/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript を画像に変換します"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript を画像に変換します。
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容。 |
+| fileName | 文字列 | ファイル名。 |
+| imageFormat | ImageFormat | 変換先の画像形式。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/japanese/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/japanese/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript を PDF に変換します。"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Postscript を PDF に変換します。
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容。 |
+| fileName | 文字列 | ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/japanese/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/japanese/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS を画像に変換します"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript を画像に変換します。
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容。 |
+| fileName | 文字列 | ファイル名。 |
+| imageFormat | ImageFormat | 変換先の画像形式。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/japanese/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/japanese/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS を PDF に変換します"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+XPS を PDF に変換します。
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容。 |
+| fileName | 文字列 | ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/japanese/javascript-cpp/core/_index.md
+++ b/japanese/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "コア関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルを操作するためのコア関数。"
+weight: 60
+type: docs
+url: /ja/javascript-cpp/core/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | 処理のために BLOB をメモリ FS に保存する。 |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | 処理のために文字列表現の BLOB をメモリ FS に保存する。 |
+
+## Detailed Description
+
+Postscript/XPS ファイルを操作するためのコア関数。
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/core/asposepageprepare/_index.md
+++ b/japanese/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "処理のために BLOB をメモリ FS に保存する。"
+type: docs
+url: /ja/javascript-cpp/core/asposepageprepare/
+---
+
+_処理のためにメモリFSにBLOBを保存します。_
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON オブジェクト
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/japanese/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/japanese/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "処理のために文字列表現の BLOB をメモリ FS に保存する。"
+type: docs
+url: /ja/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_処理のためにメモリFSに文字列表現のBLOBを保存します。_
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### 備考
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### 例
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/japanese/javascript-cpp/enumerations/_index.md
+++ b/japanese/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "列挙型"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "フォントを TrueType 形式に変換するための関数。"
+weight: 80
+type: docs
+url: /ja/javascript-cpp/enumerations/
+---
+
+## 列挙型
+
+| 列挙型 | 説明 |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | 画像形式を指定する。 |
+| [Units](./units/) | サイズのタイプを指定します。 |

--- a/japanese/javascript-cpp/enumerations/imageformat/_index.md
+++ b/japanese/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "列挙体 ImageFormat"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "ImageFormat 列挙体。画像フォーマットを指定します"
+type: docs
+weight: 100
+url: /ja/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+画像形式を指定する。
+
+```csharp
+public enum ImageFormat
+```
+
+### 値
+
+| 名前 | 値 | 説明 |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP 画像フォーマット。 |
+| Jpeg | `1` | JPG 画像フォーマット。 |
+| Gif | `2` | GIF 画像フォーマット。 |
+| Tiff | `3` | TIFF 画像フォーマット。 |
+

--- a/japanese/javascript-cpp/enumerations/units/_index.md
+++ b/japanese/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum 単位"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Units 列挙体。サイズのタイプを指定します。"
+type: docs
+weight: 100
+url: /ja/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+サイズのタイプを指定します。
+
+```js
+enum Units
+```
+
+### 値
+
+| 名前 | 値 | 説明 |
+| ---        | ---   | --- |
+| Points | `0` | ポイント (1/72 インチ)。 |
+| Inches | `1` | インチ。 |
+| Millimeters | `2` | ミリメートル。 |
+| Centimeters | `3` | センチメートル。 |
+| Percents | `4` | 既存サイズのパーセンテージ。 |

--- a/japanese/javascript-cpp/eps/_index.md
+++ b/japanese/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "EPS 関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS ファイルを操作するための関数。"
+weight: 41
+type: docs
+url: /ja/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS ファイルをトリミングします。 |
+| [AsposeResizeEPS](./resizeeps/) | EPS ファイルのサイズを変更します。 |
+
+## Detailed Description
+
+EPS ファイルのサイズを操作します。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/eps/cropeps/_index.md
+++ b/japanese/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS をトリミング"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+EPS ファイルをトリミングします。更新された既存の %%BoundingBox を使用して元の EPS ファイルを保存するか、新しいものが作成されます。
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+| 左 | 浮動小数点数 | トリミングボックスの左境界を指定します。 |
+| 上 | 浮動小数点数 | トリミングボックスの上境界を指定します。 |
+| 右 | 浮動小数点数 | トリミングボックスの右境界を指定します。 |
+| 下 | 浮動小数点数 | トリミングボックスの下境界を指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/japanese/javascript-cpp/eps/resizeeps/_index.md
+++ b/japanese/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS のサイズ変更"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+EPS ファイルのサイズを変更します。既存の %%BoundingBox を更新した元の EPS ファイルを保存するか、新しいものが作成されます。
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+| 幅 | 浮動小数点数 | 新しいバウンディングボックスの幅を指定します。 |
+| 高さ | 浮動小数点数 | 新しいバウンディングボックスの高さを指定します。 |
+| 単位 | Module.Units | 新しいサイズのタイプを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/japanese/javascript-cpp/image/_index.md
+++ b/japanese/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "画像関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "画像ファイルを操作するための関数。"
+weight: 50
+type: docs
+url: /ja/javascript-cpp/image/
+---
+
+## Image Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | 画像ファイルを EPS として保存する。 |
+
+## Detailed Description
+
+最も一般的な形式の画像（BMP、PNG、JPEG、GOF、TIFF）を EPS ファイルとして保存する。
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/image/saveimageaseps/_index.md
+++ b/japanese/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS のサイズ変更"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+EPS ファイルのサイズを変更します。既存の %%BoundingBox を更新した元の EPS ファイルを保存するか、新しいものが作成されます。
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+

--- a/japanese/javascript-cpp/merge/_index.md
+++ b/japanese/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "マージ機能"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルの操作用マージ機能。"
+weight: 20
+type: docs
+url: /ja/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Postscript ファイルを PDF に結合する。 |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | XPS ファイルを PDF にマージします。 |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | XPS ファイルを XPS ファイルにマージします。 |
+
+## Detailed Description
+
+複数の Postscript または XPS ファイルを 1 つの PDF ファイルにマージするか、複数の XPS ファイルを 1 つの XPS ファイルにマージします。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/japanese/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript ファイルを PDF に結合します"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Postscript ファイルを PDF に結合します。
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileNames | 文字列 | 結合するファイルの名前です。 |
+| fileNameResult | 文字列 | 結果の PDF ファイルの名前です。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/japanese/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/japanese/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルを PDF に結合します"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+XPS ファイルを PDF に結合します。
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileNames | 文字列 | 結合するファイルの名前です。 |
+| fileNameResult | 文字列 | 結果の PDF ファイルの名前です。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/japanese/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/japanese/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルを 1 つの XPS に結合します"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+複数の XPS ファイルを 1 つの XPS ファイルに結合します。
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileNames | 文字列 | 結合するファイルの名前です。 |
+| fileNameResult | 文字列 | 結果の XPS ファイルの名前です。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/japanese/javascript-cpp/misc/_index.md
+++ b/japanese/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "その他の関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルを操作するための二次的な関数。"
+weight: 90
+type: docs
+url: /ja/javascript-cpp/misc/
+---
+## Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | 製品に関する情報を取得する。 |
+| [DownloadFile](./downloadfile/) | HTML でファイルをダウンロードするリンクを作成する。 |
+| [DownloadFileAuto](./downloadfileauto/) | HTML でファイルをダウンロードするリンクを作成し、2 秒後にダウンロードを開始する。 |
+
+## Detailed Description
+
+Postscript/XPS ファイルを操作するための二次的な関数。
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/misc/downloadfile/_index.md
+++ b/japanese/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "HTML でファイルをダウンロードするリンクを作成する。"
+type: docs
+url: /ja/javascript-cpp/misc/downloadfile/
+---
+
+_HTML でファイルをダウンロードするリンクを作成します._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/japanese/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/japanese/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "HTML でファイルをダウンロードするリンクを作成し、2 秒後にダウンロードを開始する。"
+type: docs
+url: /ja/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+HTML でファイルをダウンロードするリンクを作成し、2 秒後にダウンロードを開始する。
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### パラメーター
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### 備考
+
+Web Worker では動作しません。

--- a/japanese/javascript-cpp/misc/pageabout/_index.md
+++ b/japanese/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "製品に関する情報を取得する。"
+type: docs
+url: /ja/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+製品に関する情報を取得する。
+
+```js
+function AsposePageAbout()
+```
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+| errorCode | コードエラー (0 エラーなし) |
+| errorText | テキストエラー ("" エラーなし) |
+| 製品 | 製品名 |
+| バージョン | 製品バージョン |
+| islicensed | 製品はライセンスされています |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/japanese/javascript-cpp/ps/_index.md
+++ b/japanese/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS 関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "PS ファイルを操作するための関数。"
+weight: 40
+type: docs
+url: /ja/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | PS ファイルの境界を取得します。 |
+| [AsposePSExtractText](./psextracttext/) | PS ファイルからテキストを抽出します。 |
+
+## Detailed Description
+
+PS ファイルを操作します。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/ps/psextracttext/_index.md
+++ b/japanese/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "PS ファイルからテキストを抽出"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+PS ファイルからテキストを抽出します。テキストは、Type 42（TrueType）フォントで記述されているか、またはベクターマップ内に Type 42 フォントを含む Type 0 フォントで記述されている場合にのみ抽出できます。
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| 開始 | int | テキスト抽出を開始するページを指定します。このパラメーターは複数ページのドキュメントで有用です。 |
+| 終了 | int | テキスト抽出を終了するページを指定します。このパラメーターは複数ページのドキュメントで有用です。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | テキスト | 抽出されたテキスト |
+
+### 例
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### 参照
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/japanese/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/japanese/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "バウンディングボックスを取得"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+EPS ファイルを読み取り、%%BoundingBox コメントから EPS 画像のバウンディングボックスを抽出します。存在しない場合はデフォルトページサイズ (0, 0, 595, 842) の境界を使用します。
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | bbox | EPS 画像のバウンディングボックス。 |
+
+### 例
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### 参照
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/japanese/javascript-cpp/xmp/_index.md
+++ b/japanese/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "XMP メタデータ関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS ファイルを操作するための XMP メタデータ関数。"
+weight: 30
+type: docs
+url: /ja/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | XMP メタデータを取得する。 |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | 配列に値を追加する。 |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | 構造体に名前付き値を追加する。 |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | 名前空間 URI を登録し、値を追加する。 |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Postscript ファイルを PDF に結合する。 |
+
+## Detailed Description
+
+Postscript または XPS ファイルを画像または PDF ファイルに変換します。
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/japanese/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMPメタデータを取得"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+PS/EPS ファイルを読み取り、既に存在する場合は XmpMetdata を抽出します。
+EPS ファイルに XMP メタデータが含まれていない場合、PS メタデータコメント (%%Creator、%%CreateDate、%%Title など) の値で埋められた新しいメタデータを取得します。
+XMP メタデータが埋め込まれた EPS ファイルは fileNameResult に保存されます。
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/japanese/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/japanese/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMPメタデータを取得"
+type: docs
+weight: 20
+url: /ja/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+配列に値を追加します。値は配列の末尾に追加されます。
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/japanese/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/japanese/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMPメタデータを取得"
+type: docs
+weight: 30
+url: /ja/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+構造体に名前付き値を追加する。
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/japanese/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/japanese/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMPメタデータを取得"
+type: docs
+weight: 40
+url: /ja/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+名前空間 URI を登録し、値を追加する。
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/japanese/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/japanese/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMPメタデータを取得"
+type: docs
+weight: 40
+url: /ja/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+構造体に名前付き値を追加する。
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+| fileNameResult | 文字列 | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 参照
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/japanese/javascript-cpp/xps/_index.md
+++ b/japanese/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS 関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルを操作するための関数。"
+weight: 42
+type: docs
+url: /ja/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | xps-document のページ数を取得します。 |
+
+## Detailed Description
+
+XPS ファイルを操作します。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/japanese/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPSファイルのページ数を取得"
+type: docs
+weight: 10
+url: /ja/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+xps-document のページ数を取得します。
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| パラメーター | タイプ | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | 文字列 | ソースファイル名。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | pageCount | ページ数 |
+
+### 例
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `japanese/javascript-cpp`

🤖 Generated by RDA