### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Russian

### DIFF
--- a/russian/nodejs-cpp/convert/_index.md
+++ b/russian/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Функции преобразования"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции преобразования для работы с файлами Postscript/XPS."
+weight: 10
+type: docs
+url: /ru/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Преобразовать файл Postscript в изображение. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Преобразовать файл Postscript в PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Преобразовать файл XPS в изображение. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Преобразовать файл XPS в PDF. |
+
+## Detailed Description
+
+Преобразовать файл postscript или xps в изображение или PDF‑файл.
+
+
+

--- a/russian/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/russian/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует Postscript в изображение"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Преобразует Postscript в изображение.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | string | Имя файла. |
+| imageFormat | ImageFormat | формат изображения для преобразования. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/russian/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/russian/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует Postscript в PDF"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Преобразует Postscript в PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | string | Имя файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page для Node.js через C++ примеры.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Произошла неизвестная ошибка: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/russian/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/russian/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует XPS в изображение"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Преобразует Postscript в изображение.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | string | Имя файла. |
+| imageFormat | ImageFormat | формат изображения для преобразования. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/russian/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/russian/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Преобразует XPS в PDF"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Преобразует XPS в PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного шрифта для преобразования. |
+| fileName | string | Имя файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/russian/nodejs-cpp/enumerations/_index.md
+++ b/russian/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Перечисления"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции конвертации шрифтов в форматы TrueType."
+weight: 80
+type: docs
+url: /ru/javascript-cpp/enumerations/
+---
+
+## Перечисления
+
+| Перечисление | Описание |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Указывает формат изображения. |
+| [Units](./units/) | Указывает тип размера. |
+

--- a/russian/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/russian/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Перечисление ImageFormat"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Перечисление ImageFormat. Указывает формат изображения"
+type: docs
+weight: 100
+url: /ru/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Указывает формат изображения.
+
+```csharp
+public enum ImageFormat
+```
+
+### Значения
+
+| Имя | Значение | Описание |
+| ---  | ---   | --- |
+| Bmp | `0` | Формат изображения BMP. |
+| Jpeg | `1` | Формат изображения JPG. |
+| Gif | `2` | Формат изображения GIF. |
+| Tiff | `3` | Формат изображения TIFF. |
+

--- a/russian/nodejs-cpp/enumerations/units/_index.md
+++ b/russian/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Перечисление Units"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Перечисление Units. Указывает тип размера"
+type: docs
+weight: 100
+url: /ru/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Указывает тип размера.
+
+```js
+enum Units
+```
+
+### Значения
+
+| Имя | Значение | Описание |
+| ---        | ---   | --- |
+| Points | `0` | Точки (1/72 дюйма). |
+| Inches | `1` | Дюймы. |
+| Millimeters | `2` | Миллиметры. |
+| Centimeters | `3` | Сантиметры. |
+| Percents | `4` | Проценты от существующего размера. |

--- a/russian/nodejs-cpp/eps/_index.md
+++ b/russian/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Функции EPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с EPS‑файлами."
+weight: 41
+type: docs
+url: /ru/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Обрезать EPS‑файл. |
+| [AsposeResizeEPS](./resizeeps/) | Изменить размер EPS‑файла. |
+
+## Detailed Description
+
+Манипулировать размером EPS‑файла.
+
+

--- a/russian/nodejs-cpp/eps/cropeps/_index.md
+++ b/russian/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Обрезать EPS"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Обрезает файл EPS. Сохраняет исходный файл EPS с обновлённым существующим %%BoundingBox или создаёт новый.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+| левый | float | Указывает левую границу области обрезки. |
+| верхний | float | Указывает верхнюю границу области обрезки. |
+| правый | float | Указывает правую границу области обрезки. |
+| нижний | float | Указывает нижнюю границу области обрезки. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/russian/nodejs-cpp/eps/resizeeps/_index.md
+++ b/russian/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Изменить размер EPS"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Изменяет размер EPS‑файла. Сохраняет исходный EPS‑файл с обновлённым существующим %%BoundingBox или создаёт новый.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+| width | float | Указывает ширину новой ограничивающей рамки. |
+| height | float | Указывает высоту новой ограничивающей рамки. |
+| unit | Module.Units | Указывает тип нового размера. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/russian/nodejs-cpp/image/_index.md
+++ b/russian/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Функции работы с изображениями"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с файловыми изображениями."
+weight: 50
+type: docs
+url: /ru/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Сохранить файл изображения в формате EPS. |
+
+## Detailed Description
+
+Сохранить изображение в наиболее популярных форматах BMP, PNG, JPEG, GOF, TIFF в файл EPS.
+

--- a/russian/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/russian/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Изменить размер EPS"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Изменяет размер EPS‑файла. Сохраняет исходный EPS‑файл с обновлённым существующим %%BoundingBox или создаёт новый.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+

--- a/russian/nodejs-cpp/merge/_index.md
+++ b/russian/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Функции объединения"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции объединения для работы с файлами Postscript/XPS."
+weight: 20
+type: docs
+url: /ru/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Объединить файлы Postscript в PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Объединить файлы XPS в PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Объединить файлы XPS в файл XPS. |
+
+## Detailed Description
+
+Объединить несколько файлов postscript или xps в один файл pdf или несколько файлов xps в один файл xps.
+
+

