### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Netherlands

### DIFF
--- a/netherlands/javascript-cpp/convert/_index.md
+++ b/netherlands/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Conversiefuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Conversiefuncties voor het werken met Postscript/XPS-bestanden."
+weight: 10
+type: docs
+url: /nl/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Converteer een Postscript-bestand naar afbeelding. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Converteer een Postscript-bestand naar PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Converteer een XPS-bestand naar afbeelding. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Converteer een XPS-bestand naar PDF. |
+
+## Detailed Description
+
+Converteer een Postscript- of XPS-bestand naar afbeelding of PDF-bestand.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/netherlands/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de Postscript naar afbeelding"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Converteert de Postscript naar afbeelding.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| imageFormat | ImageFormat | afbeeldingsformaat om naar te converteren. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/netherlands/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/netherlands/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de Postscript naar PDF"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converteert de Postscript naar PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/netherlands/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/netherlands/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de XPS naar afbeelding"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Converteert de Postscript naar afbeelding.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| imageFormat | ImageFormat | afbeeldingsformaat om naar te converteren. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/netherlands/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/netherlands/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de XPS naar PDF"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converteert de XPS naar PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/netherlands/javascript-cpp/core/_index.md
+++ b/netherlands/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Kernfuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Kernfuncties voor het werken met Postscript/XPS‑bestanden."
+weight: 60
+type: docs
+url: /nl/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Sla de BLOB op in het Memory‑FS voor verwerking. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Sla de BLOB met tekenreeksrepresentatie op in het Memory‑FS voor verwerking. |
+
+## Detailed Description
+
+Kernfuncties voor het werken met Postscript/XPS‑bestanden.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/core/asposepageprepare/_index.md
+++ b/netherlands/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Sla de BLOB op in het Memory‑FS voor verwerking."
+type: docs
+url: /nl/javascript-cpp/core/asposepageprepare/
+---
+
+_Sla de BLOB op in het geheugen‑FS voor verwerking._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON-object
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/netherlands/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/netherlands/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Sla de BLOB met tekenreeksrepresentatie op in het Memory‑FS voor verwerking."
+type: docs
+url: /nl/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Sla de stringrepresentatie van de BLOB op in het geheugen‑FS voor verwerking._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Opmerkingen
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Voorbeelden
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/netherlands/javascript-cpp/enumerations/_index.md
+++ b/netherlands/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Enumeraties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het converteren van lettertypen naar TrueType‑formaten."
+weight: 80
+type: docs
+url: /nl/javascript-cpp/enumerations/
+---
+
+## Enumeraties
+
+| Enumeratie | Beschrijving |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Specificeert afbeeldingsformaat. |
+| [Units](./units/) | Specificeert type van grootte. |

--- a/netherlands/javascript-cpp/enumerations/imageformat/_index.md
+++ b/netherlands/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "ImageFormat enum. Specificeert afbeeldingsformaat"
+type: docs
+weight: 100
+url: /nl/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Specificeert afbeeldingsformaat.
+
+```csharp
+public enum ImageFormat
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP-afbeeldingsformaat. |
+| Jpeg | `1` | JPG-afbeeldingsformaat. |
+| Gif | `2` | GIF-afbeeldingsformaat. |
+| Tiff | `3` | TIFF-afbeeldingsformaat. |
+

--- a/netherlands/javascript-cpp/enumerations/units/_index.md
+++ b/netherlands/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Units-enum. Specificeert het type grootte."
+type: docs
+weight: 100
+url: /nl/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Specificeert type van grootte.
+
+```js
+enum Units
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| ---        | ---   | --- |
+| Points | `0` | Punten (1/72 van een inch). |
+| Inches | `1` | Inches. |
+| Millimeters | `2` | Millimeters. |
+| Centimeters | `3` | Centimeters. |
+| Percents | `4` | Percenten van bestaande grootte. |

