### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Japanese

### DIFF
--- a/japanese/nodejs-cpp/convert/_index.md
+++ b/japanese/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "変換関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルを操作するための変換関数。"
+weight: 10
+type: docs
+url: /ja/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Postscript ファイルを画像に変換します。 |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Postscript ファイルを PDF に変換します。 |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | XPS ファイルを画像に変換します。 |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | XPS ファイルを PDF に変換します。 |
+
+## Detailed Description
+
+Postscript または XPS ファイルを画像または PDF ファイルに変換します。
+
+
+

--- a/japanese/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/japanese/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript を画像に変換します"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript を画像に変換します。
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容です。 |
+| fileName | string | ファイル名。 |
+| imageFormat | ImageFormat | 変換する画像形式。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/japanese/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/japanese/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript を PDF に変換します"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Postscript を PDF に変換します。
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容です。 |
+| fileName | string | ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`不明なエラーが発生しました: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/japanese/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/japanese/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS を画像に変換します"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript を画像に変換します。
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容です。 |
+| fileName | string | ファイル名。 |
+| imageFormat | ImageFormat | 変換する画像形式。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/japanese/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/japanese/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS を PDF に変換します"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+XPS を PDF に変換します。
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | 変換用のソースフォントの内容です。 |
+| fileName | string | ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/japanese/nodejs-cpp/enumerations/_index.md
+++ b/japanese/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "列挙体"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "フォントを TrueType 形式に変換するための機能です。"
+weight: 80
+type: docs
+url: /ja/javascript-cpp/enumerations/
+---
+
+## 列挙体
+
+| 列挙 | 説明 |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | 画像形式を指定します。 |
+| [Units](./units/) | サイズの種類を指定します。 |
+

--- a/japanese/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/japanese/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "ImageFormat 列挙体。画像形式を指定します"
+type: docs
+weight: 100
+url: /ja/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+画像形式を指定します。
+
+```csharp
+public enum ImageFormat
+```
+
+### 値
+
+| 名前 | 値 | 説明 |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP 画像形式。 |
+| Jpeg | `1` | JPG 画像形式。 |
+| Gif | `2` | GIF 画像形式。 |
+| Tiff | `3` | TIFF 画像形式。 |
+

--- a/japanese/nodejs-cpp/enumerations/units/_index.md
+++ b/japanese/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Units 列挙体。サイズの種類を指定します"
+type: docs
+weight: 100
+url: /ja/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+サイズの種類を指定します。
+
+```js
+enum Units
+```
+
+### 値
+
+| 名前 | 値 | 説明 |
+| ---        | ---   | --- |
+| Points | `0` | ポイント (1/72 インチ)。 |
+| Inches | `1` | インチ。 |
+| Millimeters | `2` | ミリメートル。 |
+| Centimeters | `3` | センチメートル。 |
+| Percents | `4` | 既存サイズのパーセント。 |

--- a/japanese/nodejs-cpp/eps/_index.md
+++ b/japanese/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "EPS 関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS ファイルを操作するための関数。"
+weight: 41
+type: docs
+url: /ja/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS ファイルをトリミングします。 |
+| [AsposeResizeEPS](./resizeeps/) | EPS ファイルのサイズを変更します。 |
+
+## Detailed Description
+
+EPS ファイルのサイズを操作します。
+
+

--- a/japanese/nodejs-cpp/eps/cropeps/_index.md
+++ b/japanese/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS をトリミング"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+EPS ファイルをトリミングします。既存の %%BoundingBox を更新した初期 EPS ファイルを保存するか、新しいファイルが作成されます。
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+| 左 | float | トリミングボックスの左境界を指定します。 |
+| 上 | float | トリミングボックスの上境界を指定します。 |
+| 右 | float | トリミングボックスの右境界を指定します。 |
+| 下 | float | トリミングボックスの下境界を指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/japanese/nodejs-cpp/eps/resizeeps/_index.md
+++ b/japanese/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS のリサイズ"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+EPS ファイルのサイズを変更します。既存の %%BoundingBox を更新した初期 EPS ファイルを保存するか、新しいものが作成されます。
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+| width | float | 新しいバウンディングボックスの幅を指定します。 |
+| height | float | 新しいバウンディングボックスの高さを指定します。 |
+| unit | Module.Units | 新しいサイズのタイプを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/japanese/nodejs-cpp/image/_index.md
+++ b/japanese/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "画像機能"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "画像ファイルを操作するための機能です。"
+weight: 50
+type: docs
+url: /ja/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | 画像ファイルを EPS として保存します。 |
+
+## Detailed Description
+
+最も一般的な形式の画像（BMP、PNG、JPEG、GOF、TIFF）を EPS ファイルとして保存します。
+

--- a/japanese/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/japanese/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS のリサイズ"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+EPS ファイルのサイズを変更します。既存の %%BoundingBox を更新した初期 EPS ファイルを保存するか、新しいものが作成されます。
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+

--- a/japanese/nodejs-cpp/merge/_index.md
+++ b/japanese/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "結合機能"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルを操作するための結合機能です。"
+weight: 20
+type: docs
+url: /ja/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Postscript ファイルを PDF に結合します。 |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | XPS ファイルを PDF に結合します。 |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | XPS ファイルを XPS ファイルに結合します。 |
+
+## Detailed Description
+
+複数の Postscript または XPS ファイルを 1 つの PDF ファイルに結合するか、複数の XPS ファイルを 1 つの XPS ファイルに結合します。
+
+

--- a/japanese/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/japanese/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript ファイルを PDF に結合する"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Postscript ファイルを PDF に結合する。
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileNames | string | マージするファイルの名前。 |
+| fileNameResult | string | 結果の PDF ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/japanese/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/japanese/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルを PDF に結合する"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+XPS ファイルを PDF に結合する。
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileNames | string | マージするファイルの名前。 |
+| fileNameResult | string | 結果の PDF ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/japanese/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/japanese/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルを 1つの XPS に結合する"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+複数の XPS ファイルを 1つの XPS ファイルに結合する。
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileNames | string | マージするファイルの名前。 |
+| fileNameResult | string | 結果の XPS ファイル名。 |
+| supressErrors | bool | エラーを抑制するかどうかを指定します。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/japanese/nodejs-cpp/misc/_index.md
+++ b/japanese/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "その他の機能"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "Postscript/XPS ファイルを操作するための二次的な機能です。"
+weight: 70
+type: docs
+url: /ja/nodejs-cpp/misc/
+---
+## Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | 製品に関する情報を取得します。 |
+
+## Detailed Description
+
+Postscript/XPS ファイルを操作するための二次的な機能です。
+

--- a/japanese/nodejs-cpp/misc/pageabout/_index.md
+++ b/japanese/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "製品に関する情報を取得します。"
+type: docs
+url: /ja/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+製品に関する情報を取得します。
+
+```js
+function AsposePageAbout()
+```
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+| errorCode | コードエラー (0 エラーなし) |
+| errorText | テキストエラー ("" エラーなし) |
+| 製品 | 製品名 |
+| バージョン | 製品バージョン |
+| islicensed | 製品はライセンスされています |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/japanese/nodejs-cpp/ps/_index.md
+++ b/japanese/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS 関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "PS ファイルを操作するための関数。"
+weight: 40
+type: docs
+url: /ja/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | PS ファイルの境界を取得します。 |
+| [AsposePSExtractText](./psextracttext/) | PS ファイルからテキストを抽出します。 |
+
+## Detailed Description
+
+PS ファイルを操作します。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/nodejs-cpp/ps/psextracttext/_index.md
+++ b/japanese/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "PS ファイルからテキストを抽出する"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+PS ファイルからテキストを抽出します。テキストは、Type 42（TrueType）フォントで書かれているか、または Vector Map 内に Type 42 フォントを含む Type 0 フォントで書かれている場合にのみ抽出できます。
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| 開始 | int | テキスト抽出を開始するページを指定します。このパラメータは複数ページのドキュメントで有用です。 |
+| 終了 | int | テキスト抽出を終了するページを指定します。このパラメータは複数ページのドキュメントで有用です。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | テキスト | 抽出されたテキスト |
+
+### 例
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### 関連項目
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/japanese/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/japanese/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "バウンディングボックスを取得"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+EPS ファイルを読み取り、%%BoundingBox コメントから EPS 画像のバウンディングボックスを抽出するか、存在しない場合はデフォルトページサイズ (0, 0, 595, 842) の境界を使用します。
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | bbox | EPS 画像のバウンディングボックス。 |
+
+### 例
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### 関連項目
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/japanese/nodejs-cpp/xmp/_index.md
+++ b/japanese/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "XMP メタデータ機能"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "EPS ファイルを操作するための XMP メタデータ機能です。"
+weight: 30
+type: docs
+url: /ja/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| 名前 | 説明 |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | XMP メタデータを取得します。 |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | 配列に値を追加します。 |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | 構造体に名前付きの値を追加します。 |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | 名前空間 URI を登録し、値を追加します。 |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Postscript ファイルを PDF に結合します。 |
+
+## Detailed Description
+
+Postscript または XPS ファイルを画像または PDF ファイルに変換します。
+
+
+

--- a/japanese/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/japanese/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMP メタデータを取得する"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+PS/EPS ファイルを読み取り、既に存在する場合は XMP メタデータを抽出します。
+EPS ファイルに XMP メタデータが含まれていない場合、PS メタデータコメント（%%Creator、%%CreateDate、%%Title など）から取得した値で埋められた新しいメタデータを生成します。
+XMP メタデータが埋め込まれた EPS ファイルは fileNameResult に保存されます。
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 関連項目
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/japanese/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/japanese/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMP メタデータを取得する"
+type: docs
+weight: 20
+url: /ja/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+配列に値を追加します。その値は配列の末尾に追加されます。
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 関連項目
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/japanese/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/japanese/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMP メタデータを取得する"
+type: docs
+weight: 30
+url: /ja/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+構造体に名前付きの値を追加します。
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 関連項目
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/japanese/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/japanese/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMP メタデータを取得する"
+type: docs
+weight: 40
+url: /ja/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+名前空間 URI を登録し、値を追加します。
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 関連項目
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/japanese/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/japanese/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XMP メタデータを取得する"
+type: docs
+weight: 40
+url: /ja/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+構造体に名前付きの値を追加します。
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+| fileNameResult | string | 結果ファイル名。 |
+
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | XMP | メタデータ値の配列 |
+|  | fileNameResult | 結果ファイル名 |
+
+### 例
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 関連項目
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/japanese/nodejs-cpp/xps/_index.md
+++ b/japanese/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS 関数"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルを操作するための関数。"
+weight: 42
+type: docs
+url: /ja/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| 関数 | 説明 |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | XPS ドキュメントのページ数を取得します。 |
+
+## Detailed Description
+
+XPS ファイルを操作します。
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+または
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/japanese/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/japanese/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "C++ 経由で JavaScript 用 Aspose.Page"
+description: "XPS ファイルのページ数を取得する"
+type: docs
+weight: 10
+url: /ja/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+XPS ドキュメントのページ数を取得します。
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| パラメーター | 型 | 説明 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob オブジェクト | ソースファイルの内容。 |
+| fileName | string | ソースファイル名。 |
+
+### 戻り値
+
+JSON オブジェクト
+| フィールド | 説明 |
+| ----- | ----------- |
+|  | errorCode | コードエラー (0 エラーなし) |
+|  | errorText | テキストエラー ("" エラーなし) |
+|  | pageCount | ページ数 |
+
+### 例
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Japanese** (`ja`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `japanese/nodejs-cpp`

🤖 Generated by RDA