### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Greece

### DIFF
--- a/greece/nodejs-cpp/convert/_index.md
+++ b/greece/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Συναρτήσεις μετατροπής"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις μετατροπής για εργασία με αρχεία Postscript/XPS."
+weight: 10
+type: docs
+url: /el/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Μετατροπή αρχείου Postscript σε εικόνα. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Μετατροπή αρχείου Postscript σε PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Μετατροπή αρχείου XPS σε εικόνα. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Μετατροπή αρχείου XPS σε PDF. |
+
+## Detailed Description
+
+Μετατροπή αρχείου postscript ή xps σε αρχείο εικόνας ή PDF.
+
+
+

--- a/greece/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/greece/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το Postscript σε εικόνα"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Μετατρέπει το Postscript σε εικόνα.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| imageFormat | ImageFormat | μορφή εικόνας για μετατροπή. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/greece/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/greece/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το Postscript σε PDF"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Μετατρέπει το Postscript σε PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page για Node.js μέσω παραδειγμάτων C++.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Το άγνωστο σφάλμα έχει εμφανιστεί: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/greece/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/greece/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το XPS σε εικόνα"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Μετατρέπει το Postscript σε εικόνα.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| imageFormat | ImageFormat | μορφή εικόνας για μετατροπή. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/greece/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/greece/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Μετατρέπει το XPS σε PDF"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Μετατρέπει το XPS σε PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο της πηγαίας γραμματοσειράς για μετατροπή. |
+| fileName | string | Όνομα αρχείου. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/greece/nodejs-cpp/enumerations/_index.md
+++ b/greece/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Απαριθμήσεις"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για μετατροπή γραμματοσειρών σε μορφές TrueType."
+weight: 80
+type: docs
+url: /el/javascript-cpp/enumerations/
+---
+
+## Απαριθμήσεις
+
+| Απαρίθμηση | Περιγραφή |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Καθορίζει τη μορφή εικόνας. |
+| [Units](./units/) | Καθορίζει τον τύπο μεγέθους. |
+

--- a/greece/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/greece/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Απαρίθμηση ImageFormat"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Απαρίθμηση ImageFormat. Καθορίζει τη μορφή εικόνας"
+type: docs
+weight: 100
+url: /el/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Καθορίζει τη μορφή εικόνας.
+
+```csharp
+public enum ImageFormat
+```
+
+### Τιμές
+
+| Όνομα | Τιμή | Περιγραφή |
+| ---  | ---   | --- |
+| Bmp | `0` | Μορφή εικόνας BMP. |
+| Jpeg | `1` | Μορφή εικόνας JPG. |
+| Gif | `2` | Μορφή εικόνας GIF. |
+| Tiff | `3` | Μορφή εικόνας TIFF. |
+

--- a/greece/nodejs-cpp/enumerations/units/_index.md
+++ b/greece/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Απαρίθμηση Units"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Απαρίθμηση Units. Καθορίζει τον τύπο του μεγέθους"
+type: docs
+weight: 100
+url: /el/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Καθορίζει τον τύπο μεγέθους.
+
+```js
+enum Units
+```
+
+### Τιμές
+
+| Όνομα | Τιμή | Περιγραφή |
+| ---        | ---   | --- |
+| Points | `0` | Σημεία (1/72 της ίντσας). |
+| Inches | `1` | Ίντσες. |
+| Millimeters | `2` | Χιλιοστά. |
+| Centimeters | `3` | Εκατοστά. |
+| Percents | `4` | Ποσοστά του υπάρχοντος μεγέθους. |

--- a/greece/nodejs-cpp/eps/_index.md
+++ b/greece/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Συναρτήσεις EPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία EPS."
+weight: 41
+type: docs
+url: /el/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Περικοπή αρχείου EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Αλλαγή μεγέθους αρχείου EPS. |
+
+## Detailed Description
+
+Διαχείριση μεγέθους αρχείου EPS.
+
+

--- a/greece/nodejs-cpp/eps/cropeps/_index.md
+++ b/greece/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Κόψιμο EPS"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Κόβει αρχείο EPS. Αποθηκεύει το αρχικό αρχείο EPS με ενημερωμένο υπάρχον %%BoundingBox ή θα δημιουργηθεί νέο.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+| αριστερά | float | Καθορίζει το αριστερό όριο του πλαισίου περικοπής. |
+| επάνω | float | Καθορίζει το επάνω όριο του πλαισίου περικοπής. |
+| δεξιά | float | Καθορίζει το δεξί όριο του πλαισίου περικοπής. |
+| κάτω | float | Καθορίζει το κάτω όριο του πλαισίου περικοπής. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/greece/nodejs-cpp/eps/resizeeps/_index.md
+++ b/greece/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αλλαγή μεγέθους EPS"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Αλλάζει το μέγεθος του αρχείου EPS. Αποθηκεύει το αρχικό αρχείο EPS με ενημερωμένο υπάρχον %%BoundingBox ή δημιουργείται νέο.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+| width | float | Καθορίζει το πλάτος του νέου bounding box. |
+| height | float | Καθορίζει το ύψος του νέου bounding box. |
+| unit | Module.Units | Καθορίζει τον τύπο του νέου μεγέθους. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/greece/nodejs-cpp/image/_index.md
+++ b/greece/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Συναρτήσεις εικόνας"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία εικόνας."
+weight: 50
+type: docs
+url: /el/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Αποθηκεύστε το αρχείο εικόνας ως EPS. |
+
+## Detailed Description
+
+Αποθηκεύστε εικόνα των πιο δημοφιλών μορφών (BMP, PNG, JPEG, GOF, TIFF) ως αρχείο EPS.
+

