### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Russian

### DIFF
--- a/russian/javascript-cpp/convert/_index.md
+++ b/russian/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Функции преобразования"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции преобразования для работы с файлами Postscript/XPS."
+weight: 10
+type: docs
+url: /ru/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Преобразовать файл Postscript в изображение. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Преобразовать файл Postscript в PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Преобразовать файл XPS в изображение. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Преобразовать файл XPS в PDF. |
+
+## Detailed Description
+
+Преобразовать файл postscript или xps в изображение или PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/russian/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует Postscript в изображение"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Преобразует Postscript в изображение.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | строка | Имя файла. |
+| imageFormat | ImageFormat | формат изображения для преобразования. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/russian/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/russian/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует Postscript в PDF"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Преобразует Postscript в PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | строка | Имя файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/russian/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/russian/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует XPS в изображение"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Преобразует Postscript в изображение.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | строка | Имя файла. |
+| imageFormat | ImageFormat | формат изображения для преобразования. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/russian/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/russian/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует XPS в PDF"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Преобразует XPS в PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | строка | Имя файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/russian/javascript-cpp/core/_index.md
+++ b/russian/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Основные функции"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Основные функции для работы с файлами Postscript/XPS."
+weight: 60
+type: docs
+url: /ru/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Сохранить BLOB в памяти FS для обработки. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Сохранить BLOB строкового представления в памяти FS для обработки. |
+
+## Detailed Description
+
+Основные функции для работы с файлами Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/core/asposepageprepare/_index.md
+++ b/russian/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Сохранить BLOB в памяти FS для обработки."
+type: docs
+url: /ru/javascript-cpp/core/asposepageprepare/
+---
+
+_Сохранить BLOB в памяти FS для обработки._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON-объект
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/russian/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/russian/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Сохранить BLOB строкового представления в памяти FS для обработки."
+type: docs
+url: /ru/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Сохранить строковое представление BLOB в памяти FS для обработки._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Примечания
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Примеры
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/russian/javascript-cpp/enumerations/_index.md
+++ b/russian/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Перечисления"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции конвертации шрифтов в форматы TrueType."
+weight: 80
+type: docs
+url: /ru/javascript-cpp/enumerations/
+---
+
+## Перечисления
+
+| Перечисление | Описание |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Указывает формат изображения. |
+| [Units](./units/) | Указывает тип размера. |

--- a/russian/javascript-cpp/enumerations/imageformat/_index.md
+++ b/russian/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Перечисление ImageFormat"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Перечисление ImageFormat. Указывает формат изображения"
+type: docs
+weight: 100
+url: /ru/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Указывает формат изображения.
+
+```csharp
+public enum ImageFormat
+```
+
+### Значения
+
+| Имя | Значение | Описание |
+| ---  | ---   | --- |
+| Bmp | `0` | Формат изображения BMP. |
+| Jpeg | `1` | Формат изображения JPG. |
+| Gif | `2` | Формат изображения GIF. |
+| Tiff | `3` | Формат изображения TIFF. |
+

--- a/russian/javascript-cpp/enumerations/units/_index.md
+++ b/russian/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Перечисление Units"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Перечисление Units. Указывает тип размера"
+type: docs
+weight: 100
+url: /ru/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Указывает тип размера.
+
+```js
+enum Units
+```
+
+### Значения
+
+| Имя | Значение | Описание |
+| ---        | ---   | --- |
+| Points | `0` | Точки (1/72 дюйма). |
+| Inches | `1` | Дюймы. |
+| Millimeters | `2` | Миллиметры. |
+| Centimeters | `3` | Сантиметры. |
+| Percents | `4` | Проценты существующего размера. |

