### PR TITLE
[auto] Translate NODEJS-CPP API Reference to German

### DIFF
--- a/german/nodejs-cpp/convert/_index.md
+++ b/german/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Konvertierungsfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertierungsfunktionen zum Arbeiten mit Postscript/XPS-Dateien."
+weight: 10
+type: docs
+url: /de/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Konvertiere eine Postscript-Datei in ein Bild. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Konvertiere eine Postscript-Datei in PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Konvertiere eine XPS-Datei in ein Bild. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Konvertiere eine XPS-Datei in PDF. |
+
+## Detailed Description
+
+Konvertiere Postscript- oder XPS-Datei in ein Bild oder PDF.
+
+
+

--- a/german/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/german/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das Postscript in ein Bild"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Konvertiert das Postscript in ein Bild.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| imageFormat | ImageFormat | Bildformat, in das konvertiert werden soll. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/german/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/german/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das Postscript zu PDF"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konvertiert das Postscript zu PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page für Node.js über C++-Beispiele.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Der unbekannte Fehler ist aufgetreten: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/german/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/german/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das XPS in ein Bild"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Konvertiert das Postscript in ein Bild.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| imageFormat | ImageFormat | Bildformat, in das konvertiert werden soll. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/german/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/german/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Konvertiert das XPS in ein PDF"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konvertiert das XPS in ein PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quellschriftart für die Konvertierung. |
+| fileName | string | Dateiname. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/german/nodejs-cpp/enumerations/_index.md
+++ b/german/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Aufzählungen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Konvertieren von Schriftarten in True‑Type-Formate."
+weight: 80
+type: docs
+url: /de/javascript-cpp/enumerations/
+---
+
+## Aufzählungen
+
+| Aufzählung | Beschreibung |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Gibt das Bildformat an. |
+| [Units](./units/) | Gibt den Größentyp an. |
+

