### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Spanish

### DIFF
--- a/spanish/javascript-cpp/convert/_index.md
+++ b/spanish/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Funciones de conversión"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones de conversión para trabajar con archivos Postscript/XPS."
+weight: 10
+type: docs
+url: /es/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Convertir un archivo Postscript a imagen. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Convertir un archivo Postscript a PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Convertir un archivo XPS a imagen. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Convertir un archivo XPS a PDF. |
+
+## Detailed Description
+
+Convertir archivo postscript o xps a imagen o archivo PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/spanish/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el Postscript a imagen"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Convierte el Postscript a imagen.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente origen para la conversión. |
+| fileName | cadena | Nombre de archivo. |
+| imageFormat | ImageFormat | Formato de imagen al que convertir. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/spanish/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/spanish/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el Postscript a PDF"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convierte el Postscript a PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente origen para la conversión. |
+| fileName | cadena | Nombre de archivo. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/spanish/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/spanish/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el XPS a imagen"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Convierte el Postscript a imagen.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente origen para la conversión. |
+| fileName | cadena | Nombre de archivo. |
+| imageFormat | ImageFormat | Formato de imagen al que convertir. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/spanish/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/spanish/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el XPS a PDF"
+type: docs
+weight: 10
+url: /es/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convierte el XPS a PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente origen para la conversión. |
+| fileName | cadena | Nombre de archivo. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/spanish/javascript-cpp/core/_index.md
+++ b/spanish/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funciones principales"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones principales para trabajar con archivos Postscript/XPS."
+weight: 60
+type: docs
+url: /es/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Guardar el BLOB en el FS de memoria para su procesamiento. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Guardar la representación en cadena del BLOB en el FS de memoria para su procesamiento. |
+
+## Detailed Description
+
+Funciones principales para trabajar con archivos Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/core/asposepageprepare/_index.md
+++ b/spanish/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Guardar el BLOB en el FS de memoria para su procesamiento."
+type: docs
+url: /es/javascript-cpp/core/asposepageprepare/
+---
+
+_Guardar el BLOB en el FS de memoria para procesar._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+Objeto JSON
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/spanish/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/spanish/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Guardar la representación en cadena del BLOB en el FS de memoria para su procesamiento."
+type: docs
+url: /es/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Guardar la representación en cadena del BLOB en el FS de memoria para procesar._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Observaciones
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Ejemplos
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/spanish/javascript-cpp/enumerations/_index.md
+++ b/spanish/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Enumeraciones"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para convertir fuentes a formatos TrueType."
+weight: 80
+type: docs
+url: /es/javascript-cpp/enumerations/
+---
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Especifica el formato de imagen. |
+| [Units](./units/) | Especifica el tipo de tamaño. |

--- a/spanish/javascript-cpp/enumerations/imageformat/_index.md
+++ b/spanish/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enumeración ImageFormat"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Enumeración ImageFormat. Especifica el formato de imagen"
+type: docs
+weight: 100
+url: /es/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Especifica el formato de imagen.
+
+```csharp
+public enum ImageFormat
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| ---  | ---   | --- |
+| Bmp | `0` | Formato de imagen BMP. |
+| Jpeg | `1` | Formato de imagen JPG. |
+| Gif | `2` | Formato de imagen GIF. |
+| Tiff | `3` | Formato de imagen TIFF. |
+

--- a/spanish/javascript-cpp/enumerations/units/_index.md
+++ b/spanish/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Unidades"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Enum de unidades. Especifica el tipo de tamaño"
+type: docs
+weight: 100
+url: /es/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Especifica el tipo de tamaño.
+
+```js
+enum Units
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| ---        | ---   | --- |
+| Points | `0` | Puntos (1/72 de pulgada). |
+| Inches | `1` | Pulgadas. |
+| Millimeters | `2` | Milímetros. |
+| Centimeters | `3` | Centímetros. |
+| Percents | `4` | Porcentajes del tamaño existente. |

