### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Swedish

### DIFF
--- a/swedish/javascript-cpp/convert/_index.md
+++ b/swedish/javascript-cpp/convert/_index.md
@@ -1,0 +1,33 @@
+---
+title: "Konverteringsfunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverteringsfunktioner för att arbeta med Postscript/XPS-filer."
+weight: 10
+type: docs
+url: /sv/javascript-cpp/convert/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Konvertera en Postscript-fil till bild. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Konvertera en Postscript-fil till PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Konvertera en XPS-fil till bild. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Konvertera en XPS-fil till PDF. |
+
+## Detailed Description
+
+Konvertera Postscript- eller XPS-fil till bild eller PDF-fil.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/swedish/javascript-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar Postscript till bild"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Konverterar Postscript till bild.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | sträng | Filnamn. |
+| imageFormat | ImageFormat | Bildformat att konvertera till. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fPsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/swedish/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/swedish/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar Postscript till PDF"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konverterar Postscript till PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | sträng | Filnamn. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = PSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/swedish/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/swedish/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,93 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar XPS till bild"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Konverterar Postscript till bild.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | sträng | Filnamn. |
+| imageFormat | ImageFormat | Bildformat att konvertera till. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fXpsAsPng = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsImage(event.target.result, e.target.files[0].name, Module.ImageFormat.Png, true);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Files(pages) count: " + json.filesCount.toString();
+        for (let fileIndex = 0; fileIndex < json.filesCount; fileIndex++) DownloadFile(json.filesNameResult[fileIndex], "image/png");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fXpsAsPng = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PNG and save - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsImage', "params": [event.target.result, e.target.files[0].name, 'Module.ImageFormat.Png'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/swedish/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/swedish/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar XPS till PDF"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konverterar XPS till PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | sträng | Filnamn. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fXpsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = XPSSaveAsPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Convert a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSSaveAsPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/swedish/javascript-cpp/core/_index.md
+++ b/swedish/javascript-cpp/core/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Kärnfunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Kärnfunktioner för att arbeta med Postscript/XPS-filer."
+weight: 60
+type: docs
+url: /sv/javascript-cpp/core/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePagePrepare](./asposepageprepare/) | Spara BLOB i minnes-FS för bearbetning. |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | Spara BLOB:s strängrepresentation i minnes-FS för bearbetning. |
+
+## Detailed Description
+
+Kärnfunktioner för att arbeta med Postscript/XPS-filer.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/core/asposepageprepare/_index.md
+++ b/swedish/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,0 +1,68 @@
+---
+title: "AsposePagePrepare"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Spara BLOB i minnes-FS för bearbetning."
+type: docs
+url: /sv/javascript-cpp/core/asposepageprepare/
+---
+
+_Spara BLOB i Memory FS för bearbetning._
+
+```js
+function AsposePagePrepare(
+    fileBlob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **fileBlob** Blob object 
+* **fileName** file name 
+
+**Return**: 
+JSON-objekt
+  * **errorCode** - code error (0 no error)
+  * **errorText** - text error ("" no error)
+  * **fileNameResult** - result file name
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode == 0) ?
+        `Result:\n${(evt.data.operation == 'AsposePagePrepare') ?
+          'Saved the BLOB to memory FS for processing':
+          '...main operation, see AsposePageAddImage as an example...'}` :
+        `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const ffileImage = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePageWebWorker.postMessage(
+        { "operation": 'AsposePagePrepare', "params": [event.target.result, e.target.files[0].name] },
+        [event.target.result]
+      );
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```
+**Simple example**:
+```js
+  var ffileImage = function (e) {
+    const file_reader = new FileReader();
+    /*Set the image filename*/
+    const fileImage = e.target.files[0].name;
+    file_reader.onload = (event) => {
+      /*Save the BLOB in the Memory FS for processing*/
+      AsposePagePrepare(event.target.result, fileImage);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/swedish/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,0 +1,66 @@
+---
+title: "AsposePagePrepareBase64"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Spara BLOB:s strängrepresentation i minnes-FS för bearbetning."
+type: docs
+url: /sv/javascript-cpp/core/asposepagepreparebase64/
+---
+## AsposePagePrepareBase64 function
+_Spara strängrepresentationen av BLOB i Memory FS för bearbetning._
+
+```js
+function AsposePagePrepareBase64(
+    base64Blob,
+    fileName
+)
+```
+
+**Parameters**: 
+
+* **base64Blob** string representation Blob object, with format "data:mime/type;base64,...", where 'mime/type': image/png, application/octet-stream, ...
+* **fileName** file name 
+
+### Anmärkningar
+**AsposePagePrepareBase64** doesn't work in Web Worker mode, use AsposePagePrepare
+
+### Exempel
+```js
+  const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 
+      AsposePagePrepareBase64(test_pfx, 'test.pfx') ?? 'loaded!' :
+        (evt.data.json.errorCode == 0) ?
+          `Result:${'Saved the base64 data to memory FS'}` :
+          `Error: ${evt.data.json.errorText}`;
+  
+  /*AsposePagePrepareBase64 for Web Worker*/
+  const AsposePagePrepareBase64 = (base64, filename) =>
+    fetch(base64)
+      .then(res => res.arrayBuffer())
+        .then(buffer => {
+            const file_reader = new FileReader();
+            /*Ask Web Worker */
+            file_reader.onload = event => AsposePageWebWorker.postMessage(
+                 { "operation": 'AsposePagePrepare', "params": [event.target.result, filename] },
+                 [event.target.result]
+               );
+            file_reader.readAsArrayBuffer(new File([new Uint8Array(buffer)], filename));
+          }
+        );
+```
+**Simple example**:
+```js
+  var ffileBase64 = function (e) {
+    const test_pfx = "data:application/octet-stream;base64,MIIEcQIBAzCCBDcGCSqGSIb ... ==";
+    /*Save the string representation BLOB in the Memory FS for processing*/
+    AsposePagePrepareBase64(test_pfx,"test.pfx");
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      DownloadFile('test_pfx', "application/image");
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+```

--- a/swedish/javascript-cpp/enumerations/_index.md
+++ b/swedish/javascript-cpp/enumerations/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Enumerationer"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att konvertera typsnitt till TrueType-format."
+weight: 80
+type: docs
+url: /sv/javascript-cpp/enumerations/
+---
+
+## Enumerationer
+
+| Uppräkning | Beskrivning |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Anger bildformat. |
+| [Units](./units/) | Anger typ av storlek. |

--- a/swedish/javascript-cpp/enumerations/imageformat/_index.md
+++ b/swedish/javascript-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "ImageFormat enum. Anger bildformat"
+type: docs
+weight: 100
+url: /sv/javascript-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Anger bildformat.
+
+```csharp
+public enum ImageFormat
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP bildformat. |
+| Jpeg | `1` | JPG bildformat. |
+| Gif | `2` | GIF bildformat. |
+| Tiff | `3` | TIFF bildformat. |
+

--- a/swedish/javascript-cpp/enumerations/units/_index.md
+++ b/swedish/javascript-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Enheter"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Units-enum. Anger typ av storlek"
+type: docs
+weight: 100
+url: /sv/javascript-cpp/enumerations/units/
+---
+## Units enumeration
+
+Anger typ av storlek.
+
+```js
+enum Units
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| ---        | ---   | --- |
+| Points | `0` | Punkter (1/72 tum). |
+| Inches | `1` | Tum. |
+| Millimeters | `2` | Millimeter. |
+| Centimeters | `3` | Centimeter. |
+| Percents | `4` | Procent av befintlig storlek. |

--- a/swedish/javascript-cpp/eps/_index.md
+++ b/swedish/javascript-cpp/eps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "EPS-funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med EPS-filer."
+weight: 41
+type: docs
+url: /sv/javascript-cpp/eps/
+---
+
+## EPS Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Beskär EPS-fil. |
+| [AsposeResizeEPS](./resizeeps/) | Ändra storlek på EPS-fil. |
+
+## Detailed Description
+
+Manipulera storleken på EPS-fil.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/eps/cropeps/_index.md
+++ b/swedish/javascript-cpp/eps/cropeps/_index.md
@@ -1,0 +1,96 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Beskär EPS"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Beskär EPS-filen. Den sparar den ursprungliga EPS-filen med uppdaterad befintlig %%BoundingBox eller en ny kommer att skapas.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+| vänster | flyttal | Anger vänstergräns för beskärningsrutan. |
+| övre | flyttal | Anger övre gräns för beskärningsrutan. |
+| höger | flyttal | Anger högra gränsen för beskärningsrutan. |
+| nedre | flyttal | Anger nedre gräns för beskärningsrutan. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fCropEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeCropEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_crop.eps", 30, 5, 240, 36);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fCropEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeCropEPS', "params": [event.target.result, e.target.files[0].name, 30, 5, 240, 36] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/swedish/javascript-cpp/eps/resizeeps/_index.md
+++ b/swedish/javascript-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,95 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Ändra storlek på EPS"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Ändrar storlek på EPS-fil. Den sparar den ursprungliga EPS-filen med uppdaterad befintlig %%BoundingBox eller en ny kommer att skapas.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+| bredd | flyttal | Anger bredden på den nya begränsningsrutan. |
+| höjd | flyttal | Anger höjden på den nya begränsningsrutan. |
+| enhet | Module.Units | Anger typ av ny storlek. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fResizeEPS = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeResizeEPS(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_resized.eps", 200, 100, Module.Units.Points);
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fResizeEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeResizeEPS', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_resized.eps", 200, 100, 'Module.Units.Points'] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/swedish/javascript-cpp/image/_index.md
+++ b/swedish/javascript-cpp/image/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Bildfunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med bildfiler."
+weight: 50
+type: docs
+url: /sv/javascript-cpp/image/
+---
+
+## Image Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Spara bildfil som EPS. |
+
+## Detailed Description
+
+Spara bild i de mest populära formaten BMP, PNG, JPEG, GOF, TIFF som EPS-fil.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/image/saveimageaseps/_index.md
+++ b/swedish/javascript-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,87 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Ändra storlek på EPS"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Ändrar storlek på EPS-fil. Den sparar den ursprungliga EPS-filen med uppdaterad befintlig %%BoundingBox eller en ny kommer att skapas.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fSaveImageAsEps = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeSaveImageAsEps(event.target.result, e.target.files[0].name,  e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fSaveImageAsEps = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeSaveImageAsEps', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+

--- a/swedish/javascript-cpp/merge/_index.md
+++ b/swedish/javascript-cpp/merge/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Sammanfoga funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sammanfogningsfunktioner för att arbeta med Postscript/XPS-filer."
+weight: 20
+type: docs
+url: /sv/javascript-cpp/merge/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Slå ihop Postscript-filer till PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Sammanfoga en XPS-fil till PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Sammanfoga en XPS-fil till XPS-fil. |
+
+## Detailed Description
+
+Sammanfoga flera postscript- eller xps-filer till en pdf-fil eller flera xps-filer till en xps-fil.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/swedish/javascript-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Slå samman Postscript-filerna till PDF"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Slå samman Postscript-filerna till PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileNames | sträng | Namnen på filerna för sammanslagning. |
+| fileNameResult | sträng | Namnet på den resulterande pdf-filen. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a Postscript to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/swedish/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/swedish/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Slå samman XPS-filerna till PDF"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Slå samman XPS-filerna till PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileNames | sträng | Namnen på filerna för sammanslagning. |
+| fileNameResult | sträng | Namnet på den resulterande pdf-filen. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToPdf(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to PDF - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToPdf', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/swedish/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/swedish/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,89 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Slå samman XPS-filerna till en XPS"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Slå samman flera XPS-filer till en XPS-fil.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileNames | sträng | Namnen på filerna för sammanslagning. |
+| fileNameResult | sträng | Namnet på den resulterande xps-filen. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fPsAsPdf = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeXPSMergeToXps(event.target.result, e.target.files[0].name, true);
+      if (json.errorCode == 0) {
+        DownloadFile(json.fileNameResult, "image/pdf");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      /*Merge a XPS to XPS - Ask Web Worker*/
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXPSMergeToXps', "params": [event.target.result, e.target.files[0].name, true] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/swedish/javascript-cpp/misc/_index.md
+++ b/swedish/javascript-cpp/misc/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Diverse funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sekundära funktioner för att arbeta med Postscript/XPS-filer."
+weight: 90
+type: docs
+url: /sv/javascript-cpp/misc/
+---
+## Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Hämta information om produkten. |
+| [DownloadFile](./downloadfile/) | Skapa en länk i HTML för att ladda ner filen. |
+| [DownloadFileAuto](./downloadfileauto/) | Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder. |
+
+## Detailed Description
+
+Sekundära funktioner för att arbeta med Postscript/XPS-filer.
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/misc/downloadfile/_index.md
+++ b/swedish/javascript-cpp/misc/downloadfile/_index.md
@@ -1,0 +1,23 @@
+---
+title: "DownloadFile"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Skapa en länk i HTML för att ladda ner filen."
+type: docs
+url: /sv/javascript-cpp/misc/downloadfile/
+---
+
+_Skapa en länk i HTML för att ladda ner filen._
+
+```js
+function DownloadFile(
+    filename,
+    mime 
+)
+```
+
+**Parameters**:
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+**Doesn't work in Web Worker.**

--- a/swedish/javascript-cpp/misc/downloadfileauto/_index.md
+++ b/swedish/javascript-cpp/misc/downloadfileauto/_index.md
@@ -1,0 +1,27 @@
+---
+title: "DownloadFileAuto"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder."
+type: docs
+url: /sv/javascript-cpp/misc/downloadfileauto/
+---
+
+## DownloadFileAuto function
+
+Skapa en länk i HTML för att ladda ner filen och starta nedladdning efter 2 sekunder.
+
+```js
+function DownloadFileAuto(
+    filename,
+    mime 
+)
+```
+
+### Parametrar
+
+* **fileName** file name
+* **mime** string "mime/type"
+
+### Anmärkningar
+
+Fungerar inte i Web Worker.

--- a/swedish/javascript-cpp/misc/pageabout/_index.md
+++ b/swedish/javascript-cpp/misc/pageabout/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta information om produkten."
+type: docs
+url: /sv/javascript-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Hämta information om produkten.
+
+```js
+function AsposePageAbout()
+```
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+| errorCode | kodfel (0 inget fel) |
+| errorText | textfel ("" inget fel) |
+| produkt | Produktnamn |
+| version | Produktversion |
+| islicensed | Produkten är licensierad |
+
+
+**Web Worker example**:
+```js
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'loaded!' :
+      (evt.data.json.errorCode !== 0) ? `Error: ${evt.data.json.errorText}` :
+                        "Product      : " + evt.data.json.product
+                    + "\nVersion      : " + evt.data.json.version
+                    + "\nIs licensed  : " + evt.data.json.islicensed;
+
+  /*Event handler*/
+  const onAsposePageAbout = e => {
+    /*Get info about Product - Ask Web Worker*/
+    AsposePageWebWorker.postMessage({ "operation": 'AsposePageAbout', "params": [] }, []);
+  };
+```
+**Simple example**:
+```js
+  var onAsposePageAbout = function () {
+    /*Get info about Product*/
+    const json = AsposePageAbout();
+    if (json.errorCode == 0) document.getElementById('output').textContent = "Product      : " + json.product
+                                                                         + "\nVersion      : " + json.version
+                                                                         + "\nIs licensed  : " + json.islicensed;
+    else document.getElementById('output').textContent = json.errorText;
+  }
+```

--- a/swedish/javascript-cpp/ps/_index.md
+++ b/swedish/javascript-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS-funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med PS-filer."
+weight: 40
+type: docs
+url: /sv/javascript-cpp/ps/
+---
+
+## EPS Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Hämta gränserna för PS-fil. |
+| [AsposePSExtractText](./psextracttext/) | Extrahera text från PS-fil. |
+
+## Detailed Description
+
+Manipulera PS-fil.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/ps/psextracttext/_index.md
+++ b/swedish/javascript-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Extrahera text från PS-fil"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extrahera text från PS-fil. Texten kan endast extraheras om den är skriven med Type 42 (TrueType)-teckensnitt eller Type 0-teckensnitt med Type 42-teckensnitt i dess vektorkarta.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| start | int | Anger sidan från vilken texten ska börja extraheras. Denna parameter är användbar för flersidiga dokument. |
+| slut | int | Anger sidan till vilken texten ska avslutas. Denna parameter är användbar för flersidiga dokument. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | text | den extraherade texten |
+
+### Exempel
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Se även
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/swedish/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/swedish/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta begränsningsruta"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Läser EPS-fil och extraherar begränsningsrutan för EPS-bilden från %%BoundingBox-kommentaren eller gränserna för standard sidstorlek (0, 0, 595, 842) om den inte finns.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | bbox | begränsningsrutan för EPS-bilden. |
+
+### Exempel
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Se även
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/swedish/javascript-cpp/xmp/_index.md
+++ b/swedish/javascript-cpp/xmp/_index.md
@@ -1,0 +1,34 @@
+---
+title: "XMP-metadatafunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "XMP-metadatafunktioner för att arbeta med EPS-filer."
+weight: 30
+type: docs
+url: /sv/javascript-cpp/xmp/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Hämta XMP-metadata. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Lägger till värde i en array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Lägger till namngivet värde i en struktur. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registrerar namnrymds-URI och lägger till värde. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Slå ihop Postscript-filer till PDF. |
+
+## Detailed Description
+
+Konvertera Postscript- eller XPS-fil till bild eller PDF-fil.
+
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/swedish/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,93 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Läser PS/EPS-fil och extraherar XmpMetdata om den redan finns.
+Om EPS-filen inte innehåller XMP-metadata får vi en ny som fylls med värden från PS-metadata-kommentarer (%%Creator, %%CreateDate, %%Title osv).
+EPS-filen med ifylld XMP-metadata kommer att sparas i fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeEPSGetXMP(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps");
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeEPSGetXMP', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps"] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/swedish/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/swedish/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 20
+url: /sv/javascript-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Lägger till ett värde i en array. Värdet kommer att läggas till i slutet av arrayen.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/swedish/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/swedish/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 30
+url: /sv/javascript-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Lägger till namngivet värde i en struktur.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/swedish/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/swedish/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 40
+url: /sv/javascript-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registrerar namnrymds-URI och lägger till värde.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/swedish/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/swedish/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 40
+url: /sv/javascript-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Lägger till namngivet värde i en struktur.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+| fileNameResult | sträng | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/swedish/javascript-cpp/xps/_index.md
+++ b/swedish/javascript-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS-funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med XPS-filer."
+weight: 42
+type: docs
+url: /sv/javascript-cpp/xps/
+---
+
+## XPS functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Hämta antalet sidor i xps-dokumentet. |
+
+## Detailed Description
+
+Manipulera XPS-filen.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/swedish/javascript-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta antal sidor i XPS-fil"
+type: docs
+weight: 10
+url: /sv/javascript-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Hämta antalet sidor i xps-dokumentet.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | sträng | Källfilens namn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | pageCount | antal sidor |
+
+### Exempel
+
+```js
+  var fGetPageCount = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposeGetXpsPageCount(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Pages count: " + json.pageCount.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Number of pages      : ${evt.data.json.pageCount}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fGetPagesCount = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeGetXpsPageCount', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `swedish/javascript-cpp`

🤖 Generated by RDA