### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Korean

### DIFF
--- a/korean/javascript-cpp/convert/_index.md
+++ b/korean/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "변환 기능"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript/XPS 파일 작업을 위한 변환 기능."
+weight: 10
+type: docs
+url: /ko/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Postscript 파일을 이미지로 변환. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Postscript 파일을 PDF로 변환. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | XPS 파일을 이미지로 변환. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | XPS 파일을 PDF로 변환. |
+
+## Detailed Description
+
+Postscript 또는 XPS 파일을 이미지 또는 PDF 파일로 변환.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/korean/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript를 이미지로 변환합니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript를 이미지로 변환합니다.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴의 내용. |
+| fileName | string | 파일 이름. |
+| imageFormat | ImageFormat | 변환할 이미지 형식. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/korean/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/korean/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript를 PDF로 변환합니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Postscript를 PDF로 변환합니다.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴의 내용. |
+| fileName | string | 파일 이름. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/korean/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/korean/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XPS를 이미지로 변환합니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript를 이미지로 변환합니다.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴의 내용. |
+| fileName | string | 파일 이름. |
+| imageFormat | ImageFormat | 변환할 이미지 형식. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/korean/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/korean/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XPS를 PDF로 변환합니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+XPS를 PDF로 변환합니다.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴의 내용. |
+| fileName | string | 파일 이름. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/korean/javascript-cpp/core/_index.md
+++ b/korean/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "핵심 함수"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript/XPS 파일 작업을 위한 핵심 함수."
+weight: 60
+type: docs
+url: /ko/javascript-cpp/core/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | 처리를 위해 메모리 FS에 BLOB을 저장합니다. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | 처리를 위해 메모리 FS에 문자열 표현 BLOB을 저장합니다. |
+
+## Detailed Description
+
+Postscript/XPS 파일 작업을 위한 핵심 함수.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/core/asposepageprepare/_index.md
+++ b/korean/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "처리를 위해 메모리 FS에 BLOB을 저장합니다."
+type: docs
+url: /ko/javascript-cpp/core/asposepageprepare/
+---
+
+_처리를 위해 메모리 파일 시스템에 BLOB을 저장합니다._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON 객체
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/korean/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/korean/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "처리를 위해 메모리 FS에 문자열 표현 BLOB을 저장합니다."
+type: docs
+url: /ko/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_처리를 위해 메모리 파일 시스템에 문자열 표현 BLOB을 저장합니다._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### 비고
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### 예제
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/korean/javascript-cpp/enumerations/_index.md
+++ b/korean/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "열거형"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "폰트를 TrueType 형식으로 변환하는 함수."
+weight: 80
+type: docs
+url: /ko/javascript-cpp/enumerations/
+---
+
+## 열거형
+
+| 열거 | 설명 |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | 이미지 형식을 지정합니다. |
+| [Units](./units/) | 크기 유형을 지정합니다. |

--- a/korean/javascript-cpp/enumerations/imageformat/_index.md
+++ b/korean/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "열거형 ImageFormat"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "ImageFormat 열거형. 이미지 형식을 지정합니다."
+type: docs
+weight: 100
+url: /ko/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+이미지 형식을 지정합니다.
+
+```csharp
+public enum ImageFormat
+```
+
+### 값
+
+| 이름 | 값 | 설명 |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP 이미지 형식. |
+| Jpeg | `1` | JPG 이미지 형식. |
+| Gif | `2` | GIF 이미지 형식. |
+| Tiff | `3` | TIFF 이미지 형식. |
+

--- a/korean/javascript-cpp/enumerations/units/_index.md
+++ b/korean/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Units 열거형. 크기 유형을 지정합니다."
+type: docs
+weight: 100
+url: /ko/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+크기 유형을 지정합니다.
+
+```js
+enum Units
+```
+
+### 값
+
+| 이름 | 값 | 설명 |
+| ---        | ---   | --- |
+| Points | `0` | 포인트(인치의 1/72). |
+| Inches | `1` | 인치. |
+| Millimeters | `2` | 밀리미터. |
+| Centimeters | `3` | 센티미터. |
+| Percents | `4` | 기존 크기의 백분율. |