--- a/spanish/javascript-cpp/eps/_index.md
+++ b/spanish/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Funciones EPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos EPS."
+weight: 41
+type: docs
+url: /es/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Recortar archivo EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Cambiar el tamaño del archivo EPS. |
+
+## Detailed Description
+
+Manipular el tamaño del archivo EPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/eps/cropeps/_index.md
+++ b/spanish/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Recortar EPS"
+type: docs
+weight: 10
+url: /es/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Recorta el archivo EPS. Guarda el archivo EPS inicial con el %%BoundingBox existente actualizado o se creará uno nuevo.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+| izquierda | flotante | Especifica el límite izquierdo del cuadro de recorte. |
+| superior | flotante | Especifica el límite superior del cuadro de recorte. |
+| derecha | flotante | Especifica el límite derecho del cuadro de recorte. |
+| inferior | flotante | Especifica el límite inferior del cuadro de recorte. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/spanish/javascript-cpp/eps/resizeeps/_index.md
+++ b/spanish/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Redimensionar EPS"
+type: docs
+weight: 10
+url: /es/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Redimensiona el archivo EPS. Guarda el archivo EPS inicial con el %%BoundingBox existente actualizado o se creará uno nuevo.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+| ancho | flotante | Especifica el ancho del nuevo cuadro delimitador. |
+| alto | flotante | Especifica el alto del nuevo cuadro delimitador. |
+| unidad | Module.Units | Especifica el tipo de nuevo tamaño. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/spanish/javascript-cpp/image/_index.md
+++ b/spanish/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Funciones de imagen"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos de imagen."
+weight: 50
+type: docs
+url: /es/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Guardar archivo de imagen como EPS. |
+
+## Detailed Description
+
+Guardar imagen de los formatos más populares como BMP, PNG, JPEG, GOF, TIFF en un archivo EPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/image/saveimageaseps/_index.md
+++ b/spanish/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Redimensionar EPS"
+type: docs
+weight: 10
+url: /es/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Redimensiona el archivo EPS. Guarda el archivo EPS inicial con el %%BoundingBox existente actualizado o se creará uno nuevo.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+

--- a/spanish/javascript-cpp/merge/_index.md
+++ b/spanish/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Funciones de fusión"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones de fusión para trabajar con archivos Postscript/XPS."
+weight: 20
+type: docs
+url: /es/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Combinar archivos Postscript a PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Fusionar archivos XPS a PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Fusionar archivos XPS a un archivo XPS. |
+
+## Detailed Description
+
+Fusionar varios archivos postscript o xps en un archivo pdf o varios archivos xps en un archivo xps.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/spanish/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Combinar los archivos Postscript a PDF"
+type: docs
+weight: 10
+url: /es/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Combinar los archivos Postscript a PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileNames | cadena | Los nombres de los archivos para combinar. |
+| fileNameResult | cadena | El nombre del archivo PDF resultante. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/spanish/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/spanish/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Combinar los archivos XPS a PDF"
+type: docs
+weight: 10
+url: /es/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Combinar los archivos XPS a PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileNames | cadena | Los nombres de los archivos para combinar. |
+| fileNameResult | cadena | El nombre del archivo PDF resultante. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/spanish/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/spanish/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Combinar los archivos XPS en un solo XPS"
+type: docs
+weight: 10
+url: /es/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Combinar varios archivos XPS en un solo archivo XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileNames | cadena | Los nombres de los archivos para combinar. |
+| fileNameResult | cadena | El nombre del archivo XPS resultante. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/spanish/javascript-cpp/misc/_index.md
+++ b/spanish/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funciones misceláneas"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones secundarias para trabajar con archivos Postscript/XPS."
+weight: 90
+type: docs
+url: /es/javascript-cpp/misc/
+---
+## Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Obtener información sobre el Producto. |
+| [DownloadFile](./downloadfile/) | Crear un enlace en HTML para descargar el archivo. |
+| [DownloadFileAuto](./downloadfileauto/) | Crear un enlace en HTML para descargar el archivo e iniciar la descarga después de 2 segundos. |
+
+## Detailed Description
+
+Funciones secundarias para trabajar con archivos Postscript/XPS.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/misc/downloadfile/_index.md
+++ b/spanish/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Crear un enlace en HTML para descargar el archivo."
+type: docs
+url: /es/javascript-cpp/misc/downloadfile/
+---
+
+_Crear un enlace en HTML para descargar el archivo._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/spanish/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/spanish/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Crear un enlace en HTML para descargar el archivo e iniciar la descarga después de 2 segundos."
+type: docs
+url: /es/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Crear un enlace en HTML para descargar el archivo e iniciar la descarga después de 2 segundos.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parámetros
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Observaciones
+
+No funciona en Web Worker.