--- a/netherlands/javascript-cpp/eps/_index.md
+++ b/netherlands/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "EPS-functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met EPS-bestanden."
+weight: 41
+type: docs
+url: /nl/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS-bestand bijsnijden. |
+| [AsposeResizeEPS](./resizeeps/) | EPS-bestand van formaat wijzigen. |
+
+## Detailed Description
+
+Grootte van EPS-bestand manipuleren.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/eps/cropeps/_index.md
+++ b/netherlands/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Crop EPS"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Crop EPS-bestand. Het slaat het oorspronkelijke EPS-bestand op met een bijgewerkte bestaande %%BoundingBox of er wordt een nieuwe aangemaakt.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+| links | float | Specificeert de linkse grens van de bijsnijdingsbox. |
+| boven | float | Specificeert de bovenste grens van de bijsnijdingsbox. |
+| rechts | float | Specificeert de rechtergrens van de bijsnijdingsbox. |
+| onder | float | Specificeert de ondergrens van de bijsnijdingsbox. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/netherlands/javascript-cpp/eps/resizeeps/_index.md
+++ b/netherlands/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "EPS-schalen"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Schaalt EPS-bestand. Het slaat het oorspronkelijke EPS-bestand op met een bijgewerkte bestaande %%BoundingBox of er wordt een nieuwe aangemaakt.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+| width | float | Specificeert breedte van nieuw begrenzingsvak. |
+| height | float | Specificeert hoogte van nieuw begrenzingsvak. |
+| unit | Module.Units | Specificeert type van de nieuwe grootte. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/netherlands/javascript-cpp/image/_index.md
+++ b/netherlands/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Afbeeldingsfuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met afbeeldingsbestanden."
+weight: 50
+type: docs
+url: /nl/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Sla afbeeldingsbestand op als EPS. |
+
+## Detailed Description
+
+Sla afbeelding van de meest populaire formaten op als BMP, PNG, JPEG, GOF, TIFF als EPS‑bestand.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/image/saveimageaseps/_index.md
+++ b/netherlands/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "EPS-schalen"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Schaalt EPS-bestand. Het slaat het oorspronkelijke EPS-bestand op met een bijgewerkte bestaande %%BoundingBox of er wordt een nieuwe aangemaakt.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+

--- a/netherlands/javascript-cpp/merge/_index.md
+++ b/netherlands/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Samenvoegfuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Samenvoegfuncties voor het werken met Postscript/XPS-bestanden."
+weight: 20
+type: docs
+url: /nl/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Voeg Postscript‑bestanden samen tot PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Voeg een XPS-bestand samen tot PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Voeg een XPS-bestand samen tot XPS-bestand. |
+
+## Detailed Description
+
+Voeg meerdere Postscript- of XPS-bestanden samen tot één PDF-bestand of meerdere XPS-bestanden tot één XPS-bestand.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/netherlands/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Combineer de Postscript-bestanden naar PDF"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Combineer de Postscript-bestanden naar PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileNames | string | De namen van bestanden voor samenvoegen. |
+| fileNameResult | string | De naam van het resulterende pdf-bestand. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/netherlands/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/netherlands/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Combineer de XPS-bestanden naar PDF"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Combineer de XPS-bestanden naar PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileNames | string | De namen van bestanden voor samenvoegen. |
+| fileNameResult | string | De naam van het resulterende pdf-bestand. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/netherlands/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/netherlands/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Combineer de XPS-bestanden tot één XPS"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Combineer de verschillende XPS-bestanden tot één XPS-bestand.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileNames | string | De namen van bestanden voor samenvoegen. |
+| fileNameResult | string | De naam van het resulterende xps-bestand. |
+| supressErrors | bool | Specificeert of fouten onderdrukt moeten worden of niet. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/netherlands/javascript-cpp/misc/_index.md
+++ b/netherlands/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Diverse functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Secundaire functies voor het werken met Postscript/XPS‑bestanden."
+weight: 90
+type: docs
+url: /nl/javascript-cpp/misc/
+---
+## Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Haal informatie op over Product. |
+| [DownloadFile](./downloadfile/) | Maak een link in HTML om het bestand te downloaden. |
+| [DownloadFileAuto](./downloadfileauto/) | Maak een link in HTML om het bestand te downloaden en start de download na 2 seconden. |
+
+## Detailed Description
+
+Secundaire functies voor het werken met Postscript/XPS‑bestanden.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/misc/downloadfile/_index.md
+++ b/netherlands/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Maak een link in HTML om het bestand te downloaden."
+type: docs
+url: /nl/javascript-cpp/misc/downloadfile/
+---
+
+_Maak een link in HTML om het bestand te downloaden._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/netherlands/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/netherlands/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Maak een link in HTML om het bestand te downloaden en start de download na 2 seconden."
+type: docs
+url: /nl/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Maak een link in HTML om het bestand te downloaden en start de download na 2 seconden.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parameters
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Opmerkingen
+
+Werkt niet in Web Worker.

