### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Italian

### DIFF
--- a/italian/nodejs-cpp/convert/_index.md
+++ b/italian/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Funzioni di conversione"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di conversione per lavorare con file Postscript/XPS."
+weight: 10
+type: docs
+url: /it/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Converti un file Postscript in immagine. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Converti un file Postscript in PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Converti un file XPS in immagine. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Converti un file XPS in PDF. |
+
+## Detailed Description
+
+Converti un file postscript o xps in immagine o file PDF.
+
+
+

--- a/italian/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/italian/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte il Postscript in immagine"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Converte il Postscript in immagine.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | string | Nome file. |
+| imageFormat | ImageFormat | formato immagine in cui convertire. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/italian/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/italian/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte il Postscript in PDF"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converte il Postscript in PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | string | Nome file. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page per Node.js via esempi C++.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Si è verificato un errore sconosciuto: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/italian/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/italian/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte l'XPS in immagine"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Converte il Postscript in immagine.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | string | Nome file. |
+| imageFormat | ImageFormat | formato immagine in cui convertire. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/italian/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/italian/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Converte l'XPS in PDF"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converte l'XPS in PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del font sorgente per la conversione. |
+| fileName | string | Nome file. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/italian/nodejs-cpp/enumerations/_index.md
+++ b/italian/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Enumerazioni"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per la conversione dei font in formati TrueType."
+weight: 80
+type: docs
+url: /it/javascript-cpp/enumerations/
+---
+
+## Enumerazioni
+
+| Enumerazione | Descrizione |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Specifica il formato immagine. |
+| [Units](./units/) | Specifica il tipo di dimensione. |
+

--- a/italian/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/italian/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "ImageFormat enum. Specifica il formato immagine"
+type: docs
+weight: 100
+url: /it/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Specifica il formato immagine.
+
+```csharp
+public enum ImageFormat
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| ---  | ---   | --- |
+| Bmp | `0` | Formato immagine BMP. |
+| Jpeg | `1` | Formato immagine JPG. |
+| Gif | `2` | Formato immagine GIF. |
+| Tiff | `3` | Formato immagine TIFF. |
+

--- a/italian/nodejs-cpp/enumerations/units/_index.md
+++ b/italian/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Unità"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Units enum. Specifica il tipo di dimensione"
+type: docs
+weight: 100
+url: /it/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Specifica il tipo di dimensione.
+
+```js
+enum Units
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| ---        | ---   | --- |
+| Points | `0` | Punti (1/72 di pollice). |
+| Inches | `1` | Pollici. |
+| Millimeters | `2` | Millimetri. |
+| Centimeters | `3` | Centimetri. |
+| Percents | `4` | Percentuali della dimensione esistente. |

--- a/italian/nodejs-cpp/eps/_index.md
+++ b/italian/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Funzioni EPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file EPS."
+weight: 41
+type: docs
+url: /it/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Ritaglia file EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Ridimensiona file EPS. |
+
+## Detailed Description
+
+Manipola la dimensione del file EPS.
+
+

--- a/italian/nodejs-cpp/eps/cropeps/_index.md
+++ b/italian/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ritaglia EPS"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Ritaglia il file EPS. Salva il file EPS originale con il %%BoundingBox esistente aggiornato oppure ne crea uno nuovo.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+| sinistra | float | Specifica il limite sinistro della casella di ritaglio. |
+| alto | float | Specifica il limite superiore della casella di ritaglio. |
+| destra | float | Specifica il limite destro della casella di ritaglio. |
+| inferiore | float | Specifica il limite inferiore della casella di ritaglio. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/italian/nodejs-cpp/eps/resizeeps/_index.md
+++ b/italian/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ridimensiona EPS"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Ridimensiona il file EPS. Salva il file EPS originale con il %%BoundingBox esistente aggiornato o ne crea uno nuovo.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+| larghezza | float | Specifica la larghezza del nuovo bounding box. |
+| altezza | float | Specifica l'altezza del nuovo bounding box. |
+| unità | Module.Units | Specifica il tipo della nuova dimensione. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/italian/nodejs-cpp/image/_index.md
+++ b/italian/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funzioni immagine"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file immagine."
+weight: 50
+type: docs
+url: /it/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Salva il file immagine come EPS. |
+
+## Detailed Description
+
+Salva l'immagine dei formati più popolari come BMP, PNG, JPEG, GOF, TIFF in un file EPS.
+

--- a/italian/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/italian/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ridimensiona EPS"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Ridimensiona il file EPS. Salva il file EPS originale con il %%BoundingBox esistente aggiornato o ne crea uno nuovo.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+

--- a/italian/nodejs-cpp/merge/_index.md
+++ b/italian/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Funzioni di unione"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di unione per lavorare con file Postscript/XPS."
+weight: 20
+type: docs
+url: /it/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Unisci file Postscript in PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Unisci file XPS in PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Unisci un file XPS in un file XPS. |
+
+## Detailed Description
+
+Unisci diversi file postscript o xps in un unico file pdf o diversi file xps in un unico file xps.
+
+