--- a/spanish/javascript-cpp/misc/pageabout/_index.md
+++ b/spanish/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener información sobre el Producto."
+type: docs
+url: /es/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Obtener información sobre el Producto.
+
+```js
+function AsposePageAbout()
+```
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+| errorCode | código de error (0 sin error) |
+| errorText | texto de error ("" sin error) |
+| producto | Nombre del producto |
+| versión | Versión del producto |
+| está licenciado | El producto está licenciado |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/spanish/javascript-cpp/ps/_index.md
+++ b/spanish/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Funciones PS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos PS."
+weight: 40
+type: docs
+url: /es/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Obtener los límites del archivo PS. |
+| [AsposePSExtractText](./psextracttext/) | Extraer texto del archivo PS. |
+
+## Detailed Description
+
+Manipular archivo PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/ps/psextracttext/_index.md
+++ b/spanish/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Extraer texto del archivo PS"
+type: docs
+weight: 10
+url: /es/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extraer texto del archivo PS. El texto solo puede extraerse si está escrito con una fuente Type 42 (TrueType) o una fuente Type 0 con fuentes Type 42 en su Vector Map.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| inicio | int | Especifica la página desde la cual comenzar a extraer texto. Este parámetro es útil para documentos multipágina. |
+| fin | int | Especifica la página hasta la cual terminar de extraer texto. Este parámetro es útil para documentos multipágina. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | texto | el texto extraído |
+
+### Ejemplos
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Ver también
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/spanish/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/spanish/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener cuadro delimitador"
+type: docs
+weight: 10
+url: /es/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Lee el archivo EPS y extrae el cuadro delimitador de la imagen EPS del comentario %%BoundingBox o los límites para el tamaño de página predeterminado (0, 0, 595, 842) si no existe.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | bbox | el cuadro delimitador de la imagen EPS. |
+
+### Ejemplos
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Ver también
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/spanish/javascript-cpp/xmp/_index.md
+++ b/spanish/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "Funciones de metadatos XMP"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones de metadatos XMP para trabajar con archivos EPS."
+weight: 30
+type: docs
+url: /es/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Obtener metadatos XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Agrega un valor a un arreglo. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Agrega un valor nombrado a una estructura. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registra el URI del espacio de nombres y agrega el valor. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Combinar archivos Postscript a PDF. |
+
+## Detailed Description
+
+Convertir archivo postscript o xps a imagen o archivo PDF.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/spanish/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 10
+url: /es/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Lee el archivo PS/EPS y extrae XmpMetdata si ya existe.
+Si el archivo EPS no contiene metadatos XMP, obtenemos uno nuevo rellenado con valores de los comentarios de metadatos PS (%%Creator, %%CreateDate, %%Title, etc).
+El archivo EPS con metadatos XMP rellenados se guardará en fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/spanish/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/spanish/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 20
+url: /es/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Agrega un valor a una matriz. El valor se añadirá al final de la matriz.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/spanish/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/spanish/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 30
+url: /es/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Agrega un valor nombrado a una estructura.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/spanish/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/spanish/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 40
+url: /es/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registra el URI del espacio de nombres y agrega el valor.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/spanish/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/spanish/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 40
+url: /es/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Agrega un valor nombrado a una estructura.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+| fileNameResult | cadena | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/spanish/javascript-cpp/xps/_index.md
+++ b/spanish/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funciones XPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos XPS."
+weight: 42
+type: docs
+url: /es/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Obtener el número de páginas en el xps-documento. |
+
+## Detailed Description
+
+Manipular el archivo XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/spanish/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener el número de páginas en el archivo XPS"
+type: docs
+weight: 10
+url: /es/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Obtener el número de páginas en el xps-documento.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | cadena | Nombre del archivo fuente. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | código de error (0 sin error) |
+|  | errorText | texto de error ("" sin error) |
+|  | pageCount | número de páginas |
+
+### Ejemplos
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `spanish/javascript-cpp`

🤖 Generated by RDA