### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Spanish

### DIFF
--- a/spanish/nodejs-cpp/convert/_index.md
+++ b/spanish/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Funciones de conversión"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones de conversión para trabajar con archivos Postscript/XPS."
+weight: 10
+type: docs
+url: /es/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Convertir un archivo Postscript a imagen. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Convertir un archivo Postscript a PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Convertir un archivo XPS a imagen. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Convertir un archivo XPS a PDF. |
+
+## Detailed Description
+
+Convertir archivo postscript o xps a imagen o archivo PDF.
+
+
+

--- a/spanish/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/spanish/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el Postscript a imagen"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Convierte el Postscript a imagen.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para la conversión. |
+| fileName | string | Nombre del archivo. |
+| imageFormat | ImageFormat | formato de imagen al que convertir. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/spanish/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/spanish/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el Postscript a PDF"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convierte el Postscript a PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para la conversión. |
+| fileName | string | Nombre del archivo. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page para Node.js mediante ejemplos en C++.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Se ha producido un error desconocido: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/spanish/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/spanish/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el XPS a imagen"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Convierte el Postscript a imagen.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para la conversión. |
+| fileName | string | Nombre del archivo. |
+| imageFormat | ImageFormat | formato de imagen al que convertir. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/spanish/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/spanish/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Convierte el XPS a PDF"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Convierte el XPS a PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido de la fuente de origen para la conversión. |
+| fileName | string | Nombre del archivo. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/spanish/nodejs-cpp/enumerations/_index.md
+++ b/spanish/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Enumeraciones"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para convertir fuentes a formatos TrueType."
+weight: 80
+type: docs
+url: /es/javascript-cpp/enumerations/
+---
+
+## Enumeraciones
+
+| Enumeración | Descripción |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Especifica el formato de imagen. |
+| [Units](./units/) | Especifica el tipo de tamaño. |
+

