### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Netherlands

### DIFF
--- a/netherlands/nodejs-cpp/convert/_index.md
+++ b/netherlands/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Conversiefuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Conversiefuncties voor het werken met Postscript/XPS-bestanden."
+weight: 10
+type: docs
+url: /nl/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Converteer een Postscript-bestand naar afbeelding. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Converteer een Postscript-bestand naar PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Converteer een XPS-bestand naar afbeelding. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Converteer een XPS-bestand naar PDF. |
+
+## Detailed Description
+
+Converteer een postscript- of xps-bestand naar afbeelding of PDF-bestand.
+
+
+

--- a/netherlands/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/netherlands/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de Postscript naar afbeelding"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Converteert de Postscript naar afbeelding.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| imageFormat | ImageFormat | beeldformaat om naar te converteren. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/netherlands/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/netherlands/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de Postscript naar PDF"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converteert de Postscript naar PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page voor Node.js via C++ voorbeelden.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Er is een onbekende fout opgetreden: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/netherlands/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/netherlands/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de XPS naar afbeelding"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Converteert de Postscript naar afbeelding.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| imageFormat | ImageFormat | beeldformaat om naar te converteren. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/netherlands/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/netherlands/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Converteert de XPS naar PDF"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Converteert de XPS naar PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van het bronlettertype voor conversie. |
+| fileName | string | Bestandsnaam. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/netherlands/nodejs-cpp/enumerations/_index.md
+++ b/netherlands/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Enumeraties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het converteren van lettertypen naar True‑Type‑formaten."
+weight: 80
+type: docs
+url: /nl/javascript-cpp/enumerations/
+---
+
+## Enumeraties
+
+| Enumeratie | Beschrijving |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Specificeert afbeeldingsformaat. |
+| [Units](./units/) | Specificeert type van grootte. |
+

--- a/netherlands/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/netherlands/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "ImageFormat enum. Specificeert beeldformaat"
+type: docs
+weight: 100
+url: /nl/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Specificeert afbeeldingsformaat.
+
+```csharp
+public enum ImageFormat
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP-beeldformaat. |
+| Jpeg | `1` | JPG-beeldformaat. |
+| Gif | `2` | GIF-beeldformaat. |
+| Tiff | `3` | TIFF-beeldformaat. |
+

--- a/netherlands/nodejs-cpp/enumerations/units/_index.md
+++ b/netherlands/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Units"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Units enum. Specificeert type van grootte"
+type: docs
+weight: 100
+url: /nl/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Specificeert type van grootte.
+
+```js
+enum Units
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| ---        | ---   | --- |
+| Points | `0` | Punten (1/72 van een duim). |
+| Inches | `1` | Inches. |
+| Millimeters | `2` | Millimeters. |
+| Centimeters | `3` | Centimeters. |
+| Percents | `4` | Procenten van bestaande grootte. |

--- a/netherlands/nodejs-cpp/eps/_index.md
+++ b/netherlands/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "EPS-functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met EPS-bestanden."
+weight: 41
+type: docs
+url: /nl/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | EPS-bestand bijsnijden. |
+| [AsposeResizeEPS](./resizeeps/) | EPS-bestand van formaat wijzigen. |
+
+## Detailed Description
+
+Grootte van EPS-bestand aanpassen.
+
+

--- a/netherlands/nodejs-cpp/eps/cropeps/_index.md
+++ b/netherlands/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "EPS bijsnijden"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Bijsnijdt EPS-bestand. Het slaat het oorspronkelijke EPS-bestand op met een bijgewerkte bestaande %%BoundingBox of er wordt een nieuwe aangemaakt.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+| links | float | Specificeert de linkse grens van de bijsnijdingsbox. |
+| boven | float | Specificeert de bovenste grens van de bijsnijdingsbox. |
+| rechts | float | Specificeert de rechtse grens van de bijsnijdingsbox. |
+| onder | float | Specificeert de onderste grens van de bijsnijdingsbox. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/netherlands/nodejs-cpp/eps/resizeeps/_index.md
+++ b/netherlands/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "EPS-grootte wijzigen"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Wijzigt de grootte van een EPS-bestand. Het slaat het oorspronkelijke EPS-bestand op met een bijgewerkte bestaande %%BoundingBox of er wordt een nieuwe aangemaakt.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+| width | float | Specificeert de breedte van het nieuwe begrenzingsvak. |
+| height | float | Specificeert de hoogte van het nieuwe begrenzingsvak. |
+| unit | Module.Units | Specificeert het type van de nieuwe grootte. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/netherlands/nodejs-cpp/image/_index.md
+++ b/netherlands/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Afbeeldingsfuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met afbeeldingsbestanden."
+weight: 50
+type: docs
+url: /nl/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Sla afbeeldingsbestand op als EPS. |
+
+## Detailed Description
+
+Sla afbeelding van de meest populaire formaten op als BMP, PNG, JPEG, GOF, TIFF naar een EPS‑bestand.
+