--- a/greece/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/greece/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αλλαγή μεγέθους EPS"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Αλλάζει το μέγεθος του αρχείου EPS. Αποθηκεύει το αρχικό αρχείο EPS με ενημερωμένο υπάρχον %%BoundingBox ή δημιουργείται νέο.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+

--- a/greece/nodejs-cpp/merge/_index.md
+++ b/greece/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Συναρτήσεις συγχώνευσης"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις συγχώνευσης για εργασία με αρχεία Postscript/XPS."
+weight: 20
+type: docs
+url: /el/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Συγχωνεύει αρχεία Postscript σε PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Συγχωνεύει αρχεία XPS σε PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Συγχωνεύει αρχεία XPS σε αρχείο XPS. |
+
+## Detailed Description
+
+Συγχωνεύει πολλά αρχεία postscript ή xps σε ένα αρχείο pdf ή πολλά αρχεία xps σε ένα αρχείο xps.
+
+

--- a/greece/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/greece/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συγχώνευση των αρχείων Postscript σε PDF"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Συγχώνευση των αρχείων Postscript σε PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileNames | string | Τα ονόματα των αρχείων για συγχώνευση. |
+| fileNameResult | string | Το όνομα του τελικού αρχείου pdf. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/greece/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/greece/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συγχώνευση των αρχείων XPS σε PDF"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Συγχώνευση των αρχείων XPS σε PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileNames | string | Τα ονόματα των αρχείων για συγχώνευση. |
+| fileNameResult | string | Το όνομα του τελικού αρχείου pdf. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/greece/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/greece/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συγχώνευση των αρχείων XPS σε ένα XPS"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Συγχώνευση πολλών αρχείων XPS σε ένα αρχείο XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileNames | string | Τα ονόματα των αρχείων για συγχώνευση. |
+| fileNameResult | string | Το όνομα του τελικού αρχείου xps. |
+| supressErrors | bool | Καθορίζει εάν τα σφάλματα πρέπει να καταστέλλονται ή όχι. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/greece/nodejs-cpp/misc/_index.md
+++ b/greece/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Διάφορες συναρτήσεις"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Δευτερεύουσες συναρτήσεις για εργασία με αρχεία Postscript/XPS."
+weight: 70
+type: docs
+url: /el/nodejs-cpp/misc/
+---
+## Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Αποκτήστε πληροφορίες για το προϊόν. |
+
+## Detailed Description
+
+Δευτερεύουσες συναρτήσεις για εργασία με αρχεία Postscript/XPS.
+