--- a/russian/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/russian/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Объединить файлы Postscript в PDF"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Объединить файлы Postscript в PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileNames | string | Имена файлов для объединения. |
+| fileNameResult | string | Имя результирующего PDF-файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/russian/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/russian/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Объединить файлы XPS в PDF"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Объединить файлы XPS в PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileNames | string | Имена файлов для объединения. |
+| fileNameResult | string | Имя результирующего PDF-файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/russian/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/russian/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Объединить файлы XPS в один XPS"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Объединить несколько файлов XPS в один файл XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileNames | string | Имена файлов для объединения. |
+| fileNameResult | string | Имя результирующего XPS-файла. |
+| supressErrors | bool | Указывает, должны ли ошибки подавляться или нет. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/russian/nodejs-cpp/misc/_index.md
+++ b/russian/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Разнообразные функции"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Вторичные функции для работы с файлами Postscript/XPS."
+weight: 70
+type: docs
+url: /ru/nodejs-cpp/misc/
+---
+## Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Получить информацию о продукте. |
+
+## Detailed Description
+
+Вторичные функции для работы с файлами Postscript/XPS.
+

--- a/russian/nodejs-cpp/misc/pageabout/_index.md
+++ b/russian/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить информацию о продукте."
+type: docs
+url: /ru/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Получить информацию о продукте.
+
+```js
+function AsposePageAbout()
+```
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+| errorCode | код ошибки (0 нет ошибки) |
+| errorText | текстовая ошибка ("" нет ошибки) |
+| продукт | Название продукта |
+| версия | Версия продукта |
+| islicensed | Продукт лицензирован |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/russian/nodejs-cpp/ps/_index.md
+++ b/russian/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Функции PS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с PS‑файлами."
+weight: 40
+type: docs
+url: /ru/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Получить границы PS‑файла. |
+| [AsposePSExtractText](./psextracttext/) | Извлечь текст из PS‑файла. |
+
+## Detailed Description
+
+Манипулировать PS‑файлом.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/nodejs-cpp/ps/psextracttext/_index.md
+++ b/russian/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Извлечь текст из PS-файла"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Извлечь текст из PS-файла. Текст может быть извлечён только в том случае, если он написан шрифтом Type 42 (TrueType) или шрифтом Type 0 с шрифтами Type 42 в его Vector Map.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| начало | int | Указывает страницу, с которой начинать извлечение текста. Этот параметр полезен для многостраничных документов. |
+| конец | int | Указывает страницу, до которой следует завершить извлечение текста. Этот параметр полезен для многостраничных документов. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | текст | извлечённый текст |
+
+### Примеры
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### См. также
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/russian/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/russian/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить ограничивающий прямоугольник"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Читает файл EPS и извлекает ограничивающий прямоугольник изображения EPS из комментария %%BoundingBox или границы для размера страницы по умолчанию (0, 0, 595, 842), если он не существует.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | bbox | ограничивающий прямоугольник изображения EPS. |
+
+### Примеры
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### См. также
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/russian/nodejs-cpp/xmp/_index.md
+++ b/russian/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Функции метаданных XMP"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции метаданных XMP для работы с файлами EPS."
+weight: 30
+type: docs
+url: /ru/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Имя | Описание |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Получить метаданные XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Добавляет значение в массив. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Добавляет именованное значение в структуру. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Регистрирует URI пространства имён и добавляет значение. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Объединить файлы Postscript в PDF. |
+
+## Detailed Description
+
+Преобразовать файл postscript или xps в изображение или PDF‑файл.
+
+
+

--- a/russian/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/russian/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP‑метаданные"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Читает файл PS/EPS и извлекает XMP‑метаданные, если они уже существуют.
+Если EPS‑файл не содержит XMP‑метаданных, мы получаем новые, заполненные значениями из комментариев метаданных PS (%%Creator, %%CreateDate, %%Title и т.д.).
+EPS‑файл с заполненными XMP‑метаданными будет сохранён в fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### См. также
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/russian/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/russian/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP‑метаданные"
+type: docs
+weight: 20
+url: /ru/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Добавляет значение в массив. Значение будет добавлено в конец массива.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/russian/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/russian/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP‑метаданные"
+type: docs
+weight: 30
+url: /ru/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Добавляет именованное значение в структуру.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/russian/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/russian/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP‑метаданные"
+type: docs
+weight: 40
+url: /ru/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Регистрирует URI пространства имён и добавляет значение.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/russian/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/russian/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить XMP‑метаданные"
+type: docs
+weight: 40
+url: /ru/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Добавляет именованное значение в структуру.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+| fileNameResult | string | Имя результирующего файла. |
+
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | XMP | массив значений метаданных |
+|  | fileNameResult | имя результирующего файла |
+
+### Примеры
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### См. также
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/russian/nodejs-cpp/xps/_index.md
+++ b/russian/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Функции XPS"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Функции для работы с XPS‑файлами."
+weight: 42
+type: docs
+url: /ru/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Функция | Описание |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Получить количество страниц в xps‑документе. |
+
+## Detailed Description
+
+Манипулировать файлом XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+или
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/russian/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/russian/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page для JavaScript через C++"
+description: "Получить количество страниц в XPS-файле"
+type: docs
+weight: 10
+url: /ru/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Получить количество страниц в xps‑документе.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Параметр | Тип | Описание |
+| --------- | ---- | ----------- |
+| fileBlob | Объект Blob | Содержимое исходного файла. |
+| fileName | string | Имя исходного файла. |
+
+### Возвращаемое значение
+
+Объект JSON
+| Поле | Описание |
+| ----- | ----------- |
+|  | errorCode | код ошибки (0 нет ошибки) |
+|  | errorText | текстовая ошибка ("" нет ошибки) |
+|  | pageCount | количество страниц |
+
+### Примеры
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Russian** (`ru`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `russian/nodejs-cpp`

🤖 Generated by RDA