### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Korean

### DIFF
--- a/korean/nodejs-cpp/convert/_index.md
+++ b/korean/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "변환 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Postscript/XPS 파일을 다루기 위한 변환 기능."
+weight: 10
+type: docs
+url: /ko/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Postscript 파일을 이미지로 변환합니다. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Postscript 파일을 PDF로 변환합니다. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | XPS 파일을 이미지로 변환합니다. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | XPS 파일을 PDF로 변환합니다. |
+
+## Detailed Description
+
+Postscript 또는 XPS 파일을 이미지 또는 PDF 파일로 변환합니다.
+
+
+

--- a/korean/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/korean/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Postscript를 이미지로 변환합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript를 이미지로 변환합니다.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴 내용. |
+| fileName | string | 파일 이름. |
+| imageFormat | ImageFormat | 변환할 이미지 형식. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/korean/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/korean/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Postscript를 PDF로 변환합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Postscript를 PDF로 변환합니다.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴 내용. |
+| fileName | string | 파일 이름. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ 예제.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`알 수 없는 오류가 발생했습니다: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/korean/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/korean/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XPS를 이미지로 변환합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Postscript를 이미지로 변환합니다.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴 내용. |
+| fileName | string | 파일 이름. |
+| imageFormat | ImageFormat | 변환할 이미지 형식. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/korean/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/korean/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XPS를 PDF로 변환합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+XPS를 PDF로 변환합니다.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 변환을 위한 원본 글꼴 내용. |
+| fileName | string | 파일 이름. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/korean/nodejs-cpp/enumerations/_index.md
+++ b/korean/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "열거형"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "글꼴을 TrueType 형식으로 변환하는 기능."
+weight: 80
+type: docs
+url: /ko/javascript-cpp/enumerations/
+---
+
+## 열거형
+
+| 열거형 | 설명 |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | 이미지 형식을 지정합니다. |
+| [Units](./units/) | 크기 유형을 지정합니다. |
+

--- a/korean/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/korean/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "ImageFormat 열거형. 이미지 형식을 지정합니다."
+type: docs
+weight: 100
+url: /ko/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+이미지 형식을 지정합니다.
+
+```csharp
+public enum ImageFormat
+```
+
+### 값
+
+| 이름 | 값 | 설명 |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP 이미지 형식. |
+| Jpeg | `1` | JPG 이미지 형식. |
+| Gif | `2` | GIF 이미지 형식. |
+| Tiff | `3` | TIFF 이미지 형식. |
+

--- a/korean/nodejs-cpp/enumerations/units/_index.md
+++ b/korean/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Units 열거형. 크기 유형을 지정합니다."
+type: docs
+weight: 100
+url: /ko/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+크기 유형을 지정합니다.
+
+```js
+enum Units
+```
+
+### 값
+
+| 이름 | 값 | 설명 |
+| ---        | ---   | --- |
+| Points | `0` | 포인트 (인치의 1/72). |
+| Inches | `1` | 인치. |
+| Millimeters | `2` | 밀리미터. |
+| Centimeters | `3` | 센티미터. |
+| Percents | `4` | 기존 크기의 백분율. |

--- a/korean/nodejs-cpp/eps/_index.md
+++ b/korean/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "EPS 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "EPS 파일을 다루기 위한 기능."
+weight: 41
+type: docs
+url: /ko/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS 파일을 자릅니다. |
+| [AsposeResizeEPS](./resizeeps/) | EPS 파일의 크기를 조정합니다. |
+
+## Detailed Description
+
+EPS 파일의 크기를 조작합니다.
+
+

--- a/korean/nodejs-cpp/eps/cropeps/_index.md
+++ b/korean/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "EPS 자르기"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+EPS 파일을 자릅니다. 기존 %%BoundingBox를 업데이트한 초기 EPS 파일을 저장하거나 새 파일이 생성됩니다.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+| 왼쪽 | float | 자르기 상자의 왼쪽 경계를 지정합니다. |
+| 위쪽 | float | 자르기 상자의 위쪽 경계를 지정합니다. |
+| 오른쪽 | float | 자르기 상자의 오른쪽 경계를 지정합니다. |
+| 아래쪽 | float | 자르기 상자의 아래쪽 경계를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/korean/nodejs-cpp/eps/resizeeps/_index.md
+++ b/korean/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "EPS 크기 조정"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+EPS 파일의 크기를 조정합니다. 기존 %%BoundingBox를 업데이트하거나 새로 생성된 %%BoundingBox와 함께 초기 EPS 파일을 저장합니다.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+| width | float | 새 경계 상자의 너비를 지정합니다. |
+| height | float | 새 경계 상자의 높이를 지정합니다. |
+| unit | Module.Units | 새 크기의 유형을 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/korean/nodejs-cpp/image/_index.md
+++ b/korean/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "이미지 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "이미지 파일 작업을 위한 기능."
+weight: 50
+type: docs
+url: /ko/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | 이미지 파일을 EPS로 저장합니다. |
+
+## Detailed Description
+
+가장 많이 사용되는 형식의 이미지를 BMP, PNG, JPEG, GOF, TIFF 형식으로 EPS 파일에 저장합니다.
+

--- a/korean/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/korean/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "EPS 크기 조정"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+EPS 파일의 크기를 조정합니다. 기존 %%BoundingBox를 업데이트하거나 새로 생성된 %%BoundingBox와 함께 초기 EPS 파일을 저장합니다.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+

--- a/korean/nodejs-cpp/merge/_index.md
+++ b/korean/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "병합 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Postscript/XPS 파일 작업을 위한 병합 기능."
+weight: 20
+type: docs
+url: /ko/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Postscript 파일을 PDF로 병합합니다. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | XPS 파일을 PDF로 병합합니다. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | XPS 파일을 XPS 파일로 병합합니다. |
+
+## Detailed Description
+
+여러 Postscript 또는 XPS 파일을 하나의 PDF 파일로 병합하거나 여러 XPS 파일을 하나의 XPS 파일로 병합합니다.
+
+

--- a/korean/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/korean/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Postscript 파일을 PDF로 병합합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Postscript 파일을 PDF로 병합합니다.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileNames | string | 병합을 위한 파일 이름들. |
+| fileNameResult | string | 결과 PDF 파일의 이름입니다. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/korean/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/korean/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XPS 파일을 PDF로 병합합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+XPS 파일을 PDF로 병합합니다.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileNames | string | 병합을 위한 파일 이름들. |
+| fileNameResult | string | 결과 PDF 파일의 이름입니다. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/korean/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/korean/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XPS 파일들을 하나의 XPS로 병합합니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+여러 XPS 파일을 하나의 XPS 파일로 병합합니다.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileNames | string | 병합을 위한 파일 이름들. |
+| fileNameResult | string | 결과 XPS 파일의 이름입니다. |
+| supressErrors | bool | 오류를 억제해야 하는지 여부를 지정합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/korean/nodejs-cpp/misc/_index.md
+++ b/korean/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "기타 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "Postscript/XPS 파일 작업을 위한 보조 기능."
+weight: 70
+type: docs
+url: /ko/nodejs-cpp/misc/
+---
+## Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | 제품에 대한 정보를 가져옵니다. |
+
+## Detailed Description
+
+Postscript/XPS 파일 작업을 위한 보조 기능.
+

--- a/korean/nodejs-cpp/misc/pageabout/_index.md
+++ b/korean/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "제품에 대한 정보를 가져옵니다."
+type: docs
+url: /ko/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+제품에 대한 정보를 가져옵니다.
+
+```js
+function AsposePageAbout()
+```
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+| errorCode | 코드 오류 (0 오류 없음) |
+| errorText | 텍스트 오류 ("" 오류 없음) |
+| 제품 | 제품 이름 |
+| 버전 | 제품 버전 |
+| islicensed | 제품에 라이선스가 부여되었습니다. |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/korean/nodejs-cpp/ps/_index.md
+++ b/korean/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "PS 파일을 다루기 위한 기능."
+weight: 40
+type: docs
+url: /ko/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | PS 파일의 경계를 가져옵니다. |
+| [AsposePSExtractText](./psextracttext/) | PS 파일에서 텍스트를 추출합니다. |
+
+## Detailed Description
+
+PS 파일을 조작합니다.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/nodejs-cpp/ps/psextracttext/_index.md
+++ b/korean/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "PS 파일에서 텍스트 추출"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+PS 파일에서 텍스트를 추출합니다. 텍스트는 Type 42(TrueType) 글꼴 또는 Type 0 글꼴에 Type 42 글꼴이 포함된 Vector Map으로 작성된 경우에만 추출할 수 있습니다.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| 시작 | int | 텍스트 추출을 시작할 페이지를 지정합니다. 이 매개변수는 다중 페이지 문서에 유용합니다. |
+| 끝 | int | 텍스트 추출을 마칠 페이지를 지정합니다. 이 매개변수는 다중 페이지 문서에 유용합니다. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | 텍스트 | 추출된 텍스트 |
+
+### 예제
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### 관련 항목
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/korean/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/korean/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "경계 상자를 가져옵니다"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+EPS 파일을 읽고 EPS 이미지의 경계 상자를 %%BoundingBox 주석에서 추출하거나, 존재하지 않을 경우 기본 페이지 크기 (0, 0, 595, 842)의 경계 값을 사용합니다.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | bbox | EPS 이미지의 경계 상자. |
+
+### 예제
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### 관련 항목
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/korean/nodejs-cpp/xmp/_index.md
+++ b/korean/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "XMP 메타데이터 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "EPS 파일 작업을 위한 XMP 메타데이터 기능."
+weight: 30
+type: docs
+url: /ko/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| 이름 | 설명 |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | XMP 메타데이터를 가져옵니다. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | 값을 배열에 추가합니다. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | 명명된 값을 구조체에 추가합니다. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | 네임스페이스 URI를 등록하고 값을 추가합니다. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Postscript 파일을 PDF로 병합합니다. |
+
+## Detailed Description
+
+Postscript 또는 XPS 파일을 이미지 또는 PDF 파일로 변환합니다.
+
+
+

--- a/korean/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/korean/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+PS/EPS 파일을 읽고 XmpMetdata가 이미 존재하면 추출합니다.
+EPS 파일에 XMP 메타데이터가 없으면 PS 메타데이터 주석(%%Creator, %%CreateDate, %%Title 등)에서 값을 채워 새로운 메타데이터를 생성합니다.
+EPS 파일에 채워진 XMP 메타데이터가 fileNameResult에 저장됩니다.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### 관련 항목
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/korean/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/korean/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 20
+url: /ko/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+배열에 값을 추가합니다. 값은 배열의 끝에 추가됩니다.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 관련 항목
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/korean/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/korean/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 30
+url: /ko/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+명명된 값을 구조체에 추가합니다.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 관련 항목
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/korean/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/korean/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 40
+url: /ko/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+네임스페이스 URI를 등록하고 값을 추가합니다.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 관련 항목
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/korean/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/korean/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XMP 메타데이터 가져오기"
+type: docs
+weight: 40
+url: /ko/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+명명된 값을 구조체에 추가합니다.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+| fileNameResult | string | 결과 파일 이름. |
+
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | XMP | 메타데이터 값 배열 |
+|  | fileNameResult | 결과 파일 이름 |
+
+### 예제
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### 관련 항목
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/korean/nodejs-cpp/xps/_index.md
+++ b/korean/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS 기능"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XPS 파일을 다루기 위한 기능."
+weight: 42
+type: docs
+url: /ko/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| 기능 | 설명 |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | xps 문서의 페이지 수를 가져옵니다. |
+
+## Detailed Description
+
+XPS 파일을 조작합니다.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+또는
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/korean/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/korean/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "C++를 통한 JavaScript용 Aspose.Page"
+description: "XPS 파일의 페이지 수 가져오기"
+type: docs
+weight: 10
+url: /ko/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+xps 문서의 페이지 수를 가져옵니다.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| 매개변수 | 유형 | 설명 |
+| --------- | ---- | ----------- |
+| fileBlob | Blob 객체 | 소스 파일의 내용. |
+| fileName | string | 소스 파일 이름. |
+
+### 반환 값
+
+JSON 객체
+| 필드 | 설명 |
+| ----- | ----------- |
+|  | errorCode | 코드 오류 (0 오류 없음) |
+|  | errorText | 텍스트 오류 ("" 오류 없음) |
+|  | pageCount | 페이지 수 |
+
+### 예제
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Korean** (`ko`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `korean/nodejs-cpp`

🤖 Generated by RDA