--- a/netherlands/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/netherlands/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "EPS-grootte wijzigen"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Wijzigt de grootte van een EPS-bestand. Het slaat het oorspronkelijke EPS-bestand op met een bijgewerkte bestaande %%BoundingBox of er wordt een nieuwe aangemaakt.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+

--- a/netherlands/nodejs-cpp/merge/_index.md
+++ b/netherlands/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Samenvoegfuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Samenvoegfuncties voor het werken met Postscript/XPS‑bestanden."
+weight: 20
+type: docs
+url: /nl/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Voeg een Postscript‑bestand samen tot PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Voeg een XPS‑bestand samen tot PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Voeg een XPS‑bestand samen tot XPS‑bestand. |
+
+## Detailed Description
+
+Voeg meerdere Postscript‑ of XPS‑bestanden samen tot één PDF‑bestand of meerdere XPS‑bestanden tot één XPS‑bestand.
+
+

--- a/netherlands/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/netherlands/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Voeg de Postscript-bestanden samen tot PDF"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Voeg de Postscript-bestanden samen tot PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileNames | string | De namen van bestanden voor samenvoegen. |
+| fileNameResult | string | De naam van het resulterende pdf-bestand. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/netherlands/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/netherlands/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Voeg de XPS-bestanden samen tot PDF"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Voeg de XPS-bestanden samen tot PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileNames | string | De namen van bestanden voor samenvoegen. |
+| fileNameResult | string | De naam van het resulterende pdf-bestand. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/netherlands/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/netherlands/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Voeg de XPS-bestanden samen tot één XPS"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Voeg de verschillende XPS-bestanden samen tot één XPS-bestand.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileNames | string | De namen van bestanden voor samenvoegen. |
+| fileNameResult | string | De naam van het resulterende xps-bestand. |
+| supressErrors | bool | Specificeert of fouten al dan niet onderdrukt moeten worden. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/netherlands/nodejs-cpp/misc/_index.md
+++ b/netherlands/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Diverse functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Secundaire functies voor het werken met Postscript/XPS‑bestanden."
+weight: 70
+type: docs
+url: /nl/nodejs-cpp/misc/
+---
+## Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Haal informatie op over Product. |
+
+## Detailed Description
+
+Secundaire functies voor het werken met Postscript/XPS‑bestanden.
+

