### PR TITLE
[auto] Translate NODEJS-CPP API Reference to Swedish

### DIFF
--- a/swedish/nodejs-cpp/convert/_index.md
+++ b/swedish/nodejs-cpp/convert/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Konverteringsfunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverteringsfunktioner för att arbeta med Postscript/XPS-filer."
+weight: 10
+type: docs
+url: /sv/nodejs-cpp/convert/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePSSaveAsImage](./pssaveasimage/) | Konvertera en Postscript-fil till bild. |
+| [AsposePSSaveAsPdf](./pssaveaspdf/) | Konvertera en Postscript-fil till PDF. |
+| [AsposeXPSSaveAsImage](./xpssaveasimage/) | Konvertera en XPS-fil till bild. |
+| [AsposeXPSSaveAsPdf](./xpssaveaspdf/) | Konvertera en XPS-fil till PDF. |
+
+## Detailed Description
+
+Konvertera postscript- eller xps-fil till bild eller PDF-fil.
+
+
+

--- a/swedish/nodejs-cpp/convert/pssaveasimage/_index.md
+++ b/swedish/nodejs-cpp/convert/pssaveasimage/_index.md
@@ -1,0 +1,60 @@
+---
+title: "PSSaveAsImage"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar Postscript till bild"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/pssaveasimage/
+---
+## PSSaveAsImage function
+
+Konverterar Postscript till bild.
+
+```js
+function AsposePSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | string | Filnamn. |
+| imageFormat | ImageFormat | bildformat att konvertera till. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSSaveAsImage(ps_file, AsposePageModule.ImageFormat.Png, true);
+    console.log("PSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [PSSaveAsPdf](../pssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/swedish/nodejs-cpp/convert/pssaveaspdf/_index.md
+++ b/swedish/nodejs-cpp/convert/pssaveaspdf/_index.md
@@ -1,0 +1,58 @@
+---
+title: "PSSaveAsPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar Postscript till PDF"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/pssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konverterar Postscript till PDF.
+
+```js
+function AsposePSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | string | Filnamn. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_file = "./data/program_13.ps";
+
+console.log("Aspose.Page för Node.js via C++-exempel.");
+
+AsposePage().then(AsposePageModule => {
+
+const json = AsposePageModule.AsposePSSaveAsPdf(ps_file, true);
+console.log("PSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+reason => {console.log(`Det okända felet har inträffat: ${reason}`);}
+);
+```
+
+### See Also
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/swedish/nodejs-cpp/convert/xpssaveasimage/_index.md
+++ b/swedish/nodejs-cpp/convert/xpssaveasimage/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XPSSaveAsImage"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar XPS till bild"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/xpssaveasimage/
+---
+## PSSaveAsImage function
+
+Konverterar Postscript till bild.
+
+```js
+function AsposeXPSSaveAsImage(
+    fileBlob, 
+    fileName, 
+    imageFormat, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | string | Filnamn. |
+| imageFormat | ImageFormat | bildformat att konvertera till. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsImage(xps_file,AsposePageModule.ImageFormat.Png,true);
+    console.log("XPSSaveAsImage => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [XPSSaveAsPdf](../xpssaveaspdf/)
+* enum [ImageFormat](../../enumerations/imageformat/)

--- a/swedish/nodejs-cpp/convert/xpssaveaspdf/_index.md
+++ b/swedish/nodejs-cpp/convert/xpssaveaspdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "XPSSaveAsPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Konverterar XPS till PDF"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/convert/xpssaveaspdf/
+---
+## PSSaveAsPdf function
+
+Konverterar XPS till PDF.
+
+```js
+function AsposeXPSSaveAsPdf(
+    fileBlob, 
+    fileName, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll för källteckensnitt för konvertering. |
+| fileName | string | Filnamn. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSSaveAsPdf(xps_file,true);
+    console.log("XPSSaveAsPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/swedish/nodejs-cpp/enumerations/_index.md
+++ b/swedish/nodejs-cpp/enumerations/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Enumerationer"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att konvertera typsnitt till TrueType-format."
+weight: 80
+type: docs
+url: /sv/javascript-cpp/enumerations/
+---
+
+## Enumerationer
+
+| Enumeration | Beskrivning |
+| ----------- | ----------- |
+| [ImageFormat](./imageformat/) | Anger bildformat. |
+| [Units](./units/) | Anger storlekstyp. |
+

--- a/swedish/nodejs-cpp/enumerations/imageformat/_index.md
+++ b/swedish/nodejs-cpp/enumerations/imageformat/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Bildformat"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Bildformat‑enum. Anger bildformat"
+type: docs
+weight: 100
+url: /sv/nodejs-cpp/enumerations/imageformat/
+---
+## PageSavingFormats enumeration
+
+Anger bildformat.
+
+```csharp
+public enum ImageFormat
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| ---  | ---   | --- |
+| Bmp | `0` | BMP‑bildformat. |
+| Jpeg | `1` | JPG‑bildformat. |
+| Gif | `2` | GIF‑bildformat. |
+| Tiff | `3` | TIFF‑bildformat. |
+

--- a/swedish/nodejs-cpp/enumerations/units/_index.md
+++ b/swedish/nodejs-cpp/enumerations/units/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Enum Enheter"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Enheter‑enum. Anger typ av storlek"
+type: docs
+weight: 100
+url: /sv/nodejs-cpp/enumerations/units/
+---
+## Units enumeration
+
+Anger storlekstyp.
+
+```js
+enum Units
+```
+
+### Värden
+
+| Namn | Värde | Beskrivning |
+| ---        | ---   | --- |
+| Points | `0` | Punkter (1/72 tum). |
+| Inches | `1` | Tum. |
+| Millimeters | `2` | Millimeter. |
+| Centimeters | `3` | Centimeter. |
+| Percents | `4` | Procent av befintlig storlek. |

--- a/swedish/nodejs-cpp/eps/_index.md
+++ b/swedish/nodejs-cpp/eps/_index.md
@@ -1,0 +1,21 @@
+---
+title: "EPS-funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med EPS-filer."
+weight: 41
+type: docs
+url: /sv/nodejs-cpp/eps/
+---
+
+## EPS Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeCropEPS](./cropeps/) | Beskär EPS-fil. |
+| [AsposeResizeEPS](./resizeeps/) | Ändra storlek på EPS-fil. |
+
+## Detailed Description
+
+Manipulera storleken på EPS-fil.
+
+

--- a/swedish/nodejs-cpp/eps/cropeps/_index.md
+++ b/swedish/nodejs-cpp/eps/cropeps/_index.md
@@ -1,0 +1,65 @@
+---
+title: "AsposeCropEPS"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Beskär EPS"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/eps/cropeps/
+---
+## AsposeCropEPS function
+
+Beskär EPS-fil. Den sparar den ursprungliga EPS-filen med uppdaterad befintlig %%BoundingBox eller en ny kommer att skapas.
+
+```js
+function AsposeCropEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    left,
+    top,
+    right,
+    bottom
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+| vänster | float | Anger vänster gräns för beskärningsrutan. |
+| övre | float | Anger övre gräns för beskärningsrutan. |
+| höger | float | Anger höger gräns för beskärningsrutan. |
+| nedre | float | Anger nedre gräns för beskärningsrutan. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //CropEPS - working with EPS
+    const json = AsposePageModule.AsposeCropEPS(eps_file, "croped.eps", 30, 5, 240, 36);
+    console.log("CropEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [AsposeResizeEps](../resizeeps/)

--- a/swedish/nodejs-cpp/eps/resizeeps/_index.md
+++ b/swedish/nodejs-cpp/eps/resizeeps/_index.md
@@ -1,0 +1,64 @@
+---
+title: "AsposeResizeEPS"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Ändra storlek på EPS"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/eps/resizeeps/
+---
+## AsposeResizeEPS function
+
+Ändrar storlek på EPS-fil. Den sparar den ursprungliga EPS-filen med en uppdaterad befintlig %%BoundingBox eller en ny skapas.
+
+```js
+function AsposeResizeEPS(
+    fileBlob,
+    fileName, 
+    fileNameResult, 
+    width,
+    height,
+    units
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+| width | float | Anger bredden på den nya omgivningsrutan. |
+| height | float | Anger höjden på den nya omgivningsrutan. |
+| unit | Module.Units | Anger typ av ny storlek. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const eps_file = "./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //ResizeEPS - working with EPS
+    const json = AsposePageModule.AsposeResizeEPS(eps_file, "resized.eps", 200, 100, AsposePageModule.Units.Points);
+    console.log("ResizeEPS => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [Module.Units](../../enumerations/units/)
+* function [AsposeCropEps](../cropeps/)

--- a/swedish/nodejs-cpp/image/_index.md
+++ b/swedish/nodejs-cpp/image/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Bildfunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med bildfiler."
+weight: 50
+type: docs
+url: /sv/nodejs-cpp/image/
+---
+
+## Image Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeSaveImageAsEps](./saveimageaseps/) | Spara bildfil som EPS. |
+
+## Detailed Description
+
+Spara bild i de mest populära formaten BMP, PNG, JPEG, GOF, TIFF som EPS-fil.
+

--- a/swedish/nodejs-cpp/image/saveimageaseps/_index.md
+++ b/swedish/nodejs-cpp/image/saveimageaseps/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeSaveImageAsEps"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Ändra storlek på EPS"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/image/saveimageaseps/
+---
+## AsposeSaveImageAsEps function
+
+Ändrar storlek på EPS-fil. Den sparar den ursprungliga EPS-filen med en uppdaterad befintlig %%BoundingBox eller en ny skapas.
+
+```js
+function AsposeSaveImageAsEps(
+    fileBlob,
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const img_file = "./data/PAGENET-361-10.bmp";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //SaveImageAsEps - convert image to EPS
+    const json = AsposePageModule.AsposeSaveImageAsEps(img_file, img_file + ".eps");
+    console.log("SaveImageAsEps => %O",  json.errorCode == 0 ? "Files(pages) count: " + json.filesCount.toString() + json.filesNameResult.toString() : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+

--- a/swedish/nodejs-cpp/merge/_index.md
+++ b/swedish/nodejs-cpp/merge/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Sammanfogningsfunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sammanfogningsfunktioner för att arbeta med Postscript/XPS-filer."
+weight: 20
+type: docs
+url: /sv/nodejs-cpp/merge/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePSMergeToPdf](./psmergetopdf/) | Slå samman en Postscript-fil till PDF. |
+| [AsposeXPSMergeToPdf](./xpsmergetopdf/) | Slå samman en XPS-fil till PDF. |
+| [AsposeXPSMergeToXps](./xpsmergetopdf/) | Slå samman en XPS-fil till en XPS-fil. |
+
+## Detailed Description
+
+Slå samman flera Postscript- eller XPS-filer till en PDF-fil eller flera XPS-filer till en XPS-fil.
+
+

--- a/swedish/nodejs-cpp/merge/psmergetopdf/_index.md
+++ b/swedish/nodejs-cpp/merge/psmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposePSMergeToPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sammanfoga Postscript-filerna till PDF"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/merge/psmergetopdf/
+---
+## AsposePSMergeToPdf function
+
+Sammanfoga Postscript-filerna till PDF.
+
+```js
+function AsposePSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileNames | string | Namnen på filer för sammanslagning. |
+| fileNameResult | string | Namnet på den resulterande pdf-filen. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const ps_files = "./data/program_01.ps,./data/PAGENET-361-10.eps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposePSMergeToPdf(ps_files,"PsMergedToPdfResult.pdf",true);
+    console.log("PSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/swedish/nodejs-cpp/merge/xpsmergetopdf/_index.md
+++ b/swedish/nodejs-cpp/merge/xpsmergetopdf/_index.md
@@ -1,0 +1,56 @@
+---
+title: "AsposeXPSMergeToPdf"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sammanfoga XPS-filerna till PDF"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/merge/xpsmergetopdf/
+---
+## AsposeXPSMergeToPdf function
+
+Sammanfoga XPS-filerna till PDF.
+
+```js
+function AsposeXPSMergePdf(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileNames | string | Namnen på filer för sammanslagning. |
+| fileNameResult | string | Namnet på den resulterande pdf-filen. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToPdf(xps_files,"XPsMergedToPdfResult.pdf");
+    console.log("XPSMergeToPdf => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [PSSaveAsImage](../pssaveasimage/)

--- a/swedish/nodejs-cpp/merge/xpsmergetoxps/_index.md
+++ b/swedish/nodejs-cpp/merge/xpsmergetoxps/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeXPSMergeToXps"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sammanfoga XPS-filerna till en XPS"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/merge/xpsmergetoxps/
+---
+## AsposeXPSMergeToXps function
+
+Sammanfoga flera XPS-filer till en XPS-fil.
+
+```js
+function AsposeXPSMergeXps(
+    fileNames, 
+    fileNameResult, 
+    supressErrors
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileNames | string | Namnen på filer för sammanslagning. |
+| fileNameResult | string | Namnet på den resulterande xps-filen. |
+| supressErrors | bool | Anger om fel ska undertryckas eller inte. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_files = "./data/example.xps,./data/transforms.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeXPSMergeToXps(xps_files,"XpsMergedToXpsResult.xps");
+    console.log("XPSMergeToXps => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [XPSMergeToPdf](../xpsmergetopdf/)

--- a/swedish/nodejs-cpp/misc/_index.md
+++ b/swedish/nodejs-cpp/misc/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Diverse funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Sekundära funktioner för att arbeta med Postscript/XPS-filer."
+weight: 70
+type: docs
+url: /sv/nodejs-cpp/misc/
+---
+## Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePageAbout](./pageabout/) | Hämta information om produkten. |
+
+## Detailed Description
+
+Sekundära funktioner för att arbeta med Postscript/XPS-filer.
+

--- a/swedish/nodejs-cpp/misc/pageabout/_index.md
+++ b/swedish/nodejs-cpp/misc/pageabout/_index.md
@@ -1,0 +1,42 @@
+---
+title: "AsposePageAbout"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta information om produkten."
+type: docs
+url: /sv/nodejs-cpp/misc/asposepageabout/
+---
+
+## AsposeFontAbout function
+
+Hämta information om produkten.
+
+```js
+function AsposePageAbout()
+```
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+| errorCode | kodfel (0 inget fel) |
+| errorText | textfel ("" inget fel) |
+| produkt | Produktnamn |
+| version | Produktversion |
+| islicensed | Produkten är licensierad |
+
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    //PageAbout - Get info about Product
+    const json = AsposePageModule.AsposePageAbout();
+    console.log("PageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```

--- a/swedish/nodejs-cpp/ps/_index.md
+++ b/swedish/nodejs-cpp/ps/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PS-funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med PS-filer."
+weight: 40
+type: docs
+url: /sv/nodejs-cpp/ps/
+---
+
+## EPS Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposePSGetBoundingBox](./psgetboundingbox/) | Hämta gränserna för PS-fil. |
+| [AsposePSExtractText](./psextracttext/) | Extrahera text från PS-fil. |
+
+## Detailed Description
+
+Manipulera PS-fil.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/nodejs-cpp/ps/psextracttext/_index.md
+++ b/swedish/nodejs-cpp/ps/psextracttext/_index.md
@@ -1,0 +1,79 @@
+---
+title: "AsposePSExtractText"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Extrahera text från PS-fil"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/ps/psextracttext/
+---
+## AsposePSExtractText function
+
+Extrahera text från PS-fil. Texten kan endast extraheras om den är skriven med Type 42 (TrueType)-teckensnitt eller Type 0-teckensnitt med Type 42-teckensnitt i dess Vector Map.
+
+```js
+function AsposePSExtractText(
+    fileBlob,
+    fileName, 
+    start,
+    end
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| start | int | Anger sidan från vilken texten ska börja extraheras. Denna parameter är användbar för flersidiga dokument. |
+| slut | int | Anger sidan tills vilken texten ska extraheras. Denna parameter är användbar för flersidiga dokument. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | text | den extraherade texten |
+
+### Exempel
+
+```js
+  var fPSExtractText = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSExtractText(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Text:" + json.text;
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? 
+        ((evt.data.operation == 'AsposePSExtractText') ? `Text: ${evt.data.json.text}` : `` ) : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSExtractText = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSExtractText', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+```
+
+### Se även
+
+* function [AsposePSGetBoundingBox](../psgetboundingbox/)

--- a/swedish/nodejs-cpp/ps/psgetboundingbox/_index.md
+++ b/swedish/nodejs-cpp/ps/psgetboundingbox/_index.md
@@ -1,0 +1,76 @@
+---
+title: "AsposePSGetBoundingBox"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta avgränsningsruta"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/ps/psgetboundingbox/
+---
+## AsposePSGetBoundingBox function
+
+Läser EPS-fil och extraherar avgränsningsrutan för EPS-bilden från %%BoundingBox-kommentaren eller gränserna för standardsidans storlek (0, 0, 595, 842) om den inte finns.
+
+```js
+function AsposePSGetBoundingBox(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | bbox | avgränsningsrutan för EPS-bilden. |
+
+### Exempel
+
+```js
+  var fPSGetBoundingBox = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const json = AsposePSGetBoundingBox(event.target.result, e.target.files[0].name);
+      if (json.errorCode == 0) {
+        document.getElementById('output').textContent = "Bounds: " + json.bbox.toString();
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Boundibg box: ${evt.data.json.bbox}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPSGetBoundingBox = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      AsposePageWebWorker.postMessage({ "operation": 'AsposePSGetBoundingBox', "params": [event.target.result, e.target.files[0].name] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  }
+
+```
+
+### Se även
+
+* function [AsposePSExtractText](../psextracttext/)

--- a/swedish/nodejs-cpp/xmp/_index.md
+++ b/swedish/nodejs-cpp/xmp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "XMP-metadatafunktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "XMP-metadatafunktioner för att arbeta med EPS-filer."
+weight: 30
+type: docs
+url: /sv/nodejs-cpp/xmp/
+---
+
+## Core Functions
+
+| Namn | Beskrivning |
+| -------------- | -------------- |
+| [AsposeEPSGetXMP](./epsgetxmp/) | Hämta XMP-metadata. |
+| [AsposeXMPAddArrayItem](./xmpaddarrayitem/) | Lägger till ett värde i en array. |
+| [AsposeXMPAddNamedValue](./xmpaddnamedvalue/) | Lägger till ett namngivet värde i en struktur. |
+| [AsposeXMPAddNamespace](./xmpaddnamespace/) | Registrerar namnrymds-URI och lägger till värde. |
+| [AsposeXMPAddSimpleProperties](./xmpaddsimpleproperties/) | Slå samman en Postscript-fil till PDF. |
+
+## Detailed Description
+
+Konvertera postscript- eller xps-fil till bild eller PDF-fil.
+
+
+

--- a/swedish/nodejs-cpp/xmp/epsgetxmp/_index.md
+++ b/swedish/nodejs-cpp/xmp/epsgetxmp/_index.md
@@ -1,0 +1,59 @@
+---
+title: "AsposeEPSGetXmp"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/xmp/epsgetxmp/
+---
+## AsposeEPSGetXmp function
+
+Läser PS/EPS-fil och extraherar XmpMetdata om den redan finns.
+Om EPS-filen inte innehåller XMP-metadata får vi en ny som fylls med värden från PS-metadata-kommentarer (%%Creator, %%CreateDate, %%Title etc).
+EPS‑fil med ifylld XMP‑metadata kommer att sparas i fileNameResult.
+
+```js
+function AsposeEPSGetXmp(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    const json = AsposePageModule.AsposeEPSGetXMP(eps_file, img_file + "_out.eps");
+    console.log("AsposeEPSGetXMP => %O",  json.errorCode == 0 ? json.fileNameResult : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+### Se även
+
+* function [XPSSaveAsImage](../xpssaveasimage/)

--- a/swedish/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
+++ b/swedish/nodejs-cpp/xmp/xmpaddarrayitem/_index.md
@@ -1,0 +1,100 @@
+---
+title: "AsposeXMPAddArrayItem"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 20
+url: /sv/nodejs-cpp/xmp/xmpaddarrayitem/
+---
+## AsposeXMPAddArrayItem function
+
+Lägger till ett värde i en array. Värdet kommer att läggas till i slutet av arrayen.
+
+```js
+function AsposeXMPAddArrayItem(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      const json = AsposeXMPAddArrayItem(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const input = [
+        ["dc:title", "NewTitle"],
+        ["dc:creator", "NewCreator"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddArrayItem', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", input] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddNamespace](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/swedish/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
+++ b/swedish/nodejs-cpp/xmp/xmpaddnamedvalue/_index.md
@@ -1,0 +1,99 @@
+---
+title: "AsposeXMPAddNamedValue"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 30
+url: /sv/nodejs-cpp/xmp/xmpaddnamedvalue/
+---
+## AsposeXMPAddNamedValue function
+
+Lägger till ett namngivet värde i en struktur.
+
+```js
+function AsposeXMPAddNamedValue(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      const json = AsposeXMPAddNamedValue(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const namedValues = [
+        ["xmpTPg:MaxPageSize", [["stDim:newKey", "NewValue"],["stDim:newKey2", "NewValue2"]] ],
+        ["xmpTPg:SwatchGroups", [["xmpG:newKey", "NewValue"]] ]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamedValue', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", namedValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)

--- a/swedish/nodejs-cpp/xmp/xmpaddnamespace/_index.md
+++ b/swedish/nodejs-cpp/xmp/xmpaddnamespace/_index.md
@@ -1,0 +1,102 @@
+---
+title: "AsposeXMPAddNamespace"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 40
+url: /sv/nodejs-cpp/xmp/xmpaddnamespace/
+---
+## AsposeXMPAddNamespace function
+
+Registrerar namnrymds-URI och lägger till värde.
+
+```js
+function AsposeXMPAddNamespace(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      const json = AsposeXMPAddNamespace(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const prefix = "tmp";
+      const url = "http://www.some.org/schema/tmp#";
+      const nsValues = [
+        ["tmp:newKey", "NewValue"]
+      ];
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddNamespace', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", prefix, url, nsValues] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPAddNamedValue](../xmpaddnamedvalue/)

--- a/swedish/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
+++ b/swedish/nodejs-cpp/xmp/xmpaddsimpleproperties/_index.md
@@ -1,0 +1,97 @@
+---
+title: "AsposeXMPAddSimpleProperties"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta XMP-metadata"
+type: docs
+weight: 40
+url: /sv/nodejs-cpp/xmp/xmpaddsimpleproperties/
+---
+## AsposeXMPAddSimpleProperties function
+
+Lägger till ett namngivet värde i en struktur.
+
+```js
+function AsposeXMPAddSimpleProperties(
+    fileBlob, 
+    fileName, 
+    fileNameResult
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+| fileNameResult | string | Resultatfilens namn. |
+
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | XMP | array av metadatavärden |
+|  | fileNameResult | resultatfilnamn |
+
+### Exempel
+
+```js
+  var fGetXmpMetadata = function (e) {
+    const file_reader = new FileReader();
+    file_reader.onload = (event) => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      const json = AsposeXMPAddSimpleProperties(event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value);
+      if (json.errorCode == 0) {
+          document.getElementById('output').textContent = json.XMP;
+          DownloadFile(json.fileNameResult, "image/eps");
+      }
+      else 
+        document.getElementById('output').textContent = json.errorText;
+    }
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  }
+```
+
+**Web Worker example**:
+```js
+
+  /*Create Web Worker*/
+  const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+  AsposePageWebWorker.onerror = evt => console.log(`Error from Web Worker: ${evt.message}`);
+  AsposePageWebWorker.onmessage = evt => document.getElementById('output').textContent = 
+    (evt.data == 'ready') ? 'library loaded!' :
+      (evt.data.json.errorCode == 0) ? `Result:\n${DownloadFile(evt.data.json.fileNameResult, "application/image", evt.data.params[0])}` : `Error: ${evt.data.json.errorText}`;
+
+  /*Event handler*/
+  const fPsAsPdf = e => {
+    const file_reader = new FileReader();
+    file_reader.onload = event => {
+      const key = "tmp:newKey";
+      const value = "NewValue";
+      AsposePageWebWorker.postMessage({ "operation": 'AsposeXMPAddSimpleProperties', "params": [event.target.result, e.target.files[0].name, e.target.files[0].name + "_out.eps", key, value] }, [event.target.result]);
+    };
+    file_reader.readAsArrayBuffer(e.target.files[0]);
+  };
+
+  /*Make a link to download the result file*/
+  const DownloadFile = function (filename, mime, content) {
+      mime = mime || "application/octet-stream";
+      var link = document.createElement("a"); 
+      link.href = URL.createObjectURL(new Blob([content], {type: mime}));
+      link.download = filename;
+      link.textContent = filename;
+      link.title = "Click here to download the file";
+      document.getElementById('fileDownload').appendChild(link);
+      document.getElementById('fileDownload').appendChild(document.createElement("br"));
+  }
+
+```
+
+### Se även
+
+* function [AsposeXMPAddArrayItem](../xmpaddarrayitem/)
+* function [AsposeXMPNamedValue](../xmpaddnamedvalue/)
+* function [AsposeXMPNamespace](../xmpaddnamespace/)

--- a/swedish/nodejs-cpp/xps/_index.md
+++ b/swedish/nodejs-cpp/xps/_index.md
@@ -1,0 +1,29 @@
+---
+title: "XPS-funktioner"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Funktioner för att arbeta med XPS-filer."
+weight: 42
+type: docs
+url: /sv/nodejs-cpp/xps/
+---
+
+## XPS functions
+
+| Funktion | Beskrivning |
+| -------- | ----------- |
+| [AsposeGetXpsPageCount](./getxpspagecount/) | Hämta antalet sidor i xps-dokumentet. |
+
+## Detailed Description
+
+Manipulera XPS-filen.
+
+
+```js
+/* Web Worker*/
+const AsposePageWebWorker = new Worker("AsposePageforJS.js");
+```
+eller
+```html
+<!-- Load and initiate Aspose.Page for JavaScript via C++ -->
+<script type="text/javascript" async src="AsposePageforJS.js"></script>
+```

--- a/swedish/nodejs-cpp/xps/getxpspagecount/_index.md
+++ b/swedish/nodejs-cpp/xps/getxpspagecount/_index.md
@@ -1,0 +1,57 @@
+---
+title: "AsposeGetXpsPageCount"
+second_title: "Aspose.Page för JavaScript via C++"
+description: "Hämta antal sidor i XPS-fil"
+type: docs
+weight: 10
+url: /sv/nodejs-cpp/xps/getxpspagecount/
+---
+## AsposeGetXpsPageCount function
+
+Hämta antalet sidor i xps-dokumentet.
+
+```js
+function AsposeGetXpsPageCount(
+    fileBlob,
+    fileName
+)
+```
+
+| Parameter | Typ | Beskrivning |
+| --------- | ---- | ----------- |
+| fileBlob | Blob-objekt | Innehåll i källfilen. |
+| fileName | string | Källfilens namn. |
+
+### Returvärde
+
+JSON-objekt
+| Fält | Beskrivning |
+| ----- | ----------- |
+|  | errorCode | kodfel (0 inget fel) |
+|  | errorText | textfel ("" inget fel) |
+|  | pageCount | antal sidor |
+
+### Exempel
+
+```js
+const AsposePage = require('asposepagenodejs');
+
+const xps_file = "./data/example.xps";
+
+console.log("Aspose.Page for Node.js via C++ examples.");
+
+AsposePage().then(AsposePageModule => {
+
+    let json = AsposePageModule.AsposePageAbout();
+    console.log("AsposePageAbout => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : "error:" + json.errorText);
+
+    //AsposeGetXpsPageCount
+    json = AsposePageModule.AsposeGetXpsPageCount(xps_file);
+    console.log("AsposeGetXpsPageCount => %O",  json.errorCode == 0 ? JSON.parse(JSON.stringify(json).replace('"errorCode":0,"errorText":"",','')) : json.errorText);
+
+},
+    reason => {console.log(`The unknown error has occurred: ${reason}`);}
+);
+```
+
+


### PR DESCRIPTION
Automated translation of the NODEJS-CPP API Reference to **Swedish** (`sv`) generated by RDA.

- Pages translated: 31/31
- Errors: 0
- Source: `english/nodejs-cpp`
- Output: `swedish/nodejs-cpp`

🤖 Generated by RDA