### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Indonesian

### DIFF
--- a/indonesian/nodejs-cpp/convert/_index.md
+++ b/indonesian/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Fungsi konversi"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi konversi untuk bekerja dengan file Postscript/XPS."
+weight: 10
+type: docs
+url: /id/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Konversi file Postscript ke gambar. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Konversi file Postscript ke PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Konversi file XPS ke gambar. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Konversi file XPS ke PDF. |
+
+## Detailed Description
+
+Konversi file postscript atau xps ke gambar atau file PDF.
+
+
+

--- a/indonesian/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/indonesian/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi Postscript ke gambar"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Mengonversi Postscript ke gambar.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| imageFormat | ImageFormat | format gambar untuk dikonversi menjadi. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/indonesian/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/indonesian/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi Postscript ke PDF"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Mengonversi Postscript ke PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page untuk Node.js via contoh C++.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Kesalahan tidak diketahui telah terjadi: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/indonesian/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/indonesian/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi XPS ke gambar"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Mengonversi Postscript ke gambar.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| imageFormat | ImageFormat | format gambar untuk dikonversi menjadi. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/indonesian/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/indonesian/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Mengonversi XPS ke PDF"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Mengonversi XPS ke PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten font sumber untuk konversi. |
+| fileName | string | Nama file. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/indonesian/nodejs-cpp/enumerations/_index.md
+++ b/indonesian/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Enumerasi"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk mengonversi font ke format TrueType."
+weight: 80
+type: docs
+url: /id/javascript-cpp/enumerations/
+---
+
+## Enumerasi
+
+| Enumerasi | Deskripsi |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Menentukan format gambar. |
+| [Units](./units/) | Menentukan tipe ukuran. |
+

--- a/indonesian/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/indonesian/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Enum ImageFormat. Menentukan format gambar"
+type: docs
+weight: 100
+url: /id/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Menentukan format gambar.
+
+```csharp
+public enum ImageFormat
+```
+
+### Nilai
+
+| Nama | Nilai | Deskripsi |
+| ---  | ---   | --- |
+| Bmp | `0` | Format gambar BMP. |
+| Jpeg | `1` | Format gambar JPG. |
+| Gif | `2` | Format gambar GIF. |
+| Tiff | `3` | Format gambar TIFF. |
+

--- a/indonesian/nodejs-cpp/enumerations/units/_index.md
+++ b/indonesian/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Enum Units. Menentukan jenis ukuran"
+type: docs
+weight: 100
+url: /id/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Menentukan tipe ukuran.
+
+```js
+enum Units
+```
+
+### Nilai
+
+| Nama | Nilai | Deskripsi |
+| ---        | ---   | --- |
+| Points | `0` | Poin (1/72 inci). |
+| Inches | `1` | Inci. |
+| Millimeters | `2` | Milimeter. |
+| Centimeters | `3` | Sentimeter. |
+| Percents | `4` | Persentase dari ukuran yang ada. |

--- a/indonesian/nodejs-cpp/eps/_index.md
+++ b/indonesian/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Fungsi EPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file EPS."
+weight: 41
+type: docs
+url: /id/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Potong file EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Ubah ukuran file EPS. |
+
+## Detailed Description
+
+Manipulasi ukuran file EPS.
+
+