--- a/german/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/german/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "ImageFormat-Enum. Gibt das Bildformat an"
+type: docs
+weight: 100
+url: /de/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Gibt das Bildformat an.
+
+```csharp
+public enum ImageFormat
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP-Bildformat. |
+| Jpeg | `1` | JPG-Bildformat. |
+| Gif | `2` | GIF-Bildformat. |
+| Tiff | `3` | TIFF-Bildformat. |
+

--- a/german/nodejs-cpp/enumerations/units/_index.md
+++ b/german/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Units-Enum. Gibt den Typ der Größe an"
+type: docs
+weight: 100
+url: /de/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Gibt den Größentyp an.
+
+```js
+enum Units
+```
+
+### Werte
+
+| Name | Wert | Beschreibung |
+| ---        | ---   | --- |
+| Points | `0` | Punkte (1/72 Zoll). |
+| Inches | `1` | Zoll. |
+| Millimeters | `2` | Millimeter. |
+| Centimeters | `3` | Zentimeter. |
+| Percents | `4` | Prozentsatz der vorhandenen Größe. |

--- a/german/nodejs-cpp/eps/_index.md
+++ b/german/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "EPS-Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit EPS-Dateien."
+weight: 41
+type: docs
+url: /de/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS-Datei zuschneiden. |
+| [AsposeResizeEPS](./resizeeps/) | EPS-Datei skalieren. |
+
+## Detailed Description
+
+Größe der EPS-Datei manipulieren.
+
+

--- a/german/nodejs-cpp/eps/cropeps/_index.md
+++ b/german/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "EPS zuschneiden"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Beschneidet EPS-Datei. Sie speichert die ursprüngliche EPS-Datei mit aktualisiertem vorhandenen %%BoundingBox oder es wird ein neuer erstellt.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+| links | float | Gibt die linke Grenze des Beschneidungsrahmens an. |
+| oben | float | Gibt die obere Grenze des Beschneidungsrahmens an. |
+| rechts | float | Gibt die rechte Grenze des Beschneidungsrahmens an. |
+| unten | float | Gibt die untere Grenze des Beschneidungsrahmens an. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/german/nodejs-cpp/eps/resizeeps/_index.md
+++ b/german/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "EPS skalieren"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Skaliert EPS-Datei. Sie speichert die ursprüngliche EPS-Datei mit aktualisiertem vorhandenen %%BoundingBox, oder es wird ein neuer erstellt.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+| Breite | float | Gibt die Breite des neuen Begrenzungsrahmens an. |
+| Höhe | float | Gibt die Höhe des neuen Begrenzungsrahmens an. |
+| Einheit | Module.Units | Gibt den Typ der neuen Größe an. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/german/nodejs-cpp/image/_index.md
+++ b/german/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Bildfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit Bilddateien."
+weight: 50
+type: docs
+url: /de/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Bilddatei als EPS speichern. |
+
+## Detailed Description
+
+Speichern Sie Bilder der beliebtesten Formate (BMP, PNG, JPEG, GOF, TIFF) als EPS-Datei.
+

--- a/german/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/german/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "EPS skalieren"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Skaliert EPS-Datei. Sie speichert die ursprüngliche EPS-Datei mit aktualisiertem vorhandenen %%BoundingBox, oder es wird ein neuer erstellt.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+

--- a/german/nodejs-cpp/merge/_index.md
+++ b/german/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Zusammenführungsfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Zusammenführungsfunktionen zum Arbeiten mit Postscript/XPS-Dateien."
+weight: 20
+type: docs
+url: /de/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Führt Postscript-Dateien zu einer PDF zusammen. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Führt XPS-Dateien zu einer PDF zusammen. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Führt XPS-Dateien zu einer XPS-Datei zusammen. |
+
+## Detailed Description
+
+Führt mehrere Postscript- oder XPS-Dateien zu einer PDF-Datei zusammen oder mehrere XPS-Dateien zu einer XPS-Datei.
+
+

--- a/german/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/german/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Postscript-Dateien zu PDF zusammenführen"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Postscript-Dateien zu PDF zusammenführen.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileNames | string | Die Namen der Dateien zum Zusammenführen. |
+| fileNameResult | string | Der Name der Ergebnis-PDF-Datei. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/german/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/german/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XPS-Dateien zu PDF zusammenführen"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+XPS-Dateien zu PDF zusammenführen.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileNames | string | Die Namen der Dateien zum Zusammenführen. |
+| fileNameResult | string | Der Name der Ergebnis-PDF-Datei. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/german/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/german/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XPS-Dateien zu einer XPS zusammenführen"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Mehrere XPS-Dateien zu einer XPS-Datei zusammenführen.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileNames | string | Die Namen der Dateien zum Zusammenführen. |
+| fileNameResult | string | Der Name der Ergebnis-XPS-Datei. |
+| supressErrors | bool | Gibt an, ob Fehler unterdrückt werden sollen oder nicht. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/german/nodejs-cpp/misc/_index.md
+++ b/german/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Verschiedene Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Sekundäre Funktionen zum Arbeiten mit Postscript/XPS-Dateien."
+weight: 70
+type: docs
+url: /de/nodejs-cpp/misc/
+---
+## Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Informationen zum Produkt abrufen. |
+
+## Detailed Description
+
+Sekundäre Funktionen zum Arbeiten mit Postscript/XPS-Dateien.
+

--- a/german/nodejs-cpp/misc/pageabout/_index.md
+++ b/german/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Informationen zum Produkt abrufen."
+type: docs
+url: /de/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Informationen zum Produkt abrufen.
+
+```js
+function AsposePageAbout()
+```
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+| errorCode | Code-Fehler (0 kein Fehler) |
+| errorText | Textfehler ("" kein Fehler) |
+| Produkt | Produktname |
+| Version | Produktversion |
+| islicensed | Produkt ist lizenziert |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/german/nodejs-cpp/ps/_index.md
+++ b/german/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS-Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit PS-Dateien."
+weight: 40
+type: docs
+url: /de/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Grenzen der PS-Datei ermitteln. |
+| [AsposePSExtractText](./psextracttext/) | Text aus PS-Datei extrahieren. |
+
+## Detailed Description
+
+PS-Datei manipulieren.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/nodejs-cpp/ps/psextracttext/_index.md
+++ b/german/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Text aus PS-Datei extrahieren"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Text aus PS-Datei extrahieren. Der Text kann nur extrahiert werden, wenn er mit Type 42 (TrueType) oder Type 0 font mit Type 42 fonts in seiner Vector Map geschrieben ist.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| Start | int | Gibt die Seite an, ab der Text extrahiert werden soll. Dieser Parameter ist nützlich für mehrseitige Dokumente. |
+| Ende | int | Gibt die Seite an, bis zu der Text extrahiert werden soll. Dieser Parameter ist nützlich für mehrseitige Dokumente. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | Text | der extrahierte Text |
+
+### Beispiele
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Siehe auch
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/german/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/german/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Bounding-Box abrufen"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Liest die EPS-Datei und extrahiert die Bounding-Box des EPS-Bildes aus dem %%BoundingBox-Kommentar oder die Grenzen für die Standardseitengröße (0, 0, 595, 842), falls diese nicht existieren.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | bbox | die Bounding-Box des EPS-Bildes. |
+
+### Beispiele
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/german/nodejs-cpp/xmp/_index.md
+++ b/german/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "XMP-Metadatenfunktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadatenfunktionen zum Arbeiten mit EPS-Dateien."
+weight: 30
+type: docs
+url: /de/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Name | Beschreibung |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | XMP-Metadaten abrufen. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Fügt einen Wert in ein Array ein. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Fügt einen benannten Wert in eine Struktur ein. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registriert den Namespace-URI und fügt einen Wert hinzu. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Führt Postscript-Dateien zu einer PDF zusammen. |
+
+## Detailed Description
+
+Konvertiere Postscript- oder XPS-Datei in ein Bild oder PDF.
+
+
+

--- a/german/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/german/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Liest PS/EPS-Datei und extrahiert XmpMetdata, falls sie bereits vorhanden sind.
+Wenn die EPS-Datei keine XMP-Metadaten enthält, erhalten wir neue, die mit Werten aus den PS-Metadatenkommentaren (%%Creator, %%CreateDate, %%Title usw.) gefüllt sind.
+EPS-Datei mit ausgefüllten XMP-Metadaten wird in fileNameResult gespeichert.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Siehe auch
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/german/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/german/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 20
+url: /de/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Fügt einen Wert in ein Array ein. Der Wert wird am Ende des Arrays hinzugefügt.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/german/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/german/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 30
+url: /de/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Fügt einen benannten Wert in eine Struktur ein.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/german/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/german/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 40
+url: /de/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registriert den Namespace-URI und fügt einen Wert hinzu.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/german/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/german/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "XMP-Metadaten abrufen"
+type: docs
+weight: 40
+url: /de/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Fügt einen benannten Wert in eine Struktur ein.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+| fileNameResult | string | Name der Ergebnisdatei. |
+
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | XMP | Array von Metadatenwerten |
+|  | fileNameResult | Ergebnisdateiname |
+
+### Beispiele
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Siehe auch
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/german/nodejs-cpp/xps/_index.md
+++ b/german/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS-Funktionen"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Funktionen zum Arbeiten mit XPS-Dateien."
+weight: 42
+type: docs
+url: /de/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Funktion | Beschreibung |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Erhalte die Anzahl der Seiten im xps-Dokument. |
+
+## Detailed Description
+
+Manipulieren Sie die XPS-Datei.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+oder
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/german/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/german/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page für JavaScript über C++"
+description: "Anzahl der Seiten in XPS-Datei ermitteln"
+type: docs
+weight: 10
+url: /de/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Erhalte die Anzahl der Seiten im xps-Dokument.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beschreibung |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-Objekt | Inhalt der Quelldatei. |
+| fileName | string | Name der Quelldatei. |
+
+### Rückgabewert
+
+JSON-Objekt
+| Feld | Beschreibung |
+| ----- | ----------- |
+|  | errorCode | Code-Fehler (0 kein Fehler) |
+|  | errorText | Textfehler ("" kein Fehler) |
+|  | pageCount | Anzahl der Seiten |
+
+### Beispiele
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **German** (`de`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `german/nodejs-cpp`

🤖 Generated by RDA