--- a/greece/nodejs-cpp/misc/pageabout/_index.md
+++ b/greece/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Αποκτήστε πληροφορίες για το προϊόν."
+type: docs
+url: /el/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Αποκτήστε πληροφορίες για το προϊόν.
+
+```js
+function AsposePageAbout()
+```
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+| errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+| errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+| προϊόν | Όνομα προϊόντος |
+| έκδοση | Έκδοση προϊόντος |
+| islicensed | Το προϊόν είναι αδειοδοτημένο |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/greece/nodejs-cpp/ps/_index.md
+++ b/greece/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Συναρτήσεις PS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία PS."
+weight: 40
+type: docs
+url: /el/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Λήψη ορίων αρχείου PS. |
+| [AsposePSExtractText](./psextracttext/) | Εξαγωγή κειμένου από αρχείο PS. |
+
+## Detailed Description
+
+Διαχείριση αρχείου PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/nodejs-cpp/ps/psextracttext/_index.md
+++ b/greece/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Εξαγωγή κειμένου από αρχείο PS"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Εξαγωγή κειμένου από αρχείο PS. Το κείμενο μπορεί να εξαχθεί μόνο εάν είναι γραμμένο με γραμματοσειρά Type 42 (TrueType) ή γραμματοσειρά Type 0 με γραμματοσειρές Type 42 στον Χάρτη Διανυσμάτων της.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| έναρξη | int | Καθορίζει τη σελίδα από την οποία θα ξεκινήσει η εξαγωγή κειμένου. Αυτή η παράμετρος είναι χρήσιμη για έγγραφα πολλαπλών σελίδων. |
+| λήξη | int | Καθορίζει τη σελίδα μέχρι την οποία θα ολοκληρωθεί η εξαγωγή κειμένου. Αυτή η παράμετρος είναι χρήσιμη για έγγραφα πολλαπλών σελίδων. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | κείμενο | το εξαγόμενο κείμενο |
+
+### Παραδείγματα
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Δείτε επίσης
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/greece/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/greece/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λάβετε το πλαίσιο περιγράμματος"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Διαβάζει το αρχείο EPS και εξάγει το πλαίσιο περιγράμματος της εικόνας EPS από το σχόλιο %%BoundingBox ή τα όρια για το προεπιλεγμένο μέγεθος σελίδας (0, 0, 595, 842) εάν δεν υπάρχει.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | bbox | το πλαίσιο περιγράμματος της εικόνας EPS. |
+
+### Παραδείγματα
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/greece/nodejs-cpp/xmp/_index.md
+++ b/greece/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Συναρτήσεις μεταδεδομένων XMP"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις μεταδεδομένων XMP για εργασία με αρχεία EPS."
+weight: 30
+type: docs
+url: /el/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Όνομα | Περιγραφή |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Αποκτήστε μεταδεδομένα XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Προσθέτει τιμή σε έναν πίνακα. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Προσθέτει ονομαστική τιμή σε μια δομή. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Καταχωρεί το URI του χώρου ονομάτων και προσθέτει τιμή. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Συγχωνεύει αρχεία Postscript σε PDF. |
+
+## Detailed Description
+
+Μετατροπή αρχείου postscript ή xps σε αρχείο εικόνας ή PDF.
+
+
+

--- a/greece/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/greece/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λήψη μεταδεδομένων XMP"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Διαβάζει αρχείο PS/EPS και εξάγει τα μεταδεδομένα XmpMetdata εάν υπάρχουν ήδη.
+Εάν το αρχείο EPS δεν περιέχει μεταδεδομένα XMP, δημιουργούμε ένα νέο γεμάτο με τιμές από τα σχόλια μεταδεδομένων PS (%%Creator, %%CreateDate, %%Title κλ.).
+Το αρχείο EPS με συμπληρωμένα μεταδεδομένα XMP θα αποθηκευτεί στο fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Δείτε επίσης
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/greece/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/greece/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λήψη μεταδεδομένων XMP"
+type: docs
+weight: 20
+url: /el/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Προσθέτει τιμή σε έναν πίνακα. Η τιμή θα προστεθεί στο τέλος του πίνακα.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/greece/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/greece/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λήψη μεταδεδομένων XMP"
+type: docs
+weight: 30
+url: /el/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Προσθέτει ονομαστική τιμή σε μια δομή.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/greece/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/greece/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λήψη μεταδεδομένων XMP"
+type: docs
+weight: 40
+url: /el/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Καταχωρεί το URI του χώρου ονομάτων και προσθέτει τιμή.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/greece/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/greece/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λήψη μεταδεδομένων XMP"
+type: docs
+weight: 40
+url: /el/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Προσθέτει ονομαστική τιμή σε μια δομή.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+| fileNameResult | string | Όνομα αρχείου αποτελέσματος. |
+
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | XMP | πίνακας τιμών μεταδεδομένων |
+|  | fileNameResult | όνομα αρχείου αποτελέσματος |
+
+### Παραδείγματα
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Δείτε επίσης
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/greece/nodejs-cpp/xps/_index.md
+++ b/greece/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Συναρτήσεις XPS"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Συναρτήσεις για εργασία με αρχεία XPS."
+weight: 42
+type: docs
+url: /el/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Συνάρτηση | Περιγραφή |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Λήψη του αριθμού των σελίδων στο έγγραφο xps. |
+
+## Detailed Description
+
+Διαχειριστείτε το αρχείο XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+ή
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/greece/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/greece/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page για JavaScript μέσω C++"
+description: "Λήψη αριθμού σελίδων σε αρχείο XPS"
+type: docs
+weight: 10
+url: /el/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Λήψη του αριθμού των σελίδων στο έγγραφο xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Παράμετρος | Τύπος | Περιγραφή |
+| --------- | ---- | ----------- |
+| fileBlob | Αντικείμενο Blob | Περιεχόμενο του αρχικού αρχείου. |
+| fileName | string | Όνομα αρχείου προέλευσης. |
+
+### Τιμή επιστροφής
+
+Αντικείμενο JSON
+| Πεδίο | Περιγραφή |
+| ----- | ----------- |
+|  | errorCode | σφάλμα κώδικα (0 χωρίς σφάλμα) |
+|  | errorText | σφάλμα κειμένου ("" χωρίς σφάλμα) |
+|  | pageCount | αριθμός σελίδων |
+
+### Παραδείγματα
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Greece** (`el`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `greece/nodejs-cpp`

🤖 Generated by RDA