--- a/korean/javascript-cpp/eps/_index.md
+++ b/korean/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "EPS 기능"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "EPS 파일 작업을 위한 기능."
+weight: 41
+type: docs
+url: /ko/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS 파일을 자르기. |
+| [AsposeResizeEPS](./resizeeps/) | EPS 파일 크기 조정. |
+
+## Detailed Description
+
+EPS 파일 크기 조작.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/eps/cropeps/_index.md
+++ b/korean/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "EPS 자르기"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+EPS 파일을 자릅니다. 기존 %%BoundingBox를 업데이트한 초기 EPS 파일을 저장하거나 새 파일이 생성됩니다.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+| 왼쪽 | float | 자르기 상자의 왼쪽 경계를 지정합니다. |
+| 위쪽 | float | 자르기 상자의 위쪽 경계를 지정합니다. |
+| 오른쪽 | float | 자르기 상자의 오른쪽 경계를 지정합니다. |
+| 아래쪽 | float | 자르기 상자의 아래쪽 경계를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/korean/javascript-cpp/eps/resizeeps/_index.md
+++ b/korean/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "EPS 크기 조정"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+EPS 파일의 크기를 조정합니다. 기존 %%BoundingBox를 업데이트한 초기 EPS 파일을 저장하거나 새로운 %%BoundingBox가 생성됩니다.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+| width | float | 새 경계 상자의 너비를 지정합니다. |
+| height | float | 새 경계 상자의 높이를 지정합니다. |
+| unit | Module.Units | 새 크기의 유형을 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/korean/javascript-cpp/image/_index.md
+++ b/korean/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "이미지 함수"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "이미지 파일 작업을 위한 함수."
+weight: 50
+type: docs
+url: /ko/javascript-cpp/image/
+---
+
+## Image Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | 이미지 파일을 EPS 형식으로 저장합니다. |
+
+## Detailed Description
+
+가장 많이 사용되는 형식의 이미지를 BMP, PNG, JPEG, GOF, TIFF 형식으로 EPS 파일에 저장합니다.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/image/saveimageaseps/_index.md
+++ b/korean/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "EPS 크기 조정"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+EPS 파일의 크기를 조정합니다. 기존 %%BoundingBox를 업데이트한 초기 EPS 파일을 저장하거나 새로운 %%BoundingBox가 생성됩니다.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+

--- a/korean/javascript-cpp/merge/_index.md
+++ b/korean/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "병합 기능"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript/XPS 파일 작업을 위한 병합 기능."
+weight: 20
+type: docs
+url: /ko/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Postscript 파일을 PDF로 병합합니다. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | XPS 파일을 PDF로 병합합니다. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | XPS 파일을 XPS 파일로 병합합니다. |
+
+## Detailed Description
+
+여러 postscript 또는 xps 파일을 하나의 pdf 파일로 병합하거나 여러 xps 파일을 하나의 xps 파일로 병합합니다.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/korean/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript 파일을 PDF로 병합합니다"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Postscript 파일을 PDF로 병합합니다.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileNames | string | 병합할 파일들의 이름. |
+| fileNameResult | string | 결과 PDF 파일의 이름. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/korean/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/korean/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XPS 파일을 PDF로 병합합니다"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+XPS 파일을 PDF로 병합합니다.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileNames | string | 병합할 파일들의 이름. |
+| fileNameResult | string | 결과 PDF 파일의 이름. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/korean/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/korean/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XPS 파일을 하나의 XPS로 병합합니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+여러 XPS 파일을 하나의 XPS 파일로 병합합니다.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileNames | string | 병합할 파일들의 이름. |
+| fileNameResult | string | 결과 XPS 파일의 이름. |
+| supressErrors | bool | 오류를 억제할지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/korean/javascript-cpp/misc/_index.md
+++ b/korean/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "기타 함수"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "Postscript/XPS 파일 작업을 위한 보조 함수."
+weight: 90
+type: docs
+url: /ko/javascript-cpp/misc/
+---
+## Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | 제품에 대한 정보를 가져옵니다. |
+| [DownloadFile](./downloadfile/) | HTML에서 파일을 다운로드하는 링크를 만듭니다. |
+| [DownloadFileAuto](./downloadfileauto/) | HTML에서 파일을 다운로드하는 링크를 만들고 2초 후에 다운로드를 시작합니다. |
+
+## Detailed Description
+
+Postscript/XPS 파일 작업을 위한 보조 함수.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/misc/downloadfile/_index.md
+++ b/korean/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "HTML에서 파일을 다운로드하는 링크를 만듭니다."
+type: docs
+url: /ko/javascript-cpp/misc/downloadfile/
+---
+
+_HTML에서 파일을 다운로드하기 위한 링크를 만듭니다._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/korean/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/korean/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "HTML에서 파일을 다운로드하는 링크를 만들고 2초 후에 다운로드를 시작합니다."
+type: docs
+url: /ko/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+HTML에서 파일을 다운로드하는 링크를 만들고 2초 후에 다운로드를 시작합니다.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### 매개변수
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### 비고
+
+Web Worker에서 작동하지 않습니다.

