### PR TITLE
[auto] Translate NODEJS-CPP API Reference to French

### DIFF
--- a/french/nodejs-cpp/convert/_index.md
+++ b/french/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Fonctions de conversion"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de conversion pour travailler avec des fichiers Postscript/XPS."
+weight: 10
+type: docs
+url: /fr/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Convertir un fichier Postscript en image. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Convertir un fichier Postscript en PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Convertir un fichier XPS en image. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Convertir un fichier XPS en PDF. |
+
+## Detailed Description
+
+Convertir un fichier postscript ou xps en image ou en fichier PDF.
+
+
+

--- a/french/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/french/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le Postscript en image"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Convertit le Postscript en image.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom du fichier. |
+| imageFormat | ImageFormat | format d'image dans lequel convertir. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/french/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/french/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le Postscript en PDF"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convertit le Postscript en PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom du fichier. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`L'erreur inconnue s'est produite : ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/french/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/french/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le XPS en image"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Convertit le Postscript en image.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom du fichier. |
+| imageFormat | ImageFormat | format d'image dans lequel convertir. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/french/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/french/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Convertit le XPS en PDF"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convertit le XPS en PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu de la police source pour la conversion. |
+| fileName | string | Nom du fichier. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/french/nodejs-cpp/enumerations/_index.md
+++ b/french/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Énumérations"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de conversion de polices vers les formats TrueType."
+weight: 80
+type: docs
+url: /fr/javascript-cpp/enumerations/
+---
+
+## Énumérations
+
+| Énumération | Description |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Spécifie le format d'image. |
+| [Units](./units/) | Spécifie le type de taille. |
+

--- a/french/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/french/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Enum ImageFormat. Spécifie le format d'image"
+type: docs
+weight: 100
+url: /fr/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Spécifie le format d'image.
+
+```csharp
+public enum ImageFormat
+```
+
+### Valeurs
+
+| Nom | Valeur | Description |
+| ---  | ---   | --- |
+| Bmp | `0` | Format d'image BMP. |
+| Jpeg | `1` | Format d'image JPG. |
+| Gif | `2` | Format d'image GIF. |
+| Tiff | `3` | Format d'image TIFF. |
+

--- a/french/nodejs-cpp/enumerations/units/_index.md
+++ b/french/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Unités"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Enum Unités. Spécifie le type de taille"
+type: docs
+weight: 100
+url: /fr/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Spécifie le type de taille.
+
+```js
+enum Units
+```
+
+### Valeurs
+
+| Nom | Valeur | Description |
+| ---        | ---   | --- |
+| Points | `0` | Points (1/72 de pouce). |
+| Inches | `1` | Pouces. |
+| Millimeters | `2` | Millimètres. |
+| Centimeters | `3` | Centimètres. |
+| Percents | `4` | Pourcentages de la taille existante. |

--- a/french/nodejs-cpp/eps/_index.md
+++ b/french/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Fonctions EPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers EPS."
+weight: 41
+type: docs
+url: /fr/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Recadrer le fichier EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Redimensionner le fichier EPS. |
+
+## Detailed Description
+
+Manipuler la taille du fichier EPS.
+
+

--- a/french/nodejs-cpp/eps/cropeps/_index.md
+++ b/french/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Recadrer EPS"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Recadre le fichier EPS. Il enregistre le fichier EPS initial avec le %%BoundingBox existant mis à jour ou un nouveau sera créé.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+| gauche | float | Spécifie la limite gauche de la boîte de recadrage. |
+| haut | float | Spécifie la limite supérieure de la boîte de recadrage. |
+| droite | float | Spécifie la limite droite de la boîte de recadrage. |
+| bas | float | Spécifie la limite inférieure de la boîte de recadrage. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/french/nodejs-cpp/eps/resizeeps/_index.md
+++ b/french/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Redimensionner EPS"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Redimensionne le fichier EPS. Il enregistre le fichier EPS initial avec le %%BoundingBox existant mis à jour ou un nouveau sera créé.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+| width | float | Spécifie la largeur du nouveau cadre de délimitation. |
+| height | float | Spécifie la hauteur du nouveau cadre de délimitation. |
+| unit | Module.Units | Spécifie le type de la nouvelle taille. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/french/nodejs-cpp/image/_index.md
+++ b/french/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Fonctions d'image"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers image."
+weight: 50
+type: docs
+url: /fr/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Enregistrer le fichier image au format EPS. |
+
+## Detailed Description
+
+Enregistrer l'image des formats les plus populaires (BMP, PNG, JPEG, GOF, TIFF) au format EPS.
+

--- a/french/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/french/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Redimensionner EPS"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Redimensionne le fichier EPS. Il enregistre le fichier EPS initial avec le %%BoundingBox existant mis à jour ou un nouveau sera créé.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+

--- a/french/nodejs-cpp/merge/_index.md
+++ b/french/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Fonctions de fusion"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de fusion pour travailler avec des fichiers Postscript/XPS."
+weight: 20
+type: docs
+url: /fr/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Fusionner des fichiers Postscript en PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Fusionner des fichiers XPS en PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Fusionner des fichiers XPS en un fichier XPS. |
+
+## Detailed Description
+
+Fusionner plusieurs fichiers postscript ou xps en un fichier PDF ou plusieurs fichiers XPS en un seul fichier XPS.
+
+

