### PR TITLE
[auto] Translate JAVASCRIPT-CPP API Reference to Chinese

### DIFF
--- a/chinese/javascript-cpp/convert/_index.md
+++ b/chinese/javascript-cpp/convert/_index.md
@@ -18,7 +18,7 @@ url: /zh/javascript-cpp/convert/
 
 ## Detailed Description
 
-将 Postscript 或 XPS 文件转换为图像或 PDF 文件。
+将 postscript 或 XPS 文件转换为图像或 PDF 文件。
 
 
 

--- a/chinese/javascript-cpp/convert/pssaveasimage/_index.md
+++ b/chinese/javascript-cpp/convert/pssaveasimage/_index.md
@@ -22,7 +22,7 @@ function AsposePSSaveAsImage(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 用于转换的源字体内容。 |
-| fileName | string | 文件名。 |
+| fileName | 字符串 | 文件名。 |
 | imageFormat | ImageFormat | 要转换成的图像格式。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
@@ -31,8 +31,8 @@ function AsposePSSaveAsImage(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/convert/pssaveaspdf/_index.md
+++ b/chinese/javascript-cpp/convert/pssaveaspdf/_index.md
@@ -21,7 +21,7 @@ function AsposePSSaveAsPdf(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 用于转换的源字体内容。 |
-| fileName | string | 文件名。 |
+| fileName | 字符串 | 文件名。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
 ### 返回值
@@ -29,8 +29,8 @@ function AsposePSSaveAsPdf(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/convert/xpssaveasimage/_index.md
+++ b/chinese/javascript-cpp/convert/xpssaveasimage/_index.md
@@ -22,7 +22,7 @@ function AsposeXPSSaveAsImage(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 用于转换的源字体内容。 |
-| fileName | string | 文件名。 |
+| fileName | 字符串 | 文件名。 |
 | imageFormat | ImageFormat | 要转换成的图像格式。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
@@ -31,8 +31,8 @@ function AsposeXPSSaveAsImage(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/convert/xpssaveaspdf/_index.md
+++ b/chinese/javascript-cpp/convert/xpssaveaspdf/_index.md
@@ -21,7 +21,7 @@ function AsposeXPSSaveAsPdf(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 用于转换的源字体内容。 |
-| fileName | string | 文件名。 |
+| fileName | 字符串 | 文件名。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
 ### 返回值
@@ -29,8 +29,8 @@ function AsposeXPSSaveAsPdf(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/core/_index.md
+++ b/chinese/javascript-cpp/core/_index.md
@@ -11,8 +11,8 @@ url: /zh/javascript-cpp/core/
 
 | 名称 | 描述 |
 | -------------- | -------------- |
-| [AsposePagePrepare](./asposepageprepare/) | 将 BLOB 保存到内存文件系统以进行处理。 |
-| [AsposePagePrepareBase64](./asposepagereparebase64/) | 将字符串表示的 BLOB 保存到内存文件系统以进行处理。 |
+| [AsposePagePrepare](./asposepageprepare/) | 将 BLOB 保存到内存文件系统 (Memory FS) 以供处理。 |
+| [AsposePagePrepareBase64](./asposepagereparebase64/) | 将字符串表示的 BLOB 保存到内存文件系统 (Memory FS) 以供处理。 |
 
 ## Detailed Description
 

--- a/chinese/javascript-cpp/core/asposepageprepare/_index.md
+++ b/chinese/javascript-cpp/core/asposepageprepare/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "AsposePagePrepare"
 second_title: "Aspose.Page 用于 JavaScript via C++"
-description: "将 BLOB 保存到内存文件系统以进行处理。"
+description: "将 BLOB 保存到内存文件系统 (Memory FS) 以供处理。"
 type: docs
 url: /zh/javascript-cpp/core/asposepageprepare/
 ---
 
-_在内存文件系统中保存 BLOB 以进行处理。_
+_保存 BLOB 到内存文件系统以进行处理。_
 
 ```js
 function AsposePagePrepare(

--- a/chinese/javascript-cpp/core/asposepagepreparebase64/_index.md
+++ b/chinese/javascript-cpp/core/asposepagepreparebase64/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "AsposePagePrepareBase64"
 second_title: "Aspose.Page 用于 JavaScript via C++"
-description: "将字符串表示的 BLOB 保存到内存文件系统以进行处理。"
+description: "将字符串表示的 BLOB 保存到内存文件系统 (Memory FS) 以供处理。"
 type: docs
 url: /zh/javascript-cpp/core/asposepagepreparebase64/
 ---
 ## AsposePagePrepareBase64 function
-_在内存文件系统中保存字符串表示的 BLOB 以进行处理。_
+_保存字符串表示的 BLOB 到内存文件系统以进行处理。_
 
 ```js
 function AsposePagePrepareBase64(

--- a/chinese/javascript-cpp/enumerations/_index.md
+++ b/chinese/javascript-cpp/enumerations/_index.md
@@ -12,4 +12,4 @@ url: /zh/javascript-cpp/enumerations/
 | 枚举 | 描述 |
 | ----------- | ----------- |
 | [ImageFormat](./imageformat/) | 指定图像格式。 |
-| [Units](./units/) | 指定尺寸类型。 |
+| [Units](./units/) | 指定大小的类型。 |

--- a/chinese/javascript-cpp/enumerations/units/_index.md
+++ b/chinese/javascript-cpp/enumerations/units/_index.md
@@ -8,7 +8,7 @@ url: /zh/javascript-cpp/enumerations/units/
 ---
 ## Units enumeration
 
-指定尺寸类型。
+指定大小的类型。
 
 ```js
 enum Units

--- a/chinese/javascript-cpp/eps/_index.md
+++ b/chinese/javascript-cpp/eps/_index.md
@@ -16,7 +16,7 @@ url: /zh/javascript-cpp/eps/
 
 ## Detailed Description
 
-操作 EPS 文件的尺寸。
+操作 EPS 文件的大小。
 
 
 ```js

--- a/chinese/javascript-cpp/eps/cropeps/_index.md
+++ b/chinese/javascript-cpp/eps/cropeps/_index.md
@@ -8,7 +8,7 @@ url: /zh/javascript-cpp/eps/cropeps/
 ---
 ## AsposeCropEPS function
 
-裁剪 EPS 文件。它保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或创建新的。
+裁剪 EPS 文件。它保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或将创建新的。
 
 ```js
 function AsposeCropEPS(
@@ -25,20 +25,20 @@ function AsposeCropEPS(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
-| 左 | float | 指定裁剪框的左边界。 |
-| 上 | float | 指定裁剪框的上边界。 |
-| 右 | float | 指定裁剪框的右边界。 |
-| 下 | float | 指定裁剪框的下边界。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
+| 左 | 浮点数 | 指定裁剪框的左边界。 |
+| 上 | 浮点数 | 指定裁剪框的上边界。 |
+| 右 | 浮点数 | 指定裁剪框的右边界。 |
+| 下 | 浮点数 | 指定裁剪框的下边界。 |
 
 ### 返回值
 
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/eps/resizeeps/_index.md
+++ b/chinese/javascript-cpp/eps/resizeeps/_index.md
@@ -8,7 +8,7 @@ url: /zh/javascript-cpp/eps/resizeeps/
 ---
 ## AsposeResizeEPS function
 
-调整 EPS 文件。它会保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或者创建新的。
+调整 EPS 文件的大小。它会保存原始 EPS 文件，并更新现有的 %%BoundingBox，或创建新的。
 
 ```js
 function AsposeResizeEPS(
@@ -24,19 +24,19 @@ function AsposeResizeEPS(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
-| width | float | 指定新边界框的 width。 |
-| height | float | 指定新边界框的 height。 |
-| unit | Module.Units | 指定新尺寸的类型。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
+| 宽度 | 浮点数 | 指定新边界框的宽度。 |
+| 高度 | 浮点数 | 指定新边界框的高度。 |
+| 单位 | Module.Units | 指定新尺寸的类型。 |
 
 ### 返回值
 
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/image/_index.md
+++ b/chinese/javascript-cpp/image/_index.md
@@ -15,7 +15,7 @@ url: /zh/javascript-cpp/image/
 
 ## Detailed Description
 
-将最流行格式的图像（BMP、PNG、JPEG、GOF、TIFF）保存为 EPS 文件。
+将最流行格式的图像（如 BMP、PNG、JPEG、GOF、TIFF）保存为 EPS 文件。
 
 ```js
 /* Web Worker*/

--- a/chinese/javascript-cpp/image/saveimageaseps/_index.md
+++ b/chinese/javascript-cpp/image/saveimageaseps/_index.md
@@ -8,7 +8,7 @@ url: /zh/javascript-cpp/image/saveimageaseps/
 ---
 ## AsposeSaveImageAsEps function
 
-调整 EPS 文件。它会保存初始 EPS 文件，使用更新的现有 %%BoundingBox，或者创建新的。
+调整 EPS 文件的大小。它会保存原始 EPS 文件，并更新现有的 %%BoundingBox，或创建新的。
 
 ```js
 function AsposeSaveImageAsEps(
@@ -21,16 +21,16 @@ function AsposeSaveImageAsEps(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
 
 ### 返回值
 
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/merge/_index.md
+++ b/chinese/javascript-cpp/merge/_index.md
@@ -12,12 +12,12 @@ url: /zh/javascript-cpp/merge/
 | 名称 | 描述 |
 | -------------- | -------------- |
 | [AsposePSMergeToPdf](./psmergetopdf/) | 将 Postscript 文件合并为 PDF。 |
-| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | 合并 XPS 文件为 PDF。 |
-| [AsposeXPSMergeToXps](./xpsmergetopdf/) | 合并 XPS 文件为 XPS 文件。 |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | 将 XPS 文件合并为 PDF。 |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | 将 XPS 文件合并为 XPS 文件。 |
 
 ## Detailed Description
 
-合并多个 Postscript 或 XPS 文件为一个 PDF 文件，或将多个 XPS 文件合并为一个 XPS 文件。
+将多个 Postscript 或 XPS 文件合并为一个 PDF 文件，或将多个 XPS 文件合并为一个 XPS 文件。
 
 
 ```js

--- a/chinese/javascript-cpp/merge/psmergetopdf/_index.md
+++ b/chinese/javascript-cpp/merge/psmergetopdf/_index.md
@@ -20,8 +20,8 @@ function AsposePSMergePdf(
 
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
-| fileNames | string | 用于合并的文件名称。 |
-| fileNameResult | string | 结果 PDF 文件的名称。 |
+| fileNames | 字符串 | 用于合并的文件名称。 |
+| fileNameResult | 字符串 | 结果 PDF 文件的名称。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
 ### 返回值
@@ -29,8 +29,8 @@ function AsposePSMergePdf(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/merge/xpsmergetopdf/_index.md
+++ b/chinese/javascript-cpp/merge/xpsmergetopdf/_index.md
@@ -20,8 +20,8 @@ function AsposeXPSMergePdf(
 
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
-| fileNames | string | 用于合并的文件名称。 |
-| fileNameResult | string | 结果 PDF 文件的名称。 |
+| fileNames | 字符串 | 用于合并的文件名称。 |
+| fileNameResult | 字符串 | 结果 PDF 文件的名称。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
 ### 返回值
@@ -29,8 +29,8 @@ function AsposeXPSMergePdf(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/merge/xpsmergetoxps/_index.md
+++ b/chinese/javascript-cpp/merge/xpsmergetoxps/_index.md
@@ -20,8 +20,8 @@ function AsposeXPSMergeXps(
 
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
-| fileNames | string | 用于合并的文件名称。 |
-| fileNameResult | string | 结果 XPS 文件的名称。 |
+| fileNames | 字符串 | 用于合并的文件名称。 |
+| fileNameResult | 字符串 | 结果 XPS 文件的名称。 |
 | supressErrors | bool | 指定是否必须抑制错误。 |
 
 ### 返回值
@@ -29,8 +29,8 @@ function AsposeXPSMergeXps(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | fileNameResult | 结果文件名 |
 
 ### 示例

--- a/chinese/javascript-cpp/misc/pageabout/_index.md
+++ b/chinese/javascript-cpp/misc/pageabout/_index.md
@@ -19,8 +19,8 @@ function AsposePageAbout()
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-| errorCode | 错误代码（0 表示无错误） |
-| errorText | 错误文本（"" 表示无错误） |
+| errorCode | 错误代码 (0 无错误) |
+| errorText | 文本错误 (\"\" 无错误) |
 | 产品 | 产品名称 |
 | 版本 | 产品版本 |
 | islicensed | 产品已授权 |

--- a/chinese/javascript-cpp/ps/psextracttext/_index.md
+++ b/chinese/javascript-cpp/ps/psextracttext/_index.md
@@ -1,14 +1,14 @@
 ---
 title: "AsposePSExtractText"
 second_title: "Aspose.Page 用于 JavaScript via C++"
-description: "从 PS 文件中提取文本"
+description: "从 PS 文件提取文本"
 type: docs
 weight: 10
 url: /zh/javascript-cpp/ps/psextracttext/
 ---
 ## AsposePSExtractText function
 
-从 PS 文件中提取文本。仅当文本使用 Type 42（TrueType）字体或在其向量映射中包含 Type 42 字体的 Type 0 字体编写时，才可以提取。
+从 PS 文件提取文本。仅当文本使用 Type 42（TrueType）字体或在其向量映射中包含 Type 42 字体的 Type 0 字体编写时，才可以提取。
 
 ```js
 function AsposePSExtractText(
@@ -22,17 +22,17 @@ function AsposePSExtractText(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| 开始 | int | 指定开始提取文本的页码。此参数在多页文档中非常有用。 |
-| 结束 | int | 指定提取文本结束的页码。此参数在多页文档中非常有用。 |
+| fileName | 字符串 | 源文件名。 |
+| 开始 | int | 指定开始提取文本的页码。此参数对多页文档很有用。 |
+| 结束 | int | 指定提取文本结束的页码。此参数对多页文档很有用。 |
 
 ### 返回值
 
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | 文本 | 提取的文本 |
 
 ### 示例

--- a/chinese/javascript-cpp/ps/psgetboundingbox/_index.md
+++ b/chinese/javascript-cpp/ps/psgetboundingbox/_index.md
@@ -20,15 +20,15 @@ function AsposePSGetBoundingBox(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
+| fileName | 字符串 | 源文件名。 |
 
 ### 返回值
 
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | bbox | EPS 图像的边界框。 |
 
 ### 示例

--- a/chinese/javascript-cpp/xmp/_index.md
+++ b/chinese/javascript-cpp/xmp/_index.md
@@ -19,7 +19,7 @@ url: /zh/javascript-cpp/xmp/
 
 ## Detailed Description
 
-将 Postscript 或 XPS 文件转换为图像或 PDF 文件。
+将 postscript 或 XPS 文件转换为图像或 PDF 文件。
 
 
 

--- a/chinese/javascript-cpp/xmp/epsgetxmp/_index.md
+++ b/chinese/javascript-cpp/xmp/epsgetxmp/_index.md
@@ -8,9 +8,9 @@ url: /zh/javascript-cpp/xmp/epsgetxmp/
 ---
 ## AsposeEPSGetXmp function
 
-读取 PS/EPS 文件并提取 XmpMetdata（如果已存在）。
-如果 EPS 文件不包含 XMP 元数据，我们将获取一个新元数据，并用 PS 元数据注释（%%Creator、%%CreateDate、%%Title 等）中的值填充。
-填充了 XMP 元数据的 EPS 文件将保存到 fileNameResult。
+读取 PS/EPS 文件并提取已存在的 XmpMetdata。
+如果 EPS 文件不包含 XMP 元数据，我们将获取一个新元数据，并用 PS 元数据注释（%%Creator、%%CreateDate、%%Title 等）的值填充。
+填充了 XMP 元数据的 EPS 文件将保存在 fileNameResult 中。
 
 ```js
 function AsposeEPSGetXmp(
@@ -23,8 +23,8 @@ function AsposeEPSGetXmp(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
 
 
 ### 返回值
@@ -32,8 +32,8 @@ function AsposeEPSGetXmp(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | XMP | 元数据值数组 |
 |  | fileNameResult | 结果文件名 |
 

--- a/chinese/javascript-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddarrayitem/_index.md
@@ -21,8 +21,8 @@ function AsposeXMPAddArrayItem(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
 
 
 ### 返回值
@@ -30,8 +30,8 @@ function AsposeXMPAddArrayItem(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | XMP | 元数据值数组 |
 |  | fileNameResult | 结果文件名 |
 

--- a/chinese/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -21,8 +21,8 @@ function AsposeXMPAddNamedValue(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
 
 
 ### 返回值
@@ -30,8 +30,8 @@ function AsposeXMPAddNamedValue(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | XMP | 元数据值数组 |
 |  | fileNameResult | 结果文件名 |
 

--- a/chinese/javascript-cpp/xmp/xmpaddnamespace/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddnamespace/_index.md
@@ -21,8 +21,8 @@ function AsposeXMPAddNamespace(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
 
 
 ### 返回值
@@ -30,8 +30,8 @@ function AsposeXMPAddNamespace(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | XMP | 元数据值数组 |
 |  | fileNameResult | 结果文件名 |
 

--- a/chinese/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/chinese/javascript-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -21,8 +21,8 @@ function AsposeXMPAddSimpleProperties(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
-| fileNameResult | string | 结果文件名。 |
+| fileName | 字符串 | 源文件名。 |
+| fileNameResult | 字符串 | 结果文件名。 |
 
 
 ### 返回值
@@ -30,8 +30,8 @@ function AsposeXMPAddSimpleProperties(
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | XMP | 元数据值数组 |
 |  | fileNameResult | 结果文件名 |
 

--- a/chinese/javascript-cpp/xps/_index.md
+++ b/chinese/javascript-cpp/xps/_index.md
@@ -11,7 +11,7 @@ url: /zh/javascript-cpp/xps/
 
 | 函数 | 描述 |
 | -------- | ----------- |
-| [AsposeGetXpsPageCount](./getxpspagecount/) | 获取 xps 文档的页数。 |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | 获取 xps-document 的页数。 |
 
 ## Detailed Description
 

--- a/chinese/javascript-cpp/xps/getxpspagecount/_index.md
+++ b/chinese/javascript-cpp/xps/getxpspagecount/_index.md
@@ -8,7 +8,7 @@ url: /zh/javascript-cpp/xps/getxpspagecount/
 ---
 ## AsposeGetXpsPageCount function
 
-获取 xps 文档的页数。
+获取 xps-document 的页数。
 
 ```js
 function AsposeGetXpsPageCount(
@@ -20,15 +20,15 @@ function AsposeGetXpsPageCount(
 | 参数 | 类型 | 描述 |
 | --------- | ---- | ----------- |
 | fileBlob | Blob 对象 | 源文件的内容。 |
-| fileName | string | 源文件名。 |
+| fileName | 字符串 | 源文件名。 |
 
 ### 返回值
 
 JSON 对象
 | 字段 | 描述 |
 | ----- | ----------- |
-|  | errorCode | 错误代码（0 表示无错误） |
-|  | errorText | 错误文本（"" 表示无错误） |
+|  | errorCode | 错误代码 (0 无错误) |
+|  | errorText | 文本错误 (\"\" 无错误) |
 |  | pageCount | 页数 |
 
 ### 示例


### PR DESCRIPTION
Automated translation of the JAVASCRIPT-CPP API Reference to **Chinese** (`zh`) generated by RDA.

- Pages translated: 36/36
- Errors: 0
- Source: `english/javascript-cpp`
- Output: `chinese/javascript-cpp`

🤖 Generated by RDA