--- a/italian/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/italian/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Unisci i file Postscript in PDF"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Unisci i file Postscript in PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileNames | string | I nomi dei file da unire. |
+| fileNameResult | string | Il nome del file PDF risultante. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/italian/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/italian/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Unisci i file XPS in PDF"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Unisci i file XPS in PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileNames | string | I nomi dei file da unire. |
+| fileNameResult | string | Il nome del file PDF risultante. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/italian/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/italian/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Unisci i file XPS in un unico XPS"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Unisci i diversi file XPS in un unico file XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileNames | string | I nomi dei file da unire. |
+| fileNameResult | string | Il nome del file XPS risultante. |
+| supressErrors | bool | Specifica se gli errori devono essere soppressi o meno. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/italian/nodejs-cpp/misc/_index.md
+++ b/italian/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Funzioni varie"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni secondarie per lavorare con file Postscript/XPS."
+weight: 70
+type: docs
+url: /it/nodejs-cpp/misc/
+---
+## Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Ottieni informazioni sul prodotto. |
+
+## Detailed Description
+
+Funzioni secondarie per lavorare con file Postscript/XPS.
+

--- a/italian/nodejs-cpp/misc/pageabout/_index.md
+++ b/italian/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni informazioni sul prodotto."
+type: docs
+url: /it/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Ottieni informazioni sul prodotto.
+
+```js
+function AsposePageAbout()
+```
+
+### Valore restituito
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+| errorCode | errore di codice (0 nessun errore) |
+| errorText | errore di testo ("" nessun errore) |
+| prodotto | Nome prodotto |
+| versione | Versione prodotto |
+| islicensed | Il prodotto è con licenza |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/italian/nodejs-cpp/ps/_index.md
+++ b/italian/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Funzioni PS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file PS."
+weight: 40
+type: docs
+url: /it/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Ottieni i limiti del file PS. |
+| [AsposePSExtractText](./psextracttext/) | Estrai testo dal file PS. |
+
+## Detailed Description
+
+Manipola file PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/nodejs-cpp/ps/psextracttext/_index.md
+++ b/italian/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Estrai testo da file PS"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Estrai testo da file PS. Il testo può essere estratto solo se è scritto con font Type 42 (TrueType) o font Type 0 con font Type 42 nella sua Mappa Vettoriale.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| inizio | int | Specifica la pagina da cui iniziare a estrarre il testo. Questo parametro è utile per documenti multipagina. |
+| fine | int | Specifica la pagina fino a cui terminare l'estrazione del testo. Questo parametro è utile per documenti multipagina. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | testo | il testo estratto |
+
+### Esempi
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Vedi anche
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/italian/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/italian/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni riquadro di delimitazione"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Legge il file EPS ed estrae il riquadro di delimitazione dell'immagine EPS dal commento %%BoundingBox o i limiti per la dimensione di pagina predefinita (0, 0, 595, 842) se non esiste.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | bbox | il riquadro di delimitazione dell'immagine EPS. |
+
+### Esempi
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/italian/nodejs-cpp/xmp/_index.md
+++ b/italian/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Funzioni di metadati XMP"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni di metadati XMP per lavorare con file EPS."
+weight: 30
+type: docs
+url: /it/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Nome | Descrizione |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Ottieni i metadati XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Aggiunge un valore in un array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Aggiunge un valore nominato in una struttura. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registra l'URI dello spazio dei nomi e aggiunge il valore. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Unisci file Postscript in PDF. |
+
+## Detailed Description
+
+Converti un file postscript o xps in immagine o file PDF.
+
+
+

--- a/italian/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/italian/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Legge il file PS/EPS ed estrae XmpMetdata se esiste già.
+Se il file EPS non contiene metadati XMP, ne otteniamo uno nuovo riempito con i valori dei commenti dei metadati PS (%%Creator, %%CreateDate, %%Title ecc).
+Il file EPS con i metadati XMP compilati verrà salvato in fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Vedi anche
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/italian/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/italian/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 20
+url: /it/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Aggiunge un valore in un array. Il valore verrà aggiunto alla fine dell'array.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/italian/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/italian/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 30
+url: /it/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Aggiunge un valore nominato in una struttura.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/italian/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/italian/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 40
+url: /it/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registra l'URI dello spazio dei nomi e aggiunge il valore.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/italian/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/italian/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni i metadati XMP"
+type: docs
+weight: 40
+url: /it/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Aggiunge un valore nominato in una struttura.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+| fileNameResult | string | Nome del file di risultato. |
+
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | XMP | array di valori dei metadati |
+|  | fileNameResult | nome file risultato |
+
+### Esempi
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Vedi anche
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/italian/nodejs-cpp/xps/_index.md
+++ b/italian/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funzioni XPS"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Funzioni per lavorare con file XPS."
+weight: 42
+type: docs
+url: /it/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Funzione | Descrizione |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Ottieni il numero di pagine nel documento xps. |
+
+## Detailed Description
+
+Manipola il file XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/italian/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/italian/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page per JavaScript via C++"
+description: "Ottieni il numero di pagine nel file XPS"
+type: docs
+weight: 10
+url: /it/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Ottieni il numero di pagine nel documento xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parametro | Tipo | Descrizione |
+| --------- | ---- | ----------- |
+| fileBlob | Oggetto Blob | Contenuto del file di origine. |
+| fileName | string | Nome del file di origine. |
+
+### Valore di ritorno
+
+oggetto JSON
+| Campo | Descrizione |
+| ----- | ----------- |
+|  | errorCode | errore di codice (0 nessun errore) |
+|  | errorText | errore di testo ("" nessun errore) |
+|  | pageCount | numero di pagine |
+
+### Esempi
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Italian** (`it`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `italian/nodejs-cpp`

🤖 Generated by RDA