--- a/french/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/french/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fusionner les fichiers Postscript en PDF"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Fusionner les fichiers Postscript en PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileNames | string | Les noms des fichiers à fusionner. |
+| fileNameResult | string | Le nom du fichier PDF résultant. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/french/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/french/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fusionner les fichiers XPS en PDF"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Fusionner les fichiers XPS en PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileNames | string | Les noms des fichiers à fusionner. |
+| fileNameResult | string | Le nom du fichier PDF résultant. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/french/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/french/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fusionner les fichiers XPS en un XPS"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Fusionner plusieurs fichiers XPS en un seul fichier XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileNames | string | Les noms des fichiers à fusionner. |
+| fileNameResult | string | Le nom du fichier XPS résultant. |
+| supressErrors | bool | Spécifie si les erreurs doivent être supprimées ou non. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/french/nodejs-cpp/misc/_index.md
+++ b/french/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Fonctions diverses"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions secondaires pour travailler avec des fichiers Postscript/XPS."
+weight: 70
+type: docs
+url: /fr/nodejs-cpp/misc/
+---
+## Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Obtenir des informations sur le produit. |
+
+## Detailed Description
+
+Fonctions secondaires pour travailler avec des fichiers Postscript/XPS.
+

--- a/french/nodejs-cpp/misc/pageabout/_index.md
+++ b/french/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir des informations sur le produit."
+type: docs
+url: /fr/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Obtenir des informations sur le produit.
+
+```js
+function AsposePageAbout()
+```
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+| errorCode | erreur de code (0 aucune erreur) |
+| errorText | erreur de texte ("" aucune erreur) |
+| produit | Nom du produit |
+| version | Version du produit |
+| islicensed | Le produit est licencié |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/french/nodejs-cpp/ps/_index.md
+++ b/french/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Fonctions PS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers PS."
+weight: 40
+type: docs
+url: /fr/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Obtenir les limites du fichier PS. |
+| [AsposePSExtractText](./psextracttext/) | Extraire le texte du fichier PS. |
+
+## Detailed Description
+
+Manipuler le fichier PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/nodejs-cpp/ps/psextracttext/_index.md
+++ b/french/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Extraire le texte d'un fichier PS"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extraire le texte d'un fichier PS. Le texte ne peut être extrait que s'il est écrit avec une police Type 42 (TrueType) ou une police Type 0 avec des polices Type 42 dans sa carte vectorielle.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| début | int | Spécifie la page à partir de laquelle commencer l'extraction du texte. Ce paramètre est utile pour les documents multi-pages. |
+| fin | int | Spécifie la page jusqu'à laquelle terminer l'extraction du texte. Ce paramètre est utile pour les documents multi-pages. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | texte | le texte extrait |
+
+### Exemples
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Voir aussi
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/french/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/french/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir la boîte englobante"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Lit le fichier EPS et extrait la boîte englobante de l'image EPS à partir du commentaire %%BoundingBox ou les limites pour la taille de page par défaut (0, 0, 595, 842) si elle n'existe pas.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | bbox | la boîte englobante de l'image EPS. |
+
+### Exemples
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/french/nodejs-cpp/xmp/_index.md
+++ b/french/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Fonctions de métadonnées XMP"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions de métadonnées XMP pour travailler avec des fichiers EPS."
+weight: 30
+type: docs
+url: /fr/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Nom | Description |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Obtenir les métadonnées XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Ajoute une valeur dans un tableau. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Ajoute une valeur nommée dans une structure. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Enregistre l'URI de l'espace de noms et ajoute une valeur. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Fusionner des fichiers Postscript en PDF. |
+
+## Detailed Description
+
+Convertir un fichier postscript ou xps en image ou en fichier PDF.
+
+
+

--- a/french/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/french/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Lit le fichier PS/EPS et extrait les métadonnées XMP si elles existent déjà.
+Si le fichier EPS ne contient pas de métadonnées XMP, nous obtenons un nouveau fichier rempli avec les valeurs des commentaires de métadonnées PS (%%Creator, %%CreateDate, %%Title, etc.).
+Le fichier EPS avec les métadonnées XMP remplies sera enregistré dans fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Voir aussi
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/french/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/french/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 20
+url: /fr/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Ajoute une valeur dans un tableau. La valeur sera ajoutée à la fin du tableau.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/french/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/french/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 30
+url: /fr/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Ajoute une valeur nommée dans une structure.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/french/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/french/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 40
+url: /fr/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Enregistre l'URI de l'espace de noms et ajoute une valeur.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/french/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/french/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir les métadonnées XMP"
+type: docs
+weight: 40
+url: /fr/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Ajoute une valeur nommée dans une structure.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+| fileNameResult | string | Nom du fichier résultant. |
+
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | XMP | tableau de valeurs de métadonnées |
+|  | fileNameResult | nom du fichier résultat |
+
+### Exemples
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Voir aussi
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/french/nodejs-cpp/xps/_index.md
+++ b/french/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fonctions XPS"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Fonctions pour travailler avec des fichiers XPS."
+weight: 42
+type: docs
+url: /fr/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Fonction | Description |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Obtenir le nombre de pages du document xps. |
+
+## Detailed Description
+
+Manipuler le fichier XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ou
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/french/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/french/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page pour JavaScript via C++"
+description: "Obtenir le nombre de pages dans le fichier XPS"
+type: docs
+weight: 10
+url: /fr/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Obtenir le nombre de pages du document xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Paramètre | Type | Description |
+| --------- | ---- | ----------- |
+| fileBlob | Objet Blob | Contenu du fichier source. |
+| fileName | string | Nom du fichier source. |
+
+### Valeur de retour
+
+Objet JSON
+| Champ | Description |
+| ----- | ----------- |
+|  | errorCode | erreur de code (0 aucune erreur) |
+|  | errorText | erreur de texte ("" aucune erreur) |
+|  | pageCount | nombre de pages |
+
+### Exemples
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **French** (`fr`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `french/nodejs-cpp`

🤖 Generated by RDA