--- a/netherlands/javascript-cpp/misc/pageabout/_index.md
+++ b/netherlands/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal informatie op over Product."
+type: docs
+url: /nl/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Haal informatie op over Product.
+
+```js
+function AsposePageAbout()
+```
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+| errorCode | codefout (0 geen fout) |
+| errorText | tekstfout ("" geen fout) |
+| product | Productnaam |
+| versie | Productversie |
+| islicensed | Product is gelicentieerd |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/netherlands/javascript-cpp/ps/_index.md
+++ b/netherlands/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS-functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met PS-bestanden."
+weight: 40
+type: docs
+url: /nl/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Haal de grenzen van PS-bestand op. |
+| [AsposePSExtractText](./psextracttext/) | Extraheer tekst uit PS-bestand. |
+
+## Detailed Description
+
+PS-bestand manipuleren.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/ps/psextracttext/_index.md
+++ b/netherlands/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Extraheer tekst uit PS-bestand"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extraheer tekst uit PS-bestand. De tekst kan alleen worden geëxtraheerd als deze is geschreven met Type 42 (TrueType)-lettertype of Type 0-lettertype met Type 42-lettertypen in de Vector Map.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| start | int | Specificeert de pagina waarvan de tekst moet worden geëxtraheerd. Deze parameter is handig voor documenten met meerdere pagina's. |
+| einde | int | Specificeert de pagina tot waar de tekst moet worden geëxtraheerd. Deze parameter is handig voor documenten met meerdere pagina's. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | tekst | de geëxtraheerde tekst |
+
+### Voorbeelden
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Zie ook
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/netherlands/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/netherlands/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal begrenzingsvak op"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Leest EPS-bestand en extraheert het begrenzingsvak van de EPS-afbeelding uit de %%BoundingBox-opmerking of de grenzen voor de standaard paginagrootte (0, 0, 595, 842) als deze niet bestaat.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | bbox | het begrenzingsvak van de EPS-afbeelding. |
+
+### Voorbeelden
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Zie ook
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/netherlands/javascript-cpp/xmp/_index.md
+++ b/netherlands/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "XMP‑metadatafuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP‑metadatafuncties voor het werken met EPS‑bestanden."
+weight: 30
+type: docs
+url: /nl/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Haal XMP‑metadata op. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Voegt een waarde toe aan een array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Voegt een benoemde waarde toe aan een structuur. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registreert namespace‑URI en voegt waarde toe. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Voeg Postscript‑bestanden samen tot PDF. |
+
+## Detailed Description
+
+Converteer een Postscript- of XPS-bestand naar afbeelding of PDF-bestand.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/netherlands/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal XMP-metadata op"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Leest PS/EPS-bestand en extraheert XmpMetdata als het al bestaat.
+Als het EPS-bestand geen XMP-metadata bevat, krijgen we een nieuwe die is gevuld met waarden uit PS-metadata-commentaren (%%Creator, %%CreateDate, %%Title enz.).
+Het EPS-bestand met ingevulde XMP-metadata wordt opgeslagen in fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata‑waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/netherlands/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/netherlands/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal XMP-metadata op"
+type: docs
+weight: 20
+url: /nl/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Voegt een waarde toe aan een array. De waarde wordt aan het einde van de array toegevoegd.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata‑waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/netherlands/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/netherlands/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal XMP-metadata op"
+type: docs
+weight: 30
+url: /nl/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Voegt een benoemde waarde toe aan een structuur.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata‑waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/netherlands/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/netherlands/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal XMP-metadata op"
+type: docs
+weight: 40
+url: /nl/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registreert namespace‑URI en voegt waarde toe.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata‑waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/netherlands/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/netherlands/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal XMP-metadata op"
+type: docs
+weight: 40
+url: /nl/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Voegt een benoemde waarde toe aan een structuur.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata‑waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/netherlands/javascript-cpp/xps/_index.md
+++ b/netherlands/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS-functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met XPS-bestanden."
+weight: 42
+type: docs
+url: /nl/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Functie | Beschrijving |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Haal het aantal pagina's op in het xps-document. |
+
+## Detailed Description
+
+Manipuleer het XPS‑bestand.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/netherlands/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal het aantal pagina's op in XPS-bestand"
+type: docs
+weight: 10
+url: /nl/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Haal het aantal pagina's op in het xps-document.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | pageCount | aantal pagina's |
+
+### Voorbeelden
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Netherlands** (`nl`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `netherlands/javascript-cpp`

🤖 Generated by RDA