--- a/spanish/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/spanish/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum ImageFormat"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Enum ImageFormat. Especifica el formato de imagen"
+type: docs
+weight: 100
+url: /es/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Especifica el formato de imagen.
+
+```csharp
+public enum ImageFormat
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| ---  | ---   | --- |
+| Bmp | `0` | Formato de imagen BMP. |
+| Jpeg | `1` | Formato de imagen JPG. |
+| Gif | `2` | Formato de imagen GIF. |
+| Tiff | `3` | Formato de imagen TIFF. |
+

--- a/spanish/nodejs-cpp/enumerations/units/_index.md
+++ b/spanish/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Unidades"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Enum Unidades. Especifica el tipo de tamaño"
+type: docs
+weight: 100
+url: /es/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Especifica el tipo de tamaño.
+
+```js
+enum Units
+```
+
+### Valores
+
+| Nombre | Valor | Descripción |
+| ---        | ---   | --- |
+| Points | `0` | Puntos (1/72 de pulgada). |
+| Inches | `1` | Pulgadas. |
+| Millimeters | `2` | Milímetros. |
+| Centimeters | `3` | Centímetros. |
+| Percents | `4` | Porcentajes del tamaño existente. |

--- a/spanish/nodejs-cpp/eps/_index.md
+++ b/spanish/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Funciones EPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos EPS."
+weight: 41
+type: docs
+url: /es/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Recortar archivo EPS. |
+| [AsposeResizeEPS](./resizeeps/) | Redimensionar archivo EPS. |
+
+## Detailed Description
+
+Manipular el tamaño del archivo EPS.
+
+

--- a/spanish/nodejs-cpp/eps/cropeps/_index.md
+++ b/spanish/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Recortar EPS"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Recorta el archivo EPS. Guarda el archivo EPS inicial con el %%BoundingBox existente actualizado o se creará uno nuevo.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+| izquierda | float | Especifica el límite izquierdo del cuadro de recorte. |
+| superior | float | Especifica el límite superior del cuadro de recorte. |
+| derecha | float | Especifica el límite derecho del cuadro de recorte. |
+| inferior | float | Especifica el límite inferior del cuadro de recorte. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/spanish/nodejs-cpp/eps/resizeeps/_index.md
+++ b/spanish/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Redimensionar EPS"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Redimensiona el archivo EPS. Guarda el archivo EPS inicial con el %%BoundingBox existente actualizado o se creará uno nuevo.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+| width | float | Especifica el ancho del nuevo cuadro delimitador. |
+| height | float | Especifica la altura del nuevo cuadro delimitador. |
+| unit | Module.Units | Especifica el tipo del nuevo tamaño. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/spanish/nodejs-cpp/image/_index.md
+++ b/spanish/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Funciones de imagen"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos de imagen."
+weight: 50
+type: docs
+url: /es/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Guardar archivo de imagen como EPS. |
+
+## Detailed Description
+
+Guardar imagen de los formatos más populares como BMP, PNG, JPEG, GOF, TIFF en un archivo EPS.
+

--- a/spanish/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/spanish/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Redimensionar EPS"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Redimensiona el archivo EPS. Guarda el archivo EPS inicial con el %%BoundingBox existente actualizado o se creará uno nuevo.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+

--- a/spanish/nodejs-cpp/merge/_index.md
+++ b/spanish/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Funciones de combinación"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones de combinación para trabajar con archivos Postscript/XPS."
+weight: 20
+type: docs
+url: /es/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Combinar archivos Postscript a PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Combinar archivos XPS a PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Combinar archivos XPS a un archivo XPS. |
+
+## Detailed Description
+
+Combinar varios archivos postscript o xps en un archivo pdf o varios archivos xps en un archivo xps.
+
+

--- a/spanish/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/spanish/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Combinar los archivos Postscript a PDF"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Combinar los archivos Postscript a PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileNames | string | Los nombres de los archivos para combinar. |
+| fileNameResult | string | El nombre del archivo PDF resultante. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/spanish/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/spanish/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Combinar los archivos XPS a PDF"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Combinar los archivos XPS a PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileNames | string | Los nombres de los archivos para combinar. |
+| fileNameResult | string | El nombre del archivo PDF resultante. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/spanish/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/spanish/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Combinar los archivos XPS en un solo XPS"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Combinar varios archivos XPS en un solo archivo XPS.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileNames | string | Los nombres de los archivos para combinar. |
+| fileNameResult | string | El nombre del archivo XPS resultante. |
+| supressErrors | bool | Especifica si los errores deben suprimirse o no. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/spanish/nodejs-cpp/misc/_index.md
+++ b/spanish/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Funciones misceláneas"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones secundarias para trabajar con archivos Postscript/XPS."
+weight: 70
+type: docs
+url: /es/nodejs-cpp/misc/
+---
+## Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Obtener información sobre el Producto. |
+
+## Detailed Description
+
+Funciones secundarias para trabajar con archivos Postscript/XPS.
+

--- a/spanish/nodejs-cpp/misc/pageabout/_index.md
+++ b/spanish/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener información sobre el Producto."
+type: docs
+url: /es/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Obtener información sobre el Producto.
+
+```js
+function AsposePageAbout()
+```
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+| errorCode | error de código (0 sin error) |
+| errorText | error de texto ("" sin error) |
+| producto | Nombre del producto |
+| versión | Versión del producto |
+| islicensed | El producto está licenciado |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/spanish/nodejs-cpp/ps/_index.md
+++ b/spanish/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Funciones PS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos PS."
+weight: 40
+type: docs
+url: /es/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Obtener los límites del archivo PS. |
+| [AsposePSExtractText](./psextracttext/) | Extraer texto del archivo PS. |
+
+## Detailed Description
+
+Manipular archivo PS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/nodejs-cpp/ps/psextracttext/_index.md
+++ b/spanish/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Extraer texto de un archivo PS"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extraer texto de un archivo PS. El texto solo puede extraerse si está escrito con una fuente Type 42 (TrueType) o una fuente Type 0 con fuentes Type 42 en su Vector Map.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| inicio | int | Especifica la página desde la cual comenzar a extraer texto. Este parámetro es útil para documentos multipágina. |
+| fin | int | Especifica la página hasta la cual terminar de extraer texto. Este parámetro es útil para documentos multipágina. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | texto | el texto extraído |
+
+### Ejemplos
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Ver también
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/spanish/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/spanish/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener cuadro delimitador"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Lee el archivo EPS y extrae el cuadro delimitador de la imagen EPS del comentario %%BoundingBox o los límites para el tamaño de página predeterminado (0, 0, 595, 842) si no existe.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | bbox | el cuadro delimitador de la imagen EPS. |
+
+### Ejemplos
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Ver también
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/spanish/nodejs-cpp/xmp/_index.md
+++ b/spanish/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Funciones de metadatos XMP"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones de metadatos XMP para trabajar con archivos EPS."
+weight: 30
+type: docs
+url: /es/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Nombre | Descripción |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Obtener metadatos XMP. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Añade un valor a un arreglo. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Añade un valor con nombre a una estructura. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registra el URI del espacio de nombres y añade un valor. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Combinar archivos Postscript a PDF. |
+
+## Detailed Description
+
+Convertir archivo postscript o xps a imagen o archivo PDF.
+
+
+

--- a/spanish/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/spanish/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Lee un archivo PS/EPS y extrae XmpMetdata si ya existe.
+Si el archivo EPS no contiene metadatos XMP, obtenemos uno nuevo rellenado con valores de los comentarios de metadatos PS (%%Creator, %%CreateDate, %%Title, etc.).
+El archivo EPS con metadatos XMP completados se guardará en fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Ver también
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/spanish/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/spanish/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 20
+url: /es/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Agrega un valor a una matriz. El valor se añadirá al final de la matriz.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/spanish/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/spanish/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 30
+url: /es/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Añade un valor con nombre a una estructura.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/spanish/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/spanish/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 40
+url: /es/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registra el URI del espacio de nombres y añade un valor.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/spanish/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/spanish/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener metadatos XMP"
+type: docs
+weight: 40
+url: /es/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Añade un valor con nombre a una estructura.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+| fileNameResult | string | Nombre del archivo resultante. |
+
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | XMP | matriz de valores de metadatos |
+|  | fileNameResult | nombre del archivo de resultado |
+
+### Ejemplos
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Ver también
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/spanish/nodejs-cpp/xps/_index.md
+++ b/spanish/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Funciones XPS"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Funciones para trabajar con archivos XPS."
+weight: 42
+type: docs
+url: /es/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Función | Descripción |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Obtener el número de páginas del documento xps. |
+
+## Detailed Description
+
+Manipular el archivo XPS.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+o
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/spanish/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/spanish/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page para JavaScript vía C++"
+description: "Obtener número de páginas en un archivo XPS"
+type: docs
+weight: 10
+url: /es/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Obtener el número de páginas del documento xps.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parámetro | Tipo | Descripción |
+| --------- | ---- | ----------- |
+| fileBlob | Objeto Blob | Contenido del archivo fuente. |
+| fileName | string | Nombre del archivo fuente. |
+
+### Valor de retorno
+
+Objeto JSON
+| Campo | Descripción |
+| ----- | ----------- |
+|  | errorCode | error de código (0 sin error) |
+|  | errorText | error de texto ("" sin error) |
+|  | pageCount | número de páginas |
+
+### Ejemplos
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Spanish** (`es`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `spanish/nodejs-cpp`

🤖 Generated by RDA