--- a/korean/javascript-cpp/misc/pageabout/_index.md
+++ b/korean/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "제품에 대한 정보를 가져옵니다."
+type: docs
+url: /ko/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+제품에 대한 정보를 가져옵니다.
+
+```js
+function AsposePageAbout()
+```
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+| errorCode | 코드 오류 (0 오류 없음) |
+| errorText | 텍스트 오류 (\"\" 오류 없음) |
+| 제품 | 제품 이름 |
+| 버전 | 제품 버전 |
+| islicensed | 제품이 라이선스되었습니다 |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/korean/javascript-cpp/ps/_index.md
+++ b/korean/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS 기능"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "PS 파일 작업을 위한 기능."
+weight: 40
+type: docs
+url: /ko/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | PS 파일의 경계 가져오기. |
+| [AsposePSExtractText](./psextracttext/) | PS 파일에서 텍스트 추출. |
+
+## Detailed Description
+
+PS 파일 조작.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/ps/psextracttext/_index.md
+++ b/korean/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "PS 파일에서 텍스트를 추출합니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+PS 파일에서 텍스트를 추출합니다. 텍스트는 Type 42 (TrueType) 글꼴이나 Type 0 글꼴에 Type 42 글꼴이 포함된 Vector Map으로 작성된 경우에만 추출할 수 있습니다.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| 시작 | int | 텍스트 추출을 시작할 페이지를 지정합니다. 이 매개변수는 다중 페이지 문서에 유용합니다. |
+| 끝 | int | 텍스트 추출을 마칠 페이지를 지정합니다. 이 매개변수는 다중 페이지 문서에 유용합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | 텍스트 | 추출된 텍스트 |
+
+### 예제
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### 참조
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/korean/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/korean/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "경계 상자를 가져옵니다."
+type: docs
+weight: 10
+url: /ko/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+EPS 파일을 읽고 %%BoundingBox 주석에서 EPS 이미지의 경계 상자를 추출하거나, 존재하지 않을 경우 기본 페이지 크기 (0, 0, 595, 842)의 경계 값을 사용합니다.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | bbox | EPS 이미지의 경계 상자. |
+
+### 예제
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### 참조
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/korean/javascript-cpp/xmp/_index.md
+++ b/korean/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "XMP 메타데이터 함수"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "EPS 파일 작업을 위한 XMP 메타데이터 함수."
+weight: 30
+type: docs
+url: /ko/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | XMP 메타데이터를 가져옵니다. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | 값을 배열에 추가합니다. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | 명명된 값을 구조체에 추가합니다. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | 네임스페이스 URI를 등록하고 값을 추가합니다. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Postscript 파일을 PDF로 병합합니다. |
+
+## Detailed Description
+
+Postscript 또는 XPS 파일을 이미지 또는 PDF 파일로 변환.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/korean/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+PS/EPS 파일을 읽고 이미 존재한다면 XmpMetdata를 추출합니다.
+EPS 파일에 XMP 메타데이터가 없으면 PS 메타데이터 주석(%%Creator, %%CreateDate, %%Title 등)에서 값을 채워 새로운 메타데이터를 생성합니다.
+채워진 XMP 메타데이터가 포함된 EPS 파일은 fileNameResult에 저장됩니다.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/korean/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/korean/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 20
+url: /ko/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+값을 배열에 추가합니다. 해당 값은 배열의 끝에 추가됩니다.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/korean/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/korean/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 30
+url: /ko/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+명명된 값을 구조체에 추가합니다.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/korean/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/korean/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 40
+url: /ko/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+네임스페이스 URI를 등록하고 값을 추가합니다.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/korean/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/korean/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 40
+url: /ko/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+명명된 값을 구조체에 추가합니다.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 참조
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/korean/javascript-cpp/xps/_index.md
+++ b/korean/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS 기능"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XPS 파일 작업을 위한 기능."
+weight: 42
+type: docs
+url: /ko/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| 함수 | 설명 |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | xps-document의 페이지 수 가져오기. |
+
+## Detailed Description
+
+XPS 파일을 조작합니다.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/korean/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page JavaScript용 C++를 통해"
+description: "XPS 파일의 페이지 수 가져오기"
+type: docs
+weight: 10
+url: /ko/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+xps-document의 페이지 수 가져오기.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 (\"\" 오류 없음) |
+|  | pageCount | 페이지 수 |
+
+### 예제
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `korean/javascript-cpp`

🤖 Generated by RDA