--- a/netherlands/nodejs-cpp/misc/pageabout/_index.md
+++ b/netherlands/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal informatie op over Product."
+type: docs
+url: /nl/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Haal informatie op over Product.
+
+```js
+function AsposePageAbout()
+```
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+| errorCode | codefout (0 geen fout) |
+| errorText | tekstfout ("" geen fout) |
+| product | Productnaam |
+| versie | Productversie |
+| islicensed | Product is gelicentieerd |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/netherlands/nodejs-cpp/ps/_index.md
+++ b/netherlands/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS-functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met PS-bestanden."
+weight: 40
+type: docs
+url: /nl/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Haal de grenzen van het PS-bestand op. |
+| [AsposePSExtractText](./psextracttext/) | Extraheer tekst uit PS-bestand. |
+
+## Detailed Description
+
+PS-bestand manipuleren.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/nodejs-cpp/ps/psextracttext/_index.md
+++ b/netherlands/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Tekst extraheren uit PS-bestand"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Tekst extraheren uit PS-bestand. De tekst kan alleen worden geëxtraheerd als deze is geschreven met Type 42 (TrueType)-lettertype of Type 0-lettertype met Type 42-lettertypen in de Vector-Map.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| start | int | Specificeert de pagina waarvan de tekst moet worden geëxtraheerd. Deze parameter is nuttig voor documenten met meerdere pagina's. |
+| end | int | Specificeert de pagina tot waar de tekst moet worden geëxtraheerd. Deze parameter is nuttig voor documenten met meerdere pagina's. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | tekst | de geëxtraheerde tekst |
+
+### Voorbeelden
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Zie ook
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/netherlands/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/netherlands/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Haal begrenzingsvak op"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Leest EPS-bestand en extraheert het begrenzingsvak van de EPS-afbeelding uit de %%BoundingBox-opmerking of de grenzen voor de standaard paginagrootte (0, 0, 595, 842) als deze niet bestaat.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | bbox | het begrenzingsvak van de EPS-afbeelding. |
+
+### Voorbeelden
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Zie ook
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/netherlands/nodejs-cpp/xmp/_index.md
+++ b/netherlands/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "XMP‑metadatafuncties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP‑metadatafuncties voor het werken met EPS‑bestanden."
+weight: 30
+type: docs
+url: /nl/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Naam | Beschrijving |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Haal XMP‑metadata op. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Voegt een waarde toe aan een array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Voegt een benoemde waarde toe aan een structuur. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registreert namespace‑URI en voegt waarde toe. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Voeg een Postscript‑bestand samen tot PDF. |
+
+## Detailed Description
+
+Converteer een postscript- of xps-bestand naar afbeelding of PDF-bestand.
+
+
+

--- a/netherlands/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/netherlands/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP-metadata ophalen"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Leest PS/EPS-bestand en extraheert XmpMetdata als deze al bestaat.
+Als een EPS-bestand geen XMP-metadata bevat, krijgen we een nieuwe die is gevuld met waarden uit PS-metadata-commentaren (%%Creator, %%CreateDate, %%Title enz.).
+EPS-bestand met ingevulde XMP-metadata wordt opgeslagen in fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata-waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Zie ook
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/netherlands/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/netherlands/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP-metadata ophalen"
+type: docs
+weight: 20
+url: /nl/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Voegt een waarde toe aan een array. De waarde wordt aan het einde van de array toegevoegd.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata-waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/netherlands/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/netherlands/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP-metadata ophalen"
+type: docs
+weight: 30
+url: /nl/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Voegt een benoemde waarde toe aan een structuur.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata-waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/netherlands/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/netherlands/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP-metadata ophalen"
+type: docs
+weight: 40
+url: /nl/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registreert namespace‑URI en voegt waarde toe.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata-waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/netherlands/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/netherlands/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "XMP-metadata ophalen"
+type: docs
+weight: 40
+url: /nl/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Voegt een benoemde waarde toe aan een structuur.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+| fileNameResult | string | Naam van resultaatbestand. |
+
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | XMP | array van metadata-waarden |
+|  | fileNameResult | resultaat bestandsnaam |
+
+### Voorbeelden
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Zie ook
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/netherlands/nodejs-cpp/xps/_index.md
+++ b/netherlands/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS-functies"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Functies voor het werken met XPS-bestanden."
+weight: 42
+type: docs
+url: /nl/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Functie | Beschrijving |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Haal het aantal pagina's op in het xps-document. |
+
+## Detailed Description
+
+Manipuleer het XPS‑bestand.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+of
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/netherlands/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/netherlands/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page voor JavaScript via C++"
+description: "Aantal pagina's in XPS-bestand ophalen"
+type: docs
+weight: 10
+url: /nl/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Haal het aantal pagina's op in het xps-document.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Type | Beschrijving |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-object | Inhoud van bronbestand. |
+| fileName | string | Naam van bronbestand. |
+
+### Retourwaarde
+
+JSON-object
+| Veld | Beschrijving |
+| ----- | ----------- |
+|  | errorCode | codefout (0 geen fout) |
+|  | errorText | tekstfout ("" geen fout) |
+|  | pageCount | aantal pagina's |
+
+### Voorbeelden
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Netherlands** (`nl`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `netherlands/nodejs-cpp`

🤖 Generated by RDA