--- a/indonesian/nodejs-cpp/eps/cropeps/_index.md
+++ b/indonesian/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Potong EPS"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Memotong file EPS. Ini menyimpan file EPS awal dengan %%BoundingBox yang ada diperbarui atau yang baru akan dibuat.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+| kiri | float | Menentukan batas kiri kotak pemotongan. |
+| atas | float | Menentukan batas atas kotak pemotongan. |
+| kanan | float | Menentukan batas kanan kotak pemotongan. |
+| bawah | float | Menentukan batas bawah kotak pemotongan. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/indonesian/nodejs-cpp/eps/resizeeps/_index.md
+++ b/indonesian/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Ubah ukuran EPS"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Mengubah ukuran file EPS. Ini menyimpan file EPS awal dengan %%BoundingBox yang ada diperbarui atau membuat yang baru.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+| lebar | float | Menentukan lebar kotak pembatas baru. |
+| tinggi | float | Menentukan tinggi kotak pembatas baru. |
+| satuan | Module.Units | Menentukan tipe ukuran baru. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/indonesian/nodejs-cpp/image/_index.md
+++ b/indonesian/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Fungsi gambar"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file gambar."
+weight: 50
+type: docs
+url: /id/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Simpan file gambar sebagai EPS. |
+
+## Detailed Description
+
+Simpan gambar dalam format paling populer seperti BMP, PNG, JPEG, GOF, TIFF sebagai file EPS.
+

--- a/indonesian/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/indonesian/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Ubah ukuran EPS"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Mengubah ukuran file EPS. Ini menyimpan file EPS awal dengan %%BoundingBox yang ada diperbarui atau membuat yang baru.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+

--- a/indonesian/nodejs-cpp/merge/_index.md
+++ b/indonesian/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Fungsi penggabungan"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi penggabungan untuk bekerja dengan file Postscript/XPS."
+weight: 20
+type: docs
+url: /id/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Gabungkan file Postscript menjadi PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Gabungkan file XPS menjadi PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Gabungkan file XPS menjadi file XPS. |
+
+## Detailed Description
+
+Gabungkan beberapa file postscript atau XPS menjadi satu file PDF atau beberapa file XPS menjadi satu file XPS.
+
+

--- a/indonesian/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/indonesian/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Gabungkan file Postscript ke PDF"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Gabungkan file Postscript ke PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileNames | string | Nama-nama file untuk digabungkan. |
+| fileNameResult | string | Nama file pdf hasil. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/indonesian/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/indonesian/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Gabungkan file XPS ke PDF"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Gabungkan file XPS ke PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileNames | string | Nama-nama file untuk digabungkan. |
+| fileNameResult | string | Nama file pdf hasil. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/indonesian/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/indonesian/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Gabungkan file XPS menjadi satu XPS"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Gabungkan beberapa file XPS menjadi satu file XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileNames | string | Nama-nama file untuk digabungkan. |
+| fileNameResult | string | Nama file xps hasil. |
+| supressErrors | bool | Menentukan apakah kesalahan harus ditekan atau tidak. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/indonesian/nodejs-cpp/misc/_index.md
+++ b/indonesian/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Fungsi beragam"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi sekunder untuk bekerja dengan file Postscript/XPS."
+weight: 70
+type: docs
+url: /id/nodejs-cpp/misc/
+---
+## Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Dapatkan info tentang Produk. |
+
+## Detailed Description
+
+Fungsi sekunder untuk bekerja dengan file Postscript/XPS.
+