--- a/russian/javascript-cpp/eps/_index.md
+++ b/russian/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Функции EPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с файлами EPS."
+weight: 41
+type: docs
+url: /ru/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Обрезать файл EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Изменить размер файла EPS. |
+
+## Detailed Description
+
+Манипулировать размером файла EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/eps/cropeps/_index.md
+++ b/russian/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Обрезать EPS"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Обрезает EPS‑файл. Сохраняет исходный EPS‑файл с обновлённым существующим %%BoundingBox или создаёт новый.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+| лево | float | Указывает левую границу области обрезки. |
+| верх | float | Указывает верхнюю границу области обрезки. |
+| право | float | Указывает правую границу области обрезки. |
+| низ | float | Указывает нижнюю границу области обрезки. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/russian/javascript-cpp/eps/resizeeps/_index.md
+++ b/russian/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Изменить размер EPS"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Изменяет размер EPS‑файла. Сохраняет исходный EPS‑файл с обновлённым существующим %%BoundingBox или создаёт новый.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+| ширина | float | Указывает ширину нового ограничивающего прямоугольника. |
+| высота | float | Указывает высоту нового ограничивающего прямоугольника. |
+| единица | Module.Units | Указывает тип нового размера. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/russian/javascript-cpp/image/_index.md
+++ b/russian/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Функции изображений"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с файловыми изображениями."
+weight: 50
+type: docs
+url: /ru/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Сохранить файл изображения как EPS. |
+
+## Detailed Description
+
+Сохранить изображение самых популярных форматов BMP, PNG, JPEG, GOF, TIFF как файл EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/image/saveimageaseps/_index.md
+++ b/russian/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Изменить размер EPS"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Изменяет размер EPS‑файла. Сохраняет исходный EPS‑файл с обновлённым существующим %%BoundingBox или создаёт новый.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+

--- a/russian/javascript-cpp/merge/_index.md
+++ b/russian/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Функции слияния"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции слияния для работы с файлами Postscript/XPS."
+weight: 20
+type: docs
+url: /ru/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Объединить файлы Postscript в PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Объединить файлы XPS в PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Объединить файлы XPS в файл XPS. |
+
+## Detailed Description
+
+Объединить несколько файлов postscript или xps в один pdf‑файл или несколько файлов xps в один xps‑файл.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/russian/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Объединить файлы Postscript в PDF"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Объединить файлы Postscript в PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileNames | строка | Имена файлов для объединения. |
+| fileNameResult | строка | Имя результирующего pdf‑файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/russian/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/russian/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Объединить файлы XPS в PDF"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Объединить файлы XPS в PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileNames | строка | Имена файлов для объединения. |
+| fileNameResult | строка | Имя результирующего pdf‑файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/russian/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/russian/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Объединить файлы XPS в один XPS"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Объединить несколько файлов XPS в один XPS‑файл.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileNames | строка | Имена файлов для объединения. |
+| fileNameResult | строка | Имя результирующего xps‑файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/russian/javascript-cpp/misc/_index.md
+++ b/russian/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Разнообразные функции"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Вторичные функции для работы с файлами Postscript/XPS."
+weight: 90
+type: docs
+url: /ru/javascript-cpp/misc/
+---
+## Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Получить информацию о продукте. |
+| [DownloadFile](./downloadfile/) | Создать ссылку в HTML для загрузки файла. |
+| [DownloadFileAuto](./downloadfileauto/) | Создать ссылку в HTML для загрузки файла и начать загрузку через 2 секунды. |
+
+## Detailed Description
+
+Вторичные функции для работы с файлами Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/misc/downloadfile/_index.md
+++ b/russian/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Создать ссылку в HTML для загрузки файла."
+type: docs
+url: /ru/javascript-cpp/misc/downloadfile/
+---
+
+_Создать ссылку в HTML для загрузки файла._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/russian/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/russian/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Создать ссылку в HTML для загрузки файла и начать загрузку через 2 секунды."
+type: docs
+url: /ru/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Создать ссылку в HTML для загрузки файла и начать загрузку через 2 секунды.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Параметры
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Примечания
+
+Не работает в Web Worker.

--- a/russian/javascript-cpp/misc/pageabout/_index.md
+++ b/russian/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить информацию о продукте."
+type: docs
+url: /ru/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Получить информацию о продукте.
+
+```js
+function AsposePageAbout()
+```
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+| errorCode | код ошибки (0 — нет ошибки) |
+| errorText | текст ошибки (\"\" — нет ошибки) |
+| продукт | Название продукта |
+| версия | Версия продукта |
+| лицензировано | Продукт лицензирован |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/russian/javascript-cpp/ps/_index.md
+++ b/russian/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Функции PS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с файлами PS."
+weight: 40
+type: docs
+url: /ru/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Получить границы файла PS. |
+| [AsposePSExtractText](./psextracttext/) | Извлечь текст из файла PS. |
+
+## Detailed Description
+
+Манипулировать файлом PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/ps/psextracttext/_index.md
+++ b/russian/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Извлечь текст из файла PS"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Извлечь текст из файла PS. Текст может быть извлечён только если он записан шрифтом Type 42 (TrueType) или шрифтом Type 0 с шрифтами Type 42 в его векторной карте.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| начало | int | Указывает страницу, с которой начинать извлечение текста. Этот параметр полезен для многостраничных документов. |
+| конец | int | Указывает страницу, до которой следует извлекать текст. Этот параметр полезен для многостраничных документов. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | текст | извлечённый текст |
+
+### Примеры
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### См. также
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/russian/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/russian/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить ограничивающий прямоугольник"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Читает файл EPS и извлекает ограничивающий прямоугольник изображения EPS из комментария %%BoundingBox или границы для размера страницы по умолчанию (0, 0, 595, 842), если он не существует.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | bbox | ограничивающий прямоугольник изображения EPS. |
+
+### Примеры
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### См. также
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/russian/javascript-cpp/xmp/_index.md
+++ b/russian/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Функции метаданных XMP"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции метаданных XMP для работы с файлами EPS."
+weight: 30
+type: docs
+url: /ru/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Получить метаданные XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Добавляет значение в массив. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Добавляет именованное значение в структуру. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Регистрирует URI пространства имён и добавляет значение. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Объединить файлы Postscript в PDF. |
+
+## Detailed Description
+
+Преобразовать файл postscript или xps в изображение или PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/russian/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP-метаданные"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Читает файл PS/EPS и извлекает XmpMetdata, если он уже существует.
+Если файл EPS не содержит XMP‑метаданных, мы получаем новые, заполненные значениями из комментариев метаданных PS (%%Creator, %%CreateDate, %%Title и т.д.).
+Файл EPS с заполненными XMP‑метаданными будет сохранён в fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/russian/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/russian/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP-метаданные"
+type: docs
+weight: 20
+url: /ru/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Добавляет значение в массив. Значение будет добавлено в конец массива.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/russian/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/russian/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP-метаданные"
+type: docs
+weight: 30
+url: /ru/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Добавляет именованное значение в структуру.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/russian/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/russian/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP-метаданные"
+type: docs
+weight: 40
+url: /ru/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Регистрирует URI пространства имён и добавляет значение.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/russian/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/russian/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP-метаданные"
+type: docs
+weight: 40
+url: /ru/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Добавляет именованное значение в структуру.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+| fileNameResult | строка | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/russian/javascript-cpp/xps/_index.md
+++ b/russian/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Функции XPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с файлами XPS."
+weight: 42
+type: docs
+url: /ru/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Функция | Описание |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Получить количество страниц в xps-документе. |
+
+## Detailed Description
+
+Манипулировать файлом XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/russian/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить количество страниц в XPS-файле"
+type: docs
+weight: 10
+url: /ru/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Получить количество страниц в xps-документе.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | строка | Имя исходного файла. |
+
+### Возвращаемое значение
+
+JSON-объект
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 — нет ошибки) |
+|  | errorText | текст ошибки (\"\" — нет ошибки) |
+|  | pageCount | количество страниц |
+
+### Примеры
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Russian** (`ru`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `russian/javascript-cpp`

🤖 Generated by RDA