--- a/indonesian/nodejs-cpp/misc/pageabout/_index.md
+++ b/indonesian/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan info tentang Produk."
+type: docs
+url: /id/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Dapatkan info tentang Produk.
+
+```js
+function AsposePageAbout()
+```
+
+### Nilai kembali
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+| errorCode | kesalahan kode (0 tidak ada kesalahan) |
+| errorText | kesalahan teks ("" tidak ada kesalahan) |
+| produk | Nama produk |
+| versi | Versi produk |
+| islicensed | Produk berlisensi |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/indonesian/nodejs-cpp/ps/_index.md
+++ b/indonesian/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Fungsi PS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file PS."
+weight: 40
+type: docs
+url: /id/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Dapatkan batas file PS. |
+| [AsposePSExtractText](./psextracttext/) | Ekstrak teks dari file PS. |
+
+## Detailed Description
+
+Manipulasi file PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/nodejs-cpp/ps/psextracttext/_index.md
+++ b/indonesian/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Ekstrak teks dari file PS"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Ekstrak teks dari file PS. Teks hanya dapat diekstrak jika ditulis dengan font Type 42 (TrueType) atau font Type 0 dengan font Type 42 dalam Vector Map-nya.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| mulai | int | Menentukan halaman dari mana memulai ekstraksi teks. Parameter ini berguna untuk dokumen multi-halaman. |
+| akhir | int | Menentukan halaman sampai mana selesai mengekstrak teks. Parameter ini berguna untuk dokumen multi-halaman. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | teks | teks yang diekstrak |
+
+### Contoh
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Lihat Juga
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/indonesian/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/indonesian/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan kotak pembatas"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Membaca file EPS dan mengekstrak kotak pembatas gambar EPS dari komentar %%BoundingBox atau batas untuk ukuran halaman default (0, 0, 595, 842) jika tidak ada.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | bbox | kotak pembatas gambar EPS. |
+
+### Contoh
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/indonesian/nodejs-cpp/xmp/_index.md
+++ b/indonesian/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Fungsi metadata XMP"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi metadata XMP untuk bekerja dengan file EPS."
+weight: 30
+type: docs
+url: /id/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Nama | Deskripsi |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Dapatkan metadata XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Menambahkan nilai ke dalam array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Menambahkan nilai bernama ke dalam struktur. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Mendaftarkan URI namespace dan menambahkan nilai. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Gabungkan file Postscript menjadi PDF. |
+
+## Detailed Description
+
+Konversi file postscript atau xps ke gambar atau file PDF.
+
+
+

--- a/indonesian/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/indonesian/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Membaca file PS/EPS dan mengekstrak XmpMetdata jika sudah ada.
+Jika file EPS tidak mengandung metadata XMP, kami akan membuat yang baru yang diisi dengan nilai dari komentar metadata PS (%%Creator, %%CreateDate, %%Title, dll).
+File EPS dengan metadata XMP yang terisi akan disimpan di fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Lihat Juga
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/indonesian/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/indonesian/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 20
+url: /id/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Menambahkan nilai ke dalam array. Nilai akan ditambahkan di akhir array.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/indonesian/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/indonesian/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 30
+url: /id/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Menambahkan nilai bernama ke dalam struktur.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/indonesian/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/indonesian/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 40
+url: /id/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Mendaftarkan URI namespace dan menambahkan nilai.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/indonesian/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/indonesian/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan metadata XMP"
+type: docs
+weight: 40
+url: /id/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Menambahkan nilai bernama ke dalam struktur.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+| fileNameResult | string | Nama file hasil. |
+
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | XMP | array nilai metadata |
+|  | fileNameResult | nama file hasil |
+
+### Contoh
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Lihat Juga
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/indonesian/nodejs-cpp/xps/_index.md
+++ b/indonesian/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Fungsi XPS"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Fungsi untuk bekerja dengan file XPS."
+weight: 42
+type: docs
+url: /id/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Fungsi | Deskripsi |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Dapatkan jumlah halaman dalam dokumen xps. |
+
+## Detailed Description
+
+Manipulasi file XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+atau
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/indonesian/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/indonesian/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page untuk JavaScript via C++"
+description: "Dapatkan jumlah halaman dalam file XPS"
+type: docs
+weight: 10
+url: /id/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Dapatkan jumlah halaman dalam dokumen xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Tipe | Deskripsi |
+| --------- | ---- | ----------- |
+| fileBlob | Objek Blob | Konten file sumber. |
+| fileName | string | Nama file sumber. |
+
+### Nilai Kembalian
+
+Objek JSON
+| Bidang | Deskripsi |
+| ----- | ----------- |
+|  | errorCode | kesalahan kode (0 tidak ada kesalahan) |
+|  | errorText | kesalahan teks ("" tidak ada kesalahan) |
+|  | pageCount | jumlah halaman |
+
+### Contoh
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Indonesian** (`id`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `indonesian/nodejs-cpp`

